### PR TITLE
fix: move tree-sitter-swift to optionalDependencies to unblock global install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "tree-sitter-python": "^0.23.6",
         "tree-sitter-ruby": "^0.23.1",
         "tree-sitter-rust": "^0.24.0",
-        "tree-sitter-swift": "^0.7.1",
         "tree-sitter-typescript": "^0.23.2",
         "vite": "^7.1.3",
         "yaml": "^2.6.1"
@@ -51,6 +50,9 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "tree-sitter-swift": "^0.7.1"
       },
       "peerDependencies": {
         "@fission-ai/openspec": ">=0.1.0"
@@ -6260,6 +6262,7 @@
       "integrity": "sha512-pneKVTuGamaBsqqqfB9BvNQjktzh/0IVPR54jLB5Fq/JTDQwYHd0Wo6pVyZ5jAYpbztzq+rJ/rpL9ruxTmSoKw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^8.0.0",
         "node-gyp-build": "^4.8.0",
@@ -6275,7 +6278,9 @@
         }
       }
     },
-    "node_modules/tree-sitter-swift/stubs/tree-sitter-cli-stub": {},
+    "node_modules/tree-sitter-swift/stubs/tree-sitter-cli-stub": {
+      "optional": true
+    },
     "node_modules/tree-sitter-typescript": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.23.2.tgz",

--- a/package.json
+++ b/package.json
@@ -98,10 +98,12 @@
     "tree-sitter-python": "^0.23.6",
     "tree-sitter-ruby": "^0.23.1",
     "tree-sitter-rust": "^0.24.0",
-    "tree-sitter-swift": "^0.7.1",
     "tree-sitter-typescript": "^0.23.2",
     "vite": "^7.1.3",
     "yaml": "^2.6.1"
+  },
+  "optionalDependencies": {
+    "tree-sitter-swift": "^0.7.1"
   },
   "overrides": {
     "tree-sitter-cli": "file:stubs/tree-sitter-cli-stub"


### PR DESCRIPTION
## Problem

`tree-sitter-swift` depends on `tree-sitter-cli`, which runs a postinstall script that downloads a binary from GitHub — failing silently or aborting in restricted/corporate networks.

The previous fix (7d717ea) used `overrides` + a local `file:` stub. **This only works for local dev** (`npm install` in the cloned repo). npm explicitly documents that overrides from non-root packages are not honored, and for `npm install -g`, the global prefix is the root — not the installed package.

Three approaches were investigated and tested, all ineffective for global installs:
1. `overrides: { "tree-sitter-cli": "file:stubs/..." }` → ignored for global install
2. `npm-shrinkwrap.json` with `resolved: "file:stubs/..."` → `file:` paths not portable from registry tarball
3. `bundledDependencies: ["tree-sitter-cli"]` → breaks native module hoisting (`fsevents` rebuild fails)

## Fix

Move `tree-sitter-swift` to `optionalDependencies`:
- If `tree-sitter-cli`'s binary download fails → `tree-sitter-swift` fails to install → npm tolerates it (optional dep semantics) and continues
- At runtime, if `tree-sitter-swift` is absent, Swift file parsing is **silently skipped** — `call-graph.ts` already wraps per-file extraction in try/catch (line 1734)
- All other languages (TS, JS, Python, Go, Rust, Ruby, Java, C++) and all spec-gen features are unaffected

## Tested

```bash
# Simulated dep resolution failure for tree-sitter-swift (overrides to non-existent version)
# → npm completes successfully, tree-sitter-swift is skipped
npm install  # exits 0, node_modules has no tree-sitter-swift

# Runtime: removed tree-sitter-swift from global install
# → spec-gen --version works, no crash
spec-gen --version  # 1.3.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)