### PR TITLE
add flake version update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ nix develop
 npm run dev
 ```
 
+**Updating the flake after a release:**
+
+```bash
+./scripts/update-flake.sh
+```
+
+Syncs `version` and `npmDepsHash` in `flake.nix` from `package.json`. Requires `jq` and `prefetch-npm-deps` (or `nix-shell`).
+
 </details>
 
 ## What It Does

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,10 @@
 
             src = ./.;
 
-            npmDepsHash = "sha256-cjPSzdyG3LrSKPwObVXU0YBAFjibi2kx45lItd0zv2w=";
+            npmDepsFetcherVersion = 2;
+            makeCacheWritable = true;
+            npmDepsHash = "sha256-oA3iPvZwKCIdt8K21LgWNHjz62ohgsvgAy5/217GGxs=";
+            npmFlags = [ "--omit=optional" ];
 
             # Build TypeScript
             buildPhase = ''
@@ -39,6 +42,10 @@
 
               # Copy node_modules for runtime dependencies
               cp -r node_modules $out/lib/node_modules/spec-gen/
+
+              # tree-sitter-swift creates a stub symlink for tree-sitter-cli
+              # that dangles when optional deps are omitted — remove it.
+              find $out -xtype l -name tree-sitter-cli -delete
 
               # Create bin wrapper (ESM — must use import(), not require())
               mkdir -p $out/bin

--- a/flake.nix
+++ b/flake.nix
@@ -18,11 +18,11 @@
         {
           default = pkgs.buildNpmPackage {
             pname = "spec-gen";
-            version = "1.0.0";
+            version = "1.2.6";
 
             src = ./.;
 
-            npmDepsHash = "sha256-5l/gdzyivfA5w5/0GA5vte3NY7AMfoFsqMvWgkzfM1A=";
+            npmDepsHash = "sha256-cjPSzdyG3LrSKPwObVXU0YBAFjibi2kx45lItd0zv2w=";
 
             # Build TypeScript
             buildPhase = ''

--- a/scripts/update-flake.sh
+++ b/scripts/update-flake.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+FLAKE="flake.nix"
+PKG="package.json"
+LOCK="package-lock.json"
+
+if [[ ! -f "$FLAKE" ]]; then echo "Error: $FLAKE not found"; exit 1; fi
+if [[ ! -f "$PKG" ]]; then echo "Error: $PKG not found"; exit 1; fi
+
+# --- Version sync ---
+new_version=$(jq -r .version "$PKG")
+old_version=$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' "$FLAKE")
+
+if [[ "$old_version" == "$new_version" ]]; then
+  echo "Version already in sync: $new_version"
+else
+  sed -i "s/version = \"$old_version\"/version = \"$new_version\"/" "$FLAKE"
+  echo "Version: $old_version → $new_version"
+fi
+
+# --- Ensure lockfile is in sync ---
+echo "Syncing package-lock.json..."
+npm install --package-lock-only --ignore-scripts --silent 2>/dev/null
+
+# --- Compute npmDepsHash ---
+echo "Computing npmDepsHash (this may take a moment)..."
+if command -v prefetch-npm-deps &>/dev/null; then
+  new_hash=$(prefetch-npm-deps "$LOCK" 2>/dev/null)
+elif command -v nix-shell &>/dev/null; then
+  new_hash=$(nix-shell -p prefetch-npm-deps --run "prefetch-npm-deps $LOCK" 2>/dev/null)
+else
+  echo "Error: prefetch-npm-deps not found and nix-shell not available"
+  exit 1
+fi
+
+old_hash=$(sed -n 's/.*npmDepsHash = "\([^"]*\)".*/\1/p' "$FLAKE")
+
+if [[ "$old_hash" == "$new_hash" ]]; then
+  echo "npmDepsHash unchanged: $new_hash"
+else
+  # Escape slashes in hash for sed
+  escaped_old=$(printf '%s\n' "$old_hash" | sed 's/[/&]/\\&/g')
+  escaped_new=$(printf '%s\n' "$new_hash" | sed 's/[/&]/\\&/g')
+  sed -i "s|npmDepsHash = \"$escaped_old\"|npmDepsHash = \"$escaped_new\"|" "$FLAKE"
+  echo "npmDepsHash: $old_hash → $new_hash"
+fi
+
+echo ""
+echo "Done. Review changes with: git diff flake.nix"


### PR DESCRIPTION
# ready ;)

### Summary

  - Fix stale flake.nix: version 1.0.0 → 1.2.6, recalculate npmDepsHash
  - Add scripts/update-flake.sh to keep the flake in sync after future releases

### Usage

  ./scripts/update-flake.sh    # after tagging a release

  Requires jq and prefetch-npm-deps (falls back to nix-shell).