### PR TITLE
feat: add nix flake for declarative installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ test-results/
 # --------------------
 .fastembed_cache/
 */.fastembed_cache/
+result

--- a/README.md
+++ b/README.md
@@ -26,6 +26,51 @@ spec-gen generate   # Generate specs (requires API key)
 spec-gen drift      # Check for spec drift
 ```
 
+<details>
+<summary>Nix/NixOS</summary>
+
+**Run directly:**
+
+```bash
+nix run github:clay-good/spec-gen -- init
+nix run github:clay-good/spec-gen -- analyze
+nix run github:clay-good/spec-gen -- generate
+```
+
+**Temporary shell:**
+
+```bash
+nix shell github:clay-good/spec-gen
+spec-gen --version
+```
+
+**System flake integration:**
+
+```nix
+{
+  inputs.spec-gen.url = "github:clay-good/spec-gen";
+
+  outputs = { self, nixpkgs, spec-gen }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [{
+        environment.systemPackages = [ spec-gen.packages.x86_64-linux.default ];
+      }];
+    };
+  };
+}
+```
+
+**Development:**
+
+```bash
+git clone https://github.com/clay-good/spec-gen
+cd spec-gen
+nix develop
+npm run dev
+```
+
+</details>
+
 ## What It Does
 
 **1. Analyze** (no API key needed)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772198003,
+        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
 
             src = ./.;
 
-            npmDepsHash = "";  # Will be filled after first build attempt
+            npmDepsHash = "sha256-5l/gdzyivfA5w5/0GA5vte3NY7AMfoFsqMvWgkzfM1A=";
 
             # Build TypeScript
             buildPhase = ''


### PR DESCRIPTION
  ## Summary

  - Add `flake.nix` and `flake.lock` for Nix package manager support
  - Enable `nix run github:clay-good/spec-gen` for direct execution
  - Provide development shell with Node.js 22, npm, and TypeScript tooling
  - Add Nix/NixOS installation section to README

  ## Usage

  ```bash
  # Run directly
  nix run github:clay-good/spec-gen -- analyze
```