### PR TITLE
feat: add support for cursor-agent provider in spec-gen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Thumbs.db
 .claude
 .spec-gen/
 .mcp.json
+.cursor/
 
 # --------------------
 # Python Specific

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ spec-gen drift --no-color                # Plain output for CI logs
 
 ## LLM Providers
 
-spec-gen supports eight providers. The default is Anthropic Claude.
+spec-gen supports nine providers. The default is Anthropic Claude.
 
 | Provider | `provider` value | API key env var | Default model |
 |----------|-----------------|-----------------|---------------|
@@ -321,6 +321,7 @@ spec-gen supports eight providers. The default is Anthropic Claude.
 | Gemini CLI | `gemini-cli` | *(none)* | *(CLI default)* |
 | Claude Code | `claude-code` | *(none)* | *(CLI default)* |
 | Mistral Vibe | `mistral-vibe` | *(none)* | *(CLI default)* |
+| Cursor Agent CLI | `cursor-agent` | *(none)* | *(CLI default)* |
 
 ### Selecting a provider
 
@@ -417,13 +418,14 @@ No API key is required — the copilot-api proxy handles authentication via your
 
 ### CLI-based providers (no API key)
 
-Three providers route LLM calls through local CLI tools instead of HTTP APIs. No API key or configuration is needed — just have the CLI installed and on your PATH.
+Four providers route LLM calls through local CLI tools instead of HTTP APIs. No API key or configuration is needed — just have the CLI installed and on your PATH.
 
 | Provider | CLI binary | Install |
-|----------|-----------|---------|
+|----------|-----------|----------------|
 | `claude-code` | `claude` | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (requires Claude Max/Pro subscription) |
 | `gemini-cli` | `gemini` | [Gemini CLI](https://github.com/google-gemini/gemini-cli) (free tier with Google account) |
 | `mistral-vibe` | `vibe` | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) (standalone binary) |
+| `cursor-agent` | `cursor-agent` | [Cursor CLI](https://cursor.com/docs/cli/overview) (Cursor subscription / CLI auth) |
 
 ```json
 {
@@ -1292,7 +1294,7 @@ The index is stored in `.spec-gen/analysis/vector-index/` and is automatically u
   export OPENAI_COMPAT_API_KEY=ollama       # OpenAI-compatible local server
   export GEMINI_API_KEY=...                 # Google Gemini
   ```
-  Or use a CLI-based provider (`claude-code`, `gemini-cli`, `mistral-vibe`) which requires no API key — just the CLI tool on your PATH.
+  Or use a CLI-based provider (`claude-code`, `gemini-cli`, `mistral-vibe`, `cursor-agent`) which requires no API key — just the CLI tool on your PATH.
 - `analyze`, `drift`, and `init` require no API key
 
 ## Supported Languages

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -107,6 +107,26 @@ The system SHALL enables or disables interactive mode.
 - **WHEN** setInteractiveMode is called
 - **THEN** Interactive mode is enabled or disabled based on input
 
+### Requirement: GeneratePreflightExemptsCursorAgentFromApiKeys
+
+The `spec-gen generate` workflow (CLI command and programmatic entrypoints that perform the same API-key preflight) SHALL treat `cursor-agent` as a provider that does not require `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENAI_COMPAT_API_KEY` to be set for pre-flight validation.
+
+Authentication for Cursor SHALL remain the responsibility of the Cursor CLI and Cursor’s documented auth mechanisms (not spec-gen cloud keys).
+
+#### Scenario: CliGenerateWithCursorAgentOnly
+
+- **GIVEN** `.spec-gen/config.json` sets `generation.provider` to `cursor-agent`
+- **AND** none of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENAI_COMPAT_API_KEY` are set
+- **WHEN** the user runs `spec-gen generate` with otherwise valid options
+- **THEN** pre-flight does not fail solely due to missing those environment variables
+
+#### Scenario: ProgrammaticGenerateWithCursorAgentOnly
+
+- **GIVEN** programmatic generation is invoked with provider `cursor-agent`
+- **AND** none of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENAI_COMPAT_API_KEY` are set
+- **WHEN** generation proceeds past provider resolution
+- **THEN** pre-flight does not throw solely due to missing those environment variables
+
 ## Technical Notes
 
 - **Dependencies**: @inquirer/prompts

--- a/openspec/specs/llm/spec.md
+++ b/openspec/specs/llm/spec.md
@@ -307,6 +307,44 @@ The system SHALL return the maximum context window size for the configured model
 - **WHEN** the operation is invoked
 - **THEN** the expected outcome occurs
 
+### Requirement: CursorAgentCliProvider
+
+The system SHALL provide an LLM provider identified as `cursor-agent` that implements `LLMProvider`, invokes the Cursor Agent CLI in non-interactive print mode to obtain completions, and returns a normalized `CompletionResponse`.
+
+The implementation SHALL:
+
+- Combine `systemPrompt` and `userPrompt` into a single prompt when both are present (consistent with other CLI providers in this codebase).
+- Resolve the CLI executable path from an environment variable (e.g. override for non-standard installs) with a documented default binary name.
+- Pass arguments appropriate for structured output (e.g. print mode and JSON output format) so the stdout can be parsed deterministically when the CLI supports it.
+- On CLI failure (non-zero exit, stderr/stdout error detail), throw an error marked non-retryable where that pattern is used for other CLI providers.
+- When token usage is not present in CLI output, SHALL derive input/output token estimates using the same estimation approach as other CLI providers.
+
+#### Scenario: SuccessfulCompletion
+
+- **WHEN** a valid `CompletionRequest` is provided and the Cursor Agent CLI returns successful structured output containing the assistant text
+- **THEN** `generateCompletion` returns a `CompletionResponse` whose `content` is that text and whose `usage` contains non-negative token counts and a `totalTokens` equal to the sum of input and output tokens
+
+#### Scenario: CliProcessFailure
+
+- **WHEN** the Cursor Agent CLI exits with an error or returns output that cannot be parsed as expected
+- **THEN** `generateCompletion` throws an error that surfaces CLI diagnostics and does not return a successful `CompletionResponse`
+
+### Requirement: CursorAgentProviderRegistration
+
+The system SHALL register the `cursor-agent` provider in the LLM service factory such that `createLLMService({ provider: 'cursor-agent', ... })` instantiates the Cursor Agent CLI-backed provider without requiring `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OPENAI_COMPAT_API_KEY`, or `GEMINI_API_KEY`.
+
+The system SHALL include `cursor-agent` in provider pricing lookup with zero per-token estimated cost for cost estimation purposes (same class as other subscription or local CLI providers).
+
+#### Scenario: FactorySelectsCursorAgent
+
+- **WHEN** `createLLMService` is called with `provider: 'cursor-agent'`
+- **THEN** the underlying provider’s `name` is `cursor-agent` and no cloud API key environment variable is read for instantiation
+
+#### Scenario: CostLookupCliProvider
+
+- **WHEN** `lookupPricing` is called for provider `cursor-agent` and any model identifier
+- **THEN** returned input and output per-million token rates are zero
+
 ## Technical Notes
 
 - **Implementation**: `src/core/services/llm-service.ts`

--- a/src/api/generate.ts
+++ b/src/api/generate.ts
@@ -128,7 +128,7 @@ export async function specGenGenerate(options: GenerateApiOptions = {}): Promise
   const geminiKey = process.env.GEMINI_API_KEY;
 
   const configuredProvider = options.provider ?? specGenConfig.generation.provider;
-  const noKeyProviders = ['claude-code', 'mistral-vibe', 'copilot'];
+  const noKeyProviders = ['claude-code', 'mistral-vibe', 'copilot', 'cursor-agent'];
 
   if (!noKeyProviders.includes(configuredProvider ?? '') && !anthropicKey && !openaiKey && !openaiCompatKey && !geminiKey) {
     throw new Error(
@@ -149,6 +149,10 @@ export async function specGenGenerate(options: GenerateApiOptions = {}): Promise
     'openai-compat': DEFAULT_OPENAI_COMPAT_MODEL,
     copilot: DEFAULT_COPILOT_MODEL,
     openai: DEFAULT_OPENAI_MODEL,
+    'claude-code': 'claude-code',
+    'mistral-vibe': 'mistral-vibe',
+    'gemini-cli': 'gemini-cli',
+    'cursor-agent': 'cursor-agent',
   };
   const effectiveModel = options.model || specGenConfig.generation.model || defaultModels[effectiveProvider];
 

--- a/src/api/run.ts
+++ b/src/api/run.ts
@@ -245,7 +245,7 @@ export async function specGenRun(options: RunApiOptions = {}): Promise<RunResult
   const openaiKey = process.env.OPENAI_API_KEY;
   const openaiCompatKey = process.env.OPENAI_COMPAT_API_KEY;
   const geminiKey = process.env.GEMINI_API_KEY;
-  const noKeyProviders = ['claude-code', 'mistral-vibe', 'copilot'];
+  const noKeyProviders = ['claude-code', 'mistral-vibe', 'copilot', 'gemini-cli', 'cursor-agent'];
   if (!noKeyProviders.includes(options.provider ?? '') && !anthropicKey && !openaiKey && !openaiCompatKey && !geminiKey) {
     throw new Error('No LLM API key found. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, OPENAI_COMPAT_API_KEY, or use provider "copilot".');
   }
@@ -262,6 +262,10 @@ export async function specGenRun(options: RunApiOptions = {}): Promise<RunResult
     'openai-compat': DEFAULT_OPENAI_COMPAT_MODEL,
     copilot: DEFAULT_COPILOT_MODEL,
     openai: DEFAULT_OPENAI_MODEL,
+    'claude-code': 'claude-code',
+    'mistral-vibe': 'mistral-vibe',
+    'gemini-cli': 'gemini-cli',
+    'cursor-agent': 'cursor-agent',
   };
   const model = options.model ?? defaultModels[provider] ?? DEFAULT_ANTHROPIC_MODEL;
   let llm: LLMService;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -107,7 +107,7 @@ export interface AnalyzeResult {
 
 export interface GenerateApiOptions extends BaseOptions {
   /** LLM provider to use */
-  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini';
+  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'gemini-cli' | 'claude-code' | 'mistral-vibe' | 'cursor-agent';
   /** LLM model name */
   model?: string;
   /** Custom LLM API base URL */
@@ -144,7 +144,7 @@ export interface GenerateResult {
 
 export interface VerifyApiOptions extends BaseOptions {
   /** LLM provider to use */
-  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini';
+  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'gemini-cli' | 'claude-code' | 'mistral-vibe' | 'cursor-agent';
   /** LLM model name */
   model?: string;
   /** Custom LLM API base URL */
@@ -180,7 +180,7 @@ export interface DriftApiOptions extends BaseOptions {
   /** Use LLM for deeper semantic comparison */
   llmEnhanced?: boolean;
   /** LLM provider (required if llmEnhanced is true) */
-  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini';
+  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'gemini-cli' | 'claude-code' | 'mistral-vibe' | 'cursor-agent';
   /** LLM model name (used when llmEnhanced is true) */
   model?: string;
   /** Custom LLM API base URL */
@@ -207,7 +207,7 @@ export interface RunApiOptions extends BaseOptions {
   /** Force fresh analysis even if recent exists */
   reanalyze?: boolean;
   /** LLM provider to use */
-  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini';
+  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'gemini-cli' | 'claude-code' | 'mistral-vibe' | 'cursor-agent';
   /** LLM model name */
   model?: string;
   /** Custom LLM API base URL */

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -396,16 +396,16 @@ Each spec.md follows OpenSpec conventions:
         : openaiCompatKey ? 'openai-compat'
         : 'openai';
       const rootConfig = specGenConfig as unknown as Record<string, string>;
-      const effectiveProvider = (specGenConfig.generation.provider ?? rootConfig['provider'] ?? envDetectedProvider) as 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'claude-code' | 'mistral-vibe';
+      const effectiveProvider = (specGenConfig.generation.provider ?? rootConfig['provider'] ?? envDetectedProvider) as 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'gemini-cli' | 'claude-code' | 'mistral-vibe' | 'cursor-agent';
 
-      if (effectiveProvider !== 'claude-code' && effectiveProvider !== 'mistral-vibe' && effectiveProvider !== 'copilot' && !anthropicKey && !openaiKey && !openaiCompatKey && !geminiKey) {
+      if (effectiveProvider !== 'claude-code' && effectiveProvider !== 'mistral-vibe' && effectiveProvider !== 'copilot' && effectiveProvider !== 'gemini-cli' && effectiveProvider !== 'cursor-agent' && !anthropicKey && !openaiKey && !openaiCompatKey && !geminiKey) {
         logger.error('No LLM API key found.');
         logger.discovery('Set one of the following environment variables:');
         logger.discovery('  ANTHROPIC_API_KEY    → https://console.anthropic.com/');
         logger.discovery('  OPENAI_API_KEY       → https://platform.openai.com/');
         logger.discovery('  GEMINI_API_KEY       → https://aistudio.google.com/');
         logger.discovery('  OPENAI_COMPAT_API_KEY + OPENAI_COMPAT_BASE_URL  → Mistral, Groq, Ollama...');
-        logger.discovery('  Or set provider to "claude-code", "mistral-vibe", or "copilot" (no API key needed).');
+        logger.discovery('  Or set provider to "claude-code", "gemini-cli", "mistral-vibe", "cursor-agent", or "copilot" (no API key needed).');
         process.exitCode = 1;
         return;
       }
@@ -419,6 +419,8 @@ Each spec.md follows OpenSpec conventions:
         openai: DEFAULT_OPENAI_MODEL,
         'claude-code': 'claude-code',
         'mistral-vibe': 'mistral-vibe',
+        'gemini-cli': 'gemini-cli',
+        'cursor-agent': 'cursor-agent',
       };
       const effectiveModel = opts.model || specGenConfig.generation.model || defaultModels[effectiveProvider];
 

--- a/src/core/services/llm-service.test.ts
+++ b/src/core/services/llm-service.test.ts
@@ -16,6 +16,7 @@ import {
   GeminiProvider,
   ClaudeCodeProvider,
   GeminiCLIProvider,
+  CursorAgentProvider,
   MistralVibeProvider,
   createMockLLMService,
   createLLMService,
@@ -641,14 +642,14 @@ describe('Integration Tests (skipped without API keys)', () => {
   describe('CLI Providers', () => {
     it('should create ClaudeCode provider', () => {
       const provider = new ClaudeCodeProvider();
-      
+
       expect(provider.name).toBe('claude-code');
       expect(provider.maxContextTokens).toBe(200_000);
     });
 
     it('should create MistralVibe provider', () => {
       const provider = new MistralVibeProvider();
-      
+
       expect(provider.name).toBe('mistral-vibe');
       expect(provider.maxContextTokens).toBe(128_000);
     });
@@ -661,6 +662,15 @@ describe('Integration Tests (skipped without API keys)', () => {
     it('should create service with mistral-vibe provider', () => {
       const service = createLLMService({ provider: 'mistral-vibe' });
       expect(service.getProviderName()).toBe('mistral-vibe');
+    });
+
+    it('should create service with cursor-agent provider', () => {
+      const service = createLLMService({ provider: 'cursor-agent' });
+      expect(service.getProviderName()).toBe('cursor-agent');
+    });
+
+    it('rejects cursor as unknown provider id', () => {
+      expect(() => createLLMService({ provider: 'cursor' as never })).toThrow(/Unknown provider/);
     });
 
     it('should support custom models for CLI providers', () => {
@@ -699,6 +709,12 @@ describe('lookupPricing', () => {
 
   it('returns zero-cost for claude-code provider', () => {
     const p = lookupPricing('claude-code', 'any-model');
+    expect(p.input).toBe(0);
+    expect(p.output).toBe(0);
+  });
+
+  it('returns zero-cost for cursor-agent provider', () => {
+    const p = lookupPricing('cursor-agent', 'any-model');
     expect(p.input).toBe(0);
     expect(p.output).toBe(0);
   });
@@ -1158,6 +1174,76 @@ describe('GeminiCLIProvider', () => {
     const err = await provider.generateCompletion({ systemPrompt: '', userPrompt: 'hi' }).catch(e => e);
     expect(err.message).toContain('gemini CLI failed');
     expect((err as { retryable?: boolean }).retryable).toBe(false);
+  });
+});
+
+// ============================================================================
+// CursorAgentProvider — CLI-based (mocked execFileSync)
+// ============================================================================
+
+describe('CursorAgentProvider', () => {
+  it('returns content from { result } JSON output', async () => {
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify({
+      result: 'cursor says hi',
+      usage: { input_tokens: 3, output_tokens: 2 },
+    }));
+    const provider = new CursorAgentProvider();
+    const result = await provider.generateCompletion({ systemPrompt: 'sys', userPrompt: 'hi' });
+    expect(result.content).toBe('cursor says hi');
+    expect(result.usage.inputTokens).toBe(3);
+    expect(result.usage.outputTokens).toBe(2);
+    expect(result.model).toBe('cursor-agent');
+  });
+
+  it('returns content from { response } JSON output', async () => {
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify({ response: 'via response field' }));
+    const provider = new CursorAgentProvider();
+    const result = await provider.generateCompletion({ systemPrompt: '', userPrompt: 'x' });
+    expect(result.content).toBe('via response field');
+  });
+
+  it('throws on CLI is_error', async () => {
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify({ result: 'bad', is_error: true }));
+    const provider = new CursorAgentProvider();
+    const err = await provider.generateCompletion({ systemPrompt: '', userPrompt: 'x' }).catch(e => e);
+    expect(err.message).toContain('cursor-agent CLI error');
+    expect((err as { retryable?: boolean }).retryable).toBe(false);
+  });
+
+  it('falls back to raw text when output is not JSON', async () => {
+    vi.mocked(execFileSync).mockReturnValue('plain cursor output');
+    const provider = new CursorAgentProvider();
+    const result = await provider.generateCompletion({ systemPrompt: '', userPrompt: 'x' });
+    expect(result.content).toBe('plain cursor output');
+  });
+
+  it('throws non-retryable error when CLI fails', async () => {
+    vi.mocked(execFileSync).mockImplementation(() => { throw Object.assign(new Error('spawn error'), { stderr: 'not found' }); });
+    const provider = new CursorAgentProvider();
+    const err = await provider.generateCompletion({ systemPrompt: '', userPrompt: 'x' }).catch(e => e);
+    expect(err.message).toContain('cursor-agent CLI failed');
+    expect((err as { retryable?: boolean }).retryable).toBe(false);
+  });
+
+  it('passes --model when configured', async () => {
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify({ result: 'ok' }));
+    const provider = new CursorAgentProvider('gpt-4o');
+    await provider.generateCompletion({ systemPrompt: '', userPrompt: 'go' });
+    const args = vi.mocked(execFileSync).mock.calls[vi.mocked(execFileSync).mock.calls.length - 1][1] as string[];
+    expect(args).toContain('--model');
+    expect(args).toContain('gpt-4o');
+  });
+
+  it('uses CURSOR_AGENT_CLI for binary path', async () => {
+    const prev = process.env.CURSOR_AGENT_CLI;
+    process.env.CURSOR_AGENT_CLI = '/opt/cursor/agent-bin';
+    vi.mocked(execFileSync).mockReturnValue(JSON.stringify({ result: 'x' }));
+    const provider = new CursorAgentProvider();
+    await provider.generateCompletion({ systemPrompt: '', userPrompt: 'y' });
+    const bin = vi.mocked(execFileSync).mock.calls[vi.mocked(execFileSync).mock.calls.length - 1][0] as string;
+    expect(bin).toBe('/opt/cursor/agent-bin');
+    if (prev === undefined) delete process.env.CURSOR_AGENT_CLI;
+    else process.env.CURSOR_AGENT_CLI = prev;
   });
 });
 

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -255,7 +255,7 @@ export interface LLMProvider {
   maxOutputTokens: number;
 }
 
-export type ProviderName = 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'gemini-cli' | 'claude-code' | 'mistral-vibe';
+export type ProviderName = 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'gemini-cli' | 'claude-code' | 'mistral-vibe' | 'cursor-agent';
 
 /**
  * Token usage tracking
@@ -470,6 +470,10 @@ const PRICING: Record<string, Record<string, { input: number; output: number }>>
   },
   'gemini-cli': {
     // No per-token cost: covered by Google account free tier
+    default: { input: 0, output: 0 },
+  },
+  'cursor-agent': {
+    // No per-token cost in spec-gen: Cursor subscription / CLI auth
     default: { input: 0, output: 0 },
   },
   copilot: {
@@ -991,6 +995,99 @@ export class GeminiCLIProvider implements LLMProvider {
       content,
       usage: { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens },
       model: modelUsed,
+      finishReason: 'stop',
+    };
+  }
+
+  countTokens(text: string): number {
+    return estimateTokens(text);
+  }
+}
+
+// ============================================================================
+// CURSOR AGENT CLI PROVIDER (uses local `cursor-agent` CLI, no cloud API key)
+// ============================================================================
+
+/**
+ * Cursor Agent CLI provider
+ *
+ * Routes LLM calls through the Cursor Agent CLI in print mode (`-p`, JSON output).
+ * Authentication is handled by Cursor (see Cursor CLI headless documentation) —
+ * e.g. `cursor auth login` or `CURSOR_API_KEY` — not ANTHROPIC_API_KEY / OPENAI_API_KEY.
+ * If the binary is not on PATH, set `CURSOR_AGENT_CLI` to its full path.
+ */
+export class CursorAgentProvider implements LLMProvider {
+  name = 'cursor-agent';
+  maxContextTokens = 1_000_000;
+  maxOutputTokens = 8192;
+  private model: string | undefined;
+
+  constructor(model?: string) {
+    this.model = model && model !== 'cursor-agent' ? model : undefined;
+  }
+
+  async generateCompletion(request: CompletionRequest): Promise<CompletionResponse> {
+    const { execFileSync } = await import('child_process');
+
+    const fullPrompt = request.systemPrompt
+      ? `${request.systemPrompt}\n\n---\n\n${request.userPrompt}`
+      : request.userPrompt;
+
+    const args = ['-p', fullPrompt, '--output-format', 'json'];
+    if (this.model) args.push('--model', this.model);
+
+    const bin = process.env.CURSOR_AGENT_CLI ?? 'cursor-agent';
+
+    let raw: string;
+    try {
+      raw = execFileSync(bin, args, {
+        encoding: 'utf8',
+        maxBuffer: LLM_CLI_MAX_BUFFER_BYTES,
+        timeout: LLM_CLI_TIMEOUT_MS,
+      });
+    } catch (err: unknown) {
+      const e = err as NodeJS.ErrnoException & { stderr?: string; stdout?: string; status?: number };
+      const detail = e.stderr ?? e.stdout ?? e.message ?? String(err);
+      throw Object.assign(new Error(`cursor-agent CLI failed: ${detail}`), { retryable: false });
+    }
+
+    let content = '';
+    let inputTokens: number | undefined;
+    let outputTokens: number | undefined;
+
+    try {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+
+      if (parsed.is_error === true && typeof parsed.result === 'string') {
+        throw Object.assign(new Error(`cursor-agent CLI error: ${parsed.result}`), { retryable: false });
+      }
+
+      if (typeof parsed.result === 'string') {
+        content = parsed.result;
+      } else if (typeof parsed.response === 'string') {
+        content = parsed.response;
+      } else {
+        content = String(parsed.message ?? parsed.text ?? parsed.content ?? '');
+      }
+
+      const u = parsed.usage as Record<string, number | undefined> | undefined;
+      if (u) {
+        inputTokens = (u.input_tokens ?? u.inputTokens) as number | undefined;
+        outputTokens = (u.output_tokens ?? u.outputTokens) as number | undefined;
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && /cursor-agent CLI error:/.test(err.message)) throw err;
+      content = raw.trim();
+    }
+
+    if (!content) content = raw.trim();
+    inputTokens ??= estimateTokens(fullPrompt);
+    outputTokens ??= estimateTokens(content);
+
+    return {
+      content,
+      usage: { inputTokens, outputTokens, totalTokens: inputTokens + outputTokens },
+      model: this.model ?? 'cursor-agent',
       finishReason: 'stop',
     };
   }
@@ -1584,8 +1681,10 @@ export function createLLMService(options: LLMServiceOptions = {}): LLMService {
     provider = new MistralVibeProvider(options.model);
   } else if (providerName === 'gemini-cli') {
     provider = new GeminiCLIProvider(options.model);
+  } else if (providerName === 'cursor-agent') {
+    provider = new CursorAgentProvider(options.model);
   } else {
-    throw new Error(`Unknown provider: ${providerName}. Supported: anthropic, openai, openai-compat, copilot, gemini, gemini-cli, claude-code, mistral-vibe`);
+    throw new Error(`Unknown provider: ${providerName}. Supported: anthropic, openai, openai-compat, copilot, gemini, gemini-cli, claude-code, mistral-vibe, cursor-agent`);
   }
 
   if (!sslVerify) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,7 +38,7 @@ export interface AnalysisConfig {
 }
 
 export interface GenerationConfig {
-  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'claude-code' | 'mistral-vibe';
+  provider?: 'anthropic' | 'openai' | 'openai-compat' | 'copilot' | 'gemini' | 'claude-code' | 'mistral-vibe' | 'gemini-cli' | 'cursor-agent';
   model?: string;
   openaiCompatBaseUrl?: string;
   skipSslVerify?: boolean;


### PR DESCRIPTION
## Summary

- Updated .gitignore to include .cursor directory.
- Enhanced README to reflect the addition of the cursor-agent provider, bringing the total to nine providers.
- Modified LLM service to handle cursor-agent as a no-API-key provider.
- Updated API types and generation options to include cursor-agent.
- Implemented CursorAgentProvider class to interface with the local cursor-agent CLI, handling authentication and output parsing.
- Added tests for cursor-agent functionality.

## Notes

- Looks like some of the contributing guidelines RE: `npm run embed:up` are outdated? All other checks pass and I ran it against a few of my projects locally w/ `cursor-provider`
- Code changes were implemented, by Cursor w/ OpenSpec, reviewed and moderately edited by me. 