### PR TITLE
fix: stub tree-sitter-cli to prevent GitHub download on npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6116,6 +6116,10 @@
         }
       }
     },
+    "node_modules/tree-sitter-cli": {
+      "resolved": "node_modules/tree-sitter-swift/stubs/tree-sitter-cli-stub",
+      "link": true
+    },
     "node_modules/tree-sitter-cpp": {
       "version": "0.23.4",
       "resolved": "https://registry.npmjs.org/tree-sitter-cpp/-/tree-sitter-cpp-0.23.4.tgz",
@@ -6270,10 +6274,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/tree-sitter-swift/node_modules/tree-sitter-cli": {
-      "resolved": "node_modules/tree-sitter-swift/stubs/tree-sitter-cli-stub",
-      "link": true
     },
     "node_modules/tree-sitter-swift/stubs/tree-sitter-cli-stub": {},
     "node_modules/tree-sitter-typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,9 +52,6 @@
       "engines": {
         "node": ">=20.0.0"
       },
-      "optionalDependencies": {
-        "tree-sitter-cli": "^0.23"
-      },
       "peerDependencies": {
         "@fission-ai/openspec": ">=0.1.0"
       },
@@ -6117,20 +6114,6 @@
         "tree-sitter": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tree-sitter-cli": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.23.2.tgz",
-      "integrity": "sha512-kPPXprOqREX+C/FgUp2Qpt9jd0vSwn+hOgjzVv/7hapdoWpa+VeWId53rf4oNNd29ikheF12BYtGD/W90feMbA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "tree-sitter": "cli.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/tree-sitter-cpp": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "!dist/**/*.test.*",
     "src/viewer",
     "examples",
+    "stubs",
     "README.md",
     "LICENSE"
   ],
@@ -102,8 +103,8 @@
     "vite": "^7.1.3",
     "yaml": "^2.6.1"
   },
-  "optionalDependencies": {
-    "tree-sitter-cli": "^0.23"
+  "overrides": {
+    "tree-sitter-cli": "file:stubs/tree-sitter-cli-stub"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/stubs/tree-sitter-cli-stub/package.json
+++ b/stubs/tree-sitter-cli-stub/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "tree-sitter-cli",
+  "version": "0.23.2",
+  "description": "Stub — prevents postinstall binary download in restricted networks. tree-sitter language packages ship prebuilds; the CLI is not needed at runtime.",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary

- `tree-sitter-swift@0.7.1` lists `tree-sitter-cli` as a runtime dependency; its `install.js` postinstall script downloads a Rust binary from GitHub, causing `npm install -g spec-gen-cli` to fail in corporate networks where `github.com` is blocked
- Add `stubs/tree-sitter-cli-stub/` — a minimal package with no scripts — and wire it up via npm `overrides` so the real `tree-sitter-cli` is never fetched or executed
- Remove `tree-sitter-cli` from `optionalDependencies` (it was never needed at runtime)
- Add `stubs/` to `files` so the override resolves correctly after `npm publish`

Language parser packages (`tree-sitter-swift`, `tree-sitter-python`, etc.) ship precompiled `.node` prebuilds for all platforms; the CLI binary is only needed to author grammars, not to use them.

## Test plan

- [ ] `npm install` completes without network access to `github.com`
- [ ] `node_modules/tree-sitter-cli` is absent (stub is inlined, not installed as a real package)
- [ ] `npm test` passes
- [ ] `npm pack` includes `stubs/tree-sitter-cli-stub/package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)