### PR TITLE
fix(llm): proxy compatibility — disableResponseFormat, SSE streaming, chunkMaxChars, live doctor checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,23 @@ Or in `config.json`:
 }
 ```
 
+**Proxies that don't support `response_format`** (vLLM, custom gateways):
+
+Some endpoints reject requests that include `response_format` with an error like
+`{"detail":"There was an error parsing the body"}`. Set `disableResponseFormat: true`
+to omit that field — the model still produces JSON via the system prompt:
+
+```json
+{
+  "generation": {
+    "provider": "openai-compat",
+    "openaiCompatBaseUrl": "https://your-gateway.corp.net/v1",
+    "disableResponseFormat": true,
+    "domains": "auto"
+  }
+}
+```
+
 Works with: Ollama, LM Studio, Mistral AI, Groq, Together AI, LiteLLM, vLLM,
 text-generation-inference, LocalAI, Azure OpenAI, and any `/v1/chat/completions` server.
 

--- a/src/api/generate.ts
+++ b/src/api/generate.ts
@@ -180,6 +180,7 @@ export async function specGenGenerate(options: GenerateApiOptions = {}): Promise
       apiBase: options.apiBase ?? specGenConfig.llm?.apiBase,
       sslVerify,
       timeout: options.timeout ?? specGenConfig.generation?.timeout,
+      disableResponseFormat: specGenConfig.generation?.disableResponseFormat,
       enableLogging: true,
       logDir: join(rootPath, SPEC_GEN_DIR, SPEC_GEN_LOGS_SUBDIR),
     });

--- a/src/api/generate.ts
+++ b/src/api/generate.ts
@@ -220,6 +220,7 @@ export async function specGenGenerate(options: GenerateApiOptions = {}): Promise
     saveIntermediate: true,
     generateADRs: adr || adrOnly,
     force: options.force,
+    chunkMaxChars: specGenConfig.generation?.chunkMaxChars,
   });
 
   let pipelineResult;

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -39,6 +39,13 @@ vi.mock('../../core/services/config-manager.js', () => ({
   }),
 }));
 
+vi.mock('../../core/services/llm-service.js', () => ({
+  createLLMService: vi.fn().mockReturnValue({
+    complete: vi.fn().mockResolvedValue({ model: 'claude-opus-4-6', content: 'pong' }),
+    saveLogs: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
 // ============================================================================
 // HELPERS
 // ============================================================================
@@ -50,15 +57,6 @@ function mockExecSuccess(stdout = 'ok'): void {
   vi.mocked(execFileMock).mockImplementation((...args: any[]) => {
     const cb = args[args.length - 1];
     if (typeof cb === 'function') cb(null, { stdout, stderr: '' });
-    return {} as ReturnType<typeof execFileMock>;
-  });
-}
-
-/** Make execFileMock fail */
-function mockExecFail(): void {
-  vi.mocked(execFileMock).mockImplementation((...args: any[]) => {
-    const cb = args[args.length - 1];
-    if (typeof cb === 'function') cb(new Error('command not found'));
     return {} as ReturnType<typeof execFileMock>;
   });
 }
@@ -83,12 +81,18 @@ async function runDoctorJson(): Promise<Array<{ name: string; status: string; de
 describe('doctor command', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     process.exitCode = undefined;
     vi.clearAllMocks();
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     mockExecSuccess();
+    // Restore default LLM mock after clearAllMocks
+    const llmService = await import('../../core/services/llm-service.js');
+    vi.mocked(llmService.createLLMService).mockReturnValue({
+      complete: vi.fn().mockResolvedValue({ model: 'claude-opus-4-6', content: 'pong' }),
+      saveLogs: vi.fn().mockResolvedValue(undefined),
+    } as never);
   });
 
   afterEach(() => {
@@ -165,9 +169,9 @@ describe('doctor command', () => {
       expect(openspecCheck).toBeDefined();
     });
 
-    it('should include an LLM provider check', async () => {
+    it('should include an LLM connection check', async () => {
       const checks = await runDoctorJson();
-      const llmCheck = checks.find(c => c.name === 'LLM provider');
+      const llmCheck = checks.find(c => c.name === 'LLM connection');
       expect(llmCheck).toBeDefined();
     });
 
@@ -188,8 +192,8 @@ describe('doctor command', () => {
   });
 
   // --------------------------------------------------------------------------
-  describe('LLM provider check', () => {
-    const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'SPEC_GEN_API_BASE'];
+  describe('LLM connection check', () => {
+    const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_COMPAT_API_KEY'];
 
     function clearLLMKeys(): Record<string, string | undefined> {
       const saved: Record<string, string | undefined> = {};
@@ -203,72 +207,66 @@ describe('doctor command', () => {
     function restoreLLMKeys(saved: Record<string, string | undefined>): void {
       for (const k of keyVars) {
         if (saved[k] !== undefined) process.env[k] = saved[k];
+        else delete process.env[k];
       }
     }
 
-    it('should pass (ok) when ANTHROPIC_API_KEY is set', async () => {
+    it('should pass (ok) when createLLMService and complete() both succeed', async () => {
       const saved = clearLLMKeys();
       process.env.ANTHROPIC_API_KEY = 'sk-test-anthropic';
       try {
         const checks = await runDoctorJson();
-        const llmCheck = checks.find(c => c.name === 'LLM provider')!;
+        const llmCheck = checks.find(c => c.name === 'LLM connection')!;
         expect(llmCheck.status).toBe('ok');
-        expect(llmCheck.detail).toContain('ANTHROPIC_API_KEY');
+        expect(llmCheck.detail).toContain('anthropic');
       } finally {
         restoreLLMKeys(saved);
       }
     });
 
-    it('should pass (ok) when OPENAI_API_KEY is set', async () => {
-      const saved = clearLLMKeys();
-      process.env.OPENAI_API_KEY = 'sk-test-openai';
-      try {
-        const checks = await runDoctorJson();
-        const llmCheck = checks.find(c => c.name === 'LLM provider')!;
-        expect(llmCheck.status).toBe('ok');
-        expect(llmCheck.detail).toContain('OPENAI_API_KEY');
-      } finally {
-        restoreLLMKeys(saved);
-      }
-    });
-
-    it('should pass (ok) when GEMINI_API_KEY is set', async () => {
+    it('should detect gemini provider when GEMINI_API_KEY is set', async () => {
       const saved = clearLLMKeys();
       process.env.GEMINI_API_KEY = 'test-gemini-key';
       try {
         const checks = await runDoctorJson();
-        const llmCheck = checks.find(c => c.name === 'LLM provider')!;
+        const llmCheck = checks.find(c => c.name === 'LLM connection')!;
         expect(llmCheck.status).toBe('ok');
-        expect(llmCheck.detail).toContain('GEMINI_API_KEY');
+        expect(llmCheck.detail).toContain('gemini');
       } finally {
         restoreLLMKeys(saved);
       }
     });
 
-    it('should fail when no provider key is set and claude CLI is absent', async () => {
+    it('should fail when createLLMService throws (missing API key)', async () => {
       const saved = clearLLMKeys();
-      // Make execFile fail so claude --version check fails
-      mockExecFail();
+      const llmService = await import('../../core/services/llm-service.js');
+      vi.mocked(llmService.createLLMService).mockImplementationOnce(() => {
+        throw new Error('No API key');
+      });
       try {
         const checks = await runDoctorJson();
-        const llmCheck = checks.find(c => c.name === 'LLM provider')!;
+        const llmCheck = checks.find(c => c.name === 'LLM connection')!;
         expect(llmCheck.status).toBe('fail');
         expect(llmCheck.fix).toBeDefined();
-        expect(llmCheck.fix).toContain('ANTHROPIC_API_KEY');
+        expect(llmCheck.fix).toContain('API key');
       } finally {
         restoreLLMKeys(saved);
       }
     });
 
-    it('should warn when SPEC_GEN_API_BASE is set but no API key', async () => {
+    it('should fail when complete() rejects (network error)', async () => {
       const saved = clearLLMKeys();
-      process.env.SPEC_GEN_API_BASE = 'http://localhost:11434/v1';
-      mockExecFail(); // no claude CLI
+      process.env.ANTHROPIC_API_KEY = 'sk-test-anthropic';
+      const llmService = await import('../../core/services/llm-service.js');
+      vi.mocked(llmService.createLLMService).mockReturnValueOnce({
+        complete: vi.fn().mockRejectedValue(new Error('Connection refused')),
+        saveLogs: vi.fn().mockResolvedValue(undefined),
+      } as never);
       try {
         const checks = await runDoctorJson();
-        const llmCheck = checks.find(c => c.name === 'LLM provider')!;
-        expect(llmCheck.status).toBe('warn');
-        expect(llmCheck.detail).toContain('SPEC_GEN_API_BASE');
+        const llmCheck = checks.find(c => c.name === 'LLM connection')!;
+        expect(llmCheck.status).toBe('fail');
+        expect(llmCheck.fix).toContain('API key');
       } finally {
         restoreLLMKeys(saved);
       }
@@ -276,11 +274,14 @@ describe('doctor command', () => {
 
     it('should include a fix suggestion when failing', async () => {
       const saved = clearLLMKeys();
-      mockExecFail();
+      const llmService = await import('../../core/services/llm-service.js');
+      vi.mocked(llmService.createLLMService).mockImplementationOnce(() => {
+        throw new Error('No API key');
+      });
       try {
         const checks = await runDoctorJson();
-        const llmCheck = checks.find(c => c.name === 'LLM provider')!;
-        expect(llmCheck.fix).toMatch(/API_KEY/);
+        const llmCheck = checks.find(c => c.name === 'LLM connection')!;
+        expect(llmCheck.fix).toBeDefined();
       } finally {
         restoreLLMKeys(saved);
       }
@@ -356,22 +357,26 @@ describe('doctor command', () => {
   describe('exit code', () => {
     it('should set exitCode=1 when any check fails (JSON mode confirms fail status)', async () => {
       consoleSpy.mockImplementation(() => {});
-      const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'SPEC_GEN_API_BASE'];
+      const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_COMPAT_API_KEY'];
       const saved: Record<string, string | undefined> = {};
       for (const k of keyVars) { saved[k] = process.env[k]; delete process.env[k]; }
-      mockExecFail();
+
+      const llmService = await import('../../core/services/llm-service.js');
+      vi.mocked(llmService.createLLMService).mockImplementationOnce(() => {
+        throw new Error('No API key');
+      });
 
       try {
         // Confirm via JSON mode that the LLM check is a 'fail'
         const checks = await runDoctorJson();
-        const llmCheck = checks.find(c => c.name === 'LLM provider')!;
+        const llmCheck = checks.find(c => c.name === 'LLM connection')!;
         expect(llmCheck.status).toBe('fail');
         // The JSON path returns early, so exitCode is only set in the non-JSON path.
         // Verify the failure count reported includes at least one failure.
         const failures = checks.filter(c => c.status === 'fail');
         expect(failures.length).toBeGreaterThan(0);
       } finally {
-        for (const k of keyVars) { if (saved[k] !== undefined) process.env[k] = saved[k]; }
+        for (const k of keyVars) { if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k]; }
       }
     });
 
@@ -405,6 +410,13 @@ describe('doctor command', () => {
         projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec', maxFiles: 500,
       } as never);
 
+      // Ensure createLLMService returns a working mock (clearAllMocks resets it)
+      const llmService = await import('../../core/services/llm-service.js');
+      vi.mocked(llmService.createLLMService).mockReturnValue({
+        complete: vi.fn().mockResolvedValue({ model: 'claude-opus-4-6', content: 'pong' }),
+        saveLogs: vi.fn().mockResolvedValue(undefined),
+      } as never);
+
       const saved = process.env.ANTHROPIC_API_KEY;
       process.env.ANTHROPIC_API_KEY = 'sk-test-key';
 
@@ -423,10 +435,14 @@ describe('doctor command', () => {
     it('non-JSON: logger.error called and exitCode=1 when a check fails', async () => {
       doctorCommand.setOptionValue('json', false);
 
-      const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'SPEC_GEN_API_BASE'];
+      const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_COMPAT_API_KEY'];
       const saved: Record<string, string | undefined> = {};
       for (const k of keyVars) { saved[k] = process.env[k]; delete process.env[k]; }
-      mockExecFail();
+
+      const llmService = await import('../../core/services/llm-service.js');
+      vi.mocked(llmService.createLLMService).mockImplementationOnce(() => {
+        throw new Error('No API key');
+      });
 
       const loggerModule = await import('../../utils/logger.js');
       vi.mocked(loggerModule.logger.error).mockClear();
@@ -436,7 +452,7 @@ describe('doctor command', () => {
         expect(vi.mocked(loggerModule.logger.error)).toHaveBeenCalled();
         expect(process.exitCode).toBe(1);
       } finally {
-        for (const k of keyVars) { if (saved[k] !== undefined) process.env[k] = saved[k]; }
+        for (const k of keyVars) { if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k]; }
       }
     });
   });

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -12,6 +12,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { logger } from '../../utils/logger.js';
 import { readSpecGenConfig } from '../../core/services/config-manager.js';
+import { createLLMService, ProviderName } from '../../core/services/llm-service.js';
 import {
   MIN_NODE_MAJOR_VERSION,
   ANALYSIS_AGE_WARNING_HOURS,
@@ -24,6 +25,11 @@ import {
   OPENSPEC_DIR,
   OPENSPEC_SPECS_SUBDIR,
   ARTIFACT_REPO_STRUCTURE,
+  DEFAULT_ANTHROPIC_MODEL,
+  DEFAULT_OPENAI_MODEL,
+  DEFAULT_OPENAI_COMPAT_MODEL,
+  DEFAULT_GEMINI_MODEL,
+  DEFAULT_COPILOT_MODEL,
 } from '../../constants.js';
 
 const execFileAsync = promisify(execFile);
@@ -150,47 +156,165 @@ async function checkOpenSpecDir(rootPath: string): Promise<CheckResult> {
   }
 }
 
-async function checkLLMProvider(): Promise<CheckResult> {
-  const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
-  const hasOpenAI = !!process.env.OPENAI_API_KEY;
-  const hasGemini = !!process.env.GEMINI_API_KEY || !!process.env.GOOGLE_API_KEY;
-  const hasApiBase = !!process.env.SPEC_GEN_API_BASE;
+const CLI_PROVIDERS: Record<string, string> = {
+  'claude-code': 'claude',
+  'gemini-cli': 'gemini',
+  'cursor-agent': 'cursor',
+  'mistral-vibe': 'vibe',
+};
 
-  // Check if claude CLI is available (Claude Code / Max plan)
-  let hasClaudeCode = false;
+const DOCTOR_TIMEOUT_MS = 10_000;
+
+async function checkLLMConnection(rootPath: string): Promise<CheckResult> {
+  let config;
+  try { config = await readSpecGenConfig(rootPath); } catch { /* no config */ }
+
+  const gen = config?.generation;
+
+  // Detect provider (mirrors generate.ts logic)
+  const configuredProvider = gen?.provider;
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  const geminiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY;
+  const openaiCompatKey = process.env.OPENAI_COMPAT_API_KEY;
+  const envDetectedProvider = anthropicKey ? 'anthropic'
+    : geminiKey ? 'gemini'
+    : openaiCompatKey ? 'openai-compat'
+    : 'openai';
+  const provider = configuredProvider ?? envDetectedProvider;
+
+  const defaultModels: Record<string, string> = {
+    anthropic: DEFAULT_ANTHROPIC_MODEL,
+    gemini: DEFAULT_GEMINI_MODEL,
+    'openai-compat': DEFAULT_OPENAI_COMPAT_MODEL,
+    copilot: DEFAULT_COPILOT_MODEL,
+    openai: DEFAULT_OPENAI_MODEL,
+    'claude-code': 'claude-code',
+    'mistral-vibe': 'mistral-vibe',
+    'gemini-cli': 'gemini-cli',
+    'cursor-agent': 'cursor-agent',
+  };
+  const model = gen?.model ?? defaultModels[provider] ?? provider;
+
+  // CLI-based providers: just check binary availability
+  if (provider in CLI_PROVIDERS) {
+    const bin = CLI_PROVIDERS[provider];
+    try {
+      await execFileAsync(bin, ['--version']);
+      return { name: 'LLM connection', status: 'ok', detail: `${provider} · ${bin} CLI detected` };
+    } catch {
+      return {
+        name: 'LLM connection',
+        status: 'fail',
+        detail: `${provider} · '${bin}' not found on PATH`,
+        fix: `Install the ${bin} CLI and ensure it is on your PATH`,
+      };
+    }
+  }
+
+  // Apply SSL setting before creating provider
+  const sslVerify = config?.llm?.sslVerify ?? true;
+  if (!sslVerify || gen?.skipSslVerify) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
+
+  const baseUrl = gen?.openaiCompatBaseUrl ?? process.env.OPENAI_COMPAT_BASE_URL;
+
+  let llm;
   try {
-    await execFileAsync('claude', ['--version']);
-    hasClaudeCode = true;
-  } catch { /* not installed */ }
-
-  if (hasAnthropic) {
-    return { name: 'LLM provider', status: 'ok', detail: 'ANTHROPIC_API_KEY set' };
-  }
-  if (hasOpenAI) {
-    return { name: 'LLM provider', status: 'ok', detail: 'OPENAI_API_KEY set' };
-  }
-  if (hasGemini) {
-    return { name: 'LLM provider', status: 'ok', detail: 'GEMINI_API_KEY set' };
-  }
-  if (hasClaudeCode) {
-    return { name: 'LLM provider', status: 'ok', detail: 'claude CLI detected (Claude Code / Max)' };
-  }
-  if (hasApiBase) {
+    llm = createLLMService({
+      provider: provider as ProviderName,
+      model,
+      openaiCompatBaseUrl: baseUrl,
+      sslVerify,
+      timeout: DOCTOR_TIMEOUT_MS,
+      disableResponseFormat: gen?.disableResponseFormat,
+    });
+  } catch (err) {
     return {
-      name: 'LLM provider',
-      status: 'warn',
-      detail: `SPEC_GEN_API_BASE set to ${process.env.SPEC_GEN_API_BASE} (no API key)`,
+      name: 'LLM connection',
+      status: 'fail',
+      detail: `${provider} · ${(err as Error).message}`,
+      fix: 'Check that the required API key environment variable is set',
     };
   }
 
-  return {
-    name: 'LLM provider',
-    status: 'fail',
-    detail: 'No LLM provider configured',
-    fix:
-      'Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY.\n' +
-      '  Alternatively install Claude Code (claude CLI) for subscription-based access.',
-  };
+  const t0 = Date.now();
+  try {
+    const result = await llm.complete({ systemPrompt: 'Reply with one word.', userPrompt: 'ping', maxTokens: 5 });
+    const ms = Date.now() - t0;
+    return {
+      name: 'LLM connection',
+      status: 'ok',
+      detail: `${provider} · ${result.model ?? model} · ${ms}ms`,
+    };
+  } catch (err) {
+    const ms = Date.now() - t0;
+    const msg = (err as Error).message ?? String(err);
+    return {
+      name: 'LLM connection',
+      status: 'fail',
+      detail: `${provider} · ${msg} (${ms}ms)`,
+      fix: 'Check your API key, base URL, and network connectivity',
+    };
+  }
+}
+
+async function checkEmbeddingConnection(rootPath: string): Promise<CheckResult | null> {
+  let config;
+  try { config = await readSpecGenConfig(rootPath); } catch { /* no config */ }
+
+  const emb = config?.embedding;
+
+  // Resolve base URL from config or env
+  const baseUrl = emb?.baseUrl ?? process.env.EMBED_BASE_URL;
+  if (!baseUrl) return null; // Embedding not configured — skip
+
+  if (emb?.skipSslVerify) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
+
+  const apiKey = emb?.apiKey ?? process.env.EMBED_API_KEY ?? 'none';
+  const model = emb?.model ?? process.env.EMBED_MODEL ?? 'text-embedding-ada-002';
+  const url = baseUrl.replace(/\/$/, '');
+
+  const t0 = Date.now();
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DOCTOR_TIMEOUT_MS);
+    const response = await fetch(`${url}/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ model, input: 'ping' }),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeout));
+
+    const ms = Date.now() - t0;
+    if (!response.ok) {
+      const body = (await response.text().catch(() => '')).trim() || '(empty)';
+      return {
+        name: 'Embedding connection',
+        status: 'fail',
+        detail: `HTTP ${response.status}: ${body} (${ms}ms)`,
+        fix: 'Check your embedding server URL, API key, and that the server is running',
+      };
+    }
+    const data = await response.json() as { data?: Array<{ embedding: number[] }> };
+    const dims = data?.data?.[0]?.embedding?.length ?? '?';
+    return {
+      name: 'Embedding connection',
+      status: 'ok',
+      detail: `${url} · ${model} · ${dims} dims · ${ms}ms`,
+    };
+  } catch (err) {
+    const ms = Date.now() - t0;
+    const msg = (err as Error).message ?? String(err);
+    return {
+      name: 'Embedding connection',
+      status: 'fail',
+      detail: `${url} · ${msg} (${ms}ms)`,
+      fix: 'Check your embedding server is running (npm run embed:up) and the URL is correct',
+    };
+  }
 }
 
 async function checkDiskSpace(rootPath: string): Promise<CheckResult> {
@@ -268,7 +392,8 @@ Checks performed:
   • spec-gen configuration (${SPEC_GEN_CONFIG_REL_PATH})
   • Analysis artifacts freshness
   • OpenSpec directory presence
-  • LLM provider configuration
+  • LLM connection (live request with 10s timeout)
+  • Embedding connection (if configured)
   • Available disk space
 `
   )
@@ -282,15 +407,24 @@ Checks performed:
       console.log('');
     }
 
-    const checks = await Promise.all([
-      checkNodeVersion(),
-      checkGit(rootPath),
-      checkConfig(rootPath),
-      checkAnalysis(rootPath),
-      checkOpenSpecDir(rootPath),
-      checkLLMProvider(),
-      checkDiskSpace(rootPath),
+    const [staticChecks, llmCheck, embeddingCheck] = await Promise.all([
+      Promise.all([
+        checkNodeVersion(),
+        checkGit(rootPath),
+        checkConfig(rootPath),
+        checkAnalysis(rootPath),
+        checkOpenSpecDir(rootPath),
+        checkDiskSpace(rootPath),
+      ]),
+      checkLLMConnection(rootPath),
+      checkEmbeddingConnection(rootPath),
     ]);
+
+    const checks = [
+      ...staticChecks,
+      llmCheck,
+      ...(embeddingCheck ? [embeddingCheck] : []),
+    ];
 
     if (options.json) {
       console.log(JSON.stringify(checks, null, 2));

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -530,6 +530,7 @@ Each spec.md follows OpenSpec conventions:
         force: opts.force,
         progress,
         semanticSearch,
+        chunkMaxChars: specGenConfig.generation?.chunkMaxChars,
       });
 
       let pipelineResult: PipelineResult;

--- a/src/core/generator/spec-pipeline.ts
+++ b/src/core/generator/spec-pipeline.ts
@@ -93,6 +93,7 @@ export class SpecGenerationPipeline implements PipelineContext {
       rootPath: options.rootPath ?? '',
       saveIntermediate: options.saveIntermediate ?? true,
       generateADRs: options.generateADRs ?? false,
+      chunkMaxChars: options.chunkMaxChars ?? STAGE_CHUNK_MAX_CHARS,
     };
   }
 
@@ -403,7 +404,7 @@ export class SpecGenerationPipeline implements PipelineContext {
     // ── Path 2: skeleton fallback for large files without god functions ─────
     // Avoids splitting files into multiple chunks (and the resulting [PARTIAL SPEC] marker)
     // when the skeleton alone is a complete, noise-free representation.
-    if (content && content.length > STAGE_CHUNK_MAX_CHARS) {
+    if (content && content.length > this.options.chunkMaxChars) {
       const language = detectLanguage(filePath);
       const skeleton = getSkeletonContent(content, language);
       if (isSkeletonWorthIncluding(content, skeleton) && skeleton.length <= SKELETON_STANDALONE_MAX_CHARS) {

--- a/src/core/generator/stages/stage2-entities.ts
+++ b/src/core/generator/stages/stage2-entities.ts
@@ -5,7 +5,7 @@
  */
 
 import logger from '../../../utils/logger.js';
-import { STAGE2_MAX_TOKENS, STAGE_CHUNK_MAX_CHARS } from '../../../constants.js';
+import { STAGE2_MAX_TOKENS } from '../../../constants.js';
 import { PROMPTS } from '../prompts.js';
 import type { ExtractedEntity, StageResult, PipelineContext, ProjectSurveyResult } from '../../../types/pipeline.js';
 import { astChunkContent } from '../../analyzer/ast-chunker.js';
@@ -24,7 +24,7 @@ export async function runStage2(
 
   for (const [idx, file] of schemaFiles.entries()) {
     onFile?.(idx + 1, schemaFiles.length, file.path);
-    const chunks = await astChunkContent(file.content, file.path, STAGE_CHUNK_MAX_CHARS);
+    const chunks = await astChunkContent(file.content, file.path, pipeline.options.chunkMaxChars);
     const isLargeFile = chunks.length > 1;
     const graphSection = pipeline.graphPromptFor(file.path, file.content);
 

--- a/src/core/generator/stages/stage3-services.ts
+++ b/src/core/generator/stages/stage3-services.ts
@@ -5,7 +5,7 @@
  */
 
 import logger from '../../../utils/logger.js';
-import { STAGE3_MAX_TOKENS, STAGE_CHUNK_MAX_CHARS } from '../../../constants.js';
+import { STAGE3_MAX_TOKENS } from '../../../constants.js';
 import { PROMPTS } from '../prompts.js';
 import type { ExtractedEntity, ExtractedService, StageResult, PipelineContext, ProjectSurveyResult } from '../../../types/pipeline.js';
 import { astChunkContent } from '../../analyzer/ast-chunker.js';
@@ -26,7 +26,7 @@ export async function runStage3(
 
   for (const [idx, file] of serviceFiles.entries()) {
     onFile?.(idx + 1, serviceFiles.length, file.path);
-    const chunks = await astChunkContent(file.content, file.path, STAGE_CHUNK_MAX_CHARS);
+    const chunks = await astChunkContent(file.content, file.path, pipeline.options.chunkMaxChars);
     const isLargeFile = chunks.length > 1;
     const graphSection = pipeline.graphPromptFor(file.path, file.content);
 

--- a/src/core/generator/stages/stage4-api.ts
+++ b/src/core/generator/stages/stage4-api.ts
@@ -5,7 +5,7 @@
  */
 
 import logger from '../../../utils/logger.js';
-import { STAGE4_MAX_TOKENS, STAGE_CHUNK_MAX_CHARS } from '../../../constants.js';
+import { STAGE4_MAX_TOKENS } from '../../../constants.js';
 import { PROMPTS } from '../prompts.js';
 import type { ExtractedEndpoint, StageResult, PipelineContext } from '../../../types/pipeline.js';
 import { astChunkContent } from '../../analyzer/ast-chunker.js';
@@ -22,7 +22,7 @@ export async function runStage4(
 
   for (const [idx, file] of apiFiles.entries()) {
     onFile?.(idx + 1, apiFiles.length, file.path);
-    const chunks = await astChunkContent(file.content, file.path, STAGE_CHUNK_MAX_CHARS);
+    const chunks = await astChunkContent(file.content, file.path, pipeline.options.chunkMaxChars);
     const isLargeFile = chunks.length > 1;
     const graphSection = pipeline.graphPromptFor(file.path, file.content);
 

--- a/src/core/generator/stages/stage5-architecture.test.ts
+++ b/src/core/generator/stages/stage5-architecture.test.ts
@@ -197,7 +197,7 @@ function createMockPipelineContext() {
   const saveResult = vi.fn().mockResolvedValue(undefined);
   const pipeline: PipelineContext = {
     llm,
-    options: { saveIntermediate: false },
+    options: { saveIntermediate: false, chunkMaxChars: 8000 },
     saveResult,
     chunkContent: vi.fn(),
     graphPromptFor: vi.fn().mockReturnValue(null),

--- a/src/core/generator/stages/stages.test.ts
+++ b/src/core/generator/stages/stages.test.ts
@@ -28,7 +28,7 @@ function makePipeline(overrides?: Partial<PipelineContext>): PipelineContext {
       completeJSON: vi.fn().mockResolvedValue([]),
       getTokenUsage: vi.fn().mockReturnValue({ totalTokens: 42 }),
     } as unknown as PipelineContext['llm'],
-    options: { saveIntermediate: false },
+    options: { saveIntermediate: false, chunkMaxChars: 8000 },
     saveResult: vi.fn().mockResolvedValue(undefined),
     chunkContent: vi.fn().mockImplementation((content: string) => [content]),
     graphPromptFor: vi.fn().mockReturnValue(null),

--- a/src/core/services/llm-service.test.ts
+++ b/src/core/services/llm-service.test.ts
@@ -934,6 +934,25 @@ describe('OpenAICompatibleProvider', () => {
     expect(body.response_format.type).toBe('json_schema');
   });
 
+  it('omits response_format when disableResponseFormat=true', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(SUCCESS_BODY));
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = new OpenAICompatibleProvider('key', 'https://api.mistral.ai/v1', 'mistral-small-4', true);
+    const schema = { type: 'array' };
+    await provider.generateCompletion({ systemPrompt: '', userPrompt: 'hi', responseFormat: 'json', jsonSchema: schema });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.response_format).toBeUndefined();
+  });
+
+  it('includes response_format when disableResponseFormat=false (default)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(SUCCESS_BODY));
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = new OpenAICompatibleProvider('key', 'https://api.mistral.ai/v1', 'mistral-small-4', false);
+    await provider.generateCompletion({ systemPrompt: '', userPrompt: 'hi', responseFormat: 'json' });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.response_format).toBeDefined();
+  });
+
   it('throws retryable error on 500', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockErrorResponse('server error', 500)));
     const provider = new OpenAICompatibleProvider('key', 'https://api.mistral.ai/v1');

--- a/src/core/services/llm-service.test.ts
+++ b/src/core/services/llm-service.test.ts
@@ -38,6 +38,17 @@ function mockResponse(body: object, status = 200, headers: Record<string, string
   });
 }
 
+function mockStreamResponse(chunks: object[], status = 200): Response {
+  const lines = [
+    ...chunks.map(c => `data: ${JSON.stringify(c)}\n\n`),
+    'data: [DONE]\n\n',
+  ].join('');
+  return new Response(lines, {
+    status,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
 function mockErrorResponse(body: string, status: number, headers: Record<string, string> = {}): Response {
   return new Response(body, { status, headers });
 }
@@ -917,7 +928,10 @@ describe('OpenAICompatibleProvider', () => {
   };
 
   it('returns content on success', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse(SUCCESS_BODY)));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockStreamResponse([
+      { choices: [{ delta: { content: 'compat response' }, finish_reason: null }], model: 'mistral-large-latest' },
+      { choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 5, completion_tokens: 3, total_tokens: 8 }, model: 'mistral-large-latest' },
+    ])));
     const provider = new OpenAICompatibleProvider('key', 'https://api.mistral.ai/v1');
     const result = await provider.generateCompletion({ systemPrompt: '', userPrompt: 'hi' });
     expect(result.content).toBe('compat response');

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -304,6 +304,8 @@ export interface LLMServiceOptions {
   logDir?: string;
   /** Enable prompt logging */
   enableLogging?: boolean;
+  /** Disable response_format field in requests (for endpoints that don't support it) */
+  disableResponseFormat?: boolean;
 }
 
 /**
@@ -611,7 +613,8 @@ export class AnthropicProvider implements LLMProvider {
   }
 
   private parseError(error: string, status: number, retryAfterHeader?: string | null): Error & { status?: number; retryable?: boolean; retryAfterMs?: number } {
-    const err = new Error(error) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
+    const detail = error.trim() || '(empty response body)';
+    const err = new Error(`HTTP ${status}: ${detail}`) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
     err.status = status;
     err.retryable = status === 429 || status >= 500;
     if (status === 429) {
@@ -728,7 +731,8 @@ export class OpenAIProvider implements LLMProvider {
   }
 
   private parseError(error: string, status: number, retryAfterHeader?: string | null): Error & { status?: number; retryable?: boolean; retryAfterMs?: number } {
-    const err = new Error(error) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
+    const detail = error.trim() || '(empty response body)';
+    const err = new Error(`HTTP ${status}: ${detail}`) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
     err.status = status;
     err.retryable = status === 429 || status >= 500;
     if (status === 429) {
@@ -765,11 +769,13 @@ export class OpenAICompatibleProvider implements LLMProvider {
   private apiKey: string;
   private model: string;
   private baseUrl: string;
+  private disableResponseFormat: boolean;
 
-  constructor(apiKey: string, baseUrl: string, model = DEFAULT_OPENAI_COMPAT_MODEL) {
+  constructor(apiKey: string, baseUrl: string, model = DEFAULT_OPENAI_COMPAT_MODEL, disableResponseFormat = false) {
     this.apiKey = apiKey;
     this.baseUrl = normalizeApiBase(baseUrl);
     this.model = model;
+    this.disableResponseFormat = disableResponseFormat;
   }
 
   countTokens(text: string): number {
@@ -855,16 +861,18 @@ export class OpenAICompatibleProvider implements LLMProvider {
       ...(request.stopSequences && { stop: request.stopSequences }),
     };
 
-    if (request.responseFormat === 'json' && request.jsonSchema) {
-      body.response_format = {
-        type: 'json_schema',
-        json_schema: {
-          name: 'response',
-          schema: wrapArraySchema(request.jsonSchema),
-        },
-      };
-    } else if (request.responseFormat === 'json') {
-      body.response_format = { type: 'json_object' };
+    if (!this.disableResponseFormat) {
+      if (request.responseFormat === 'json' && request.jsonSchema) {
+        body.response_format = {
+          type: 'json_schema',
+          json_schema: {
+            name: 'response',
+            schema: wrapArraySchema(request.jsonSchema),
+          },
+        };
+      } else if (request.responseFormat === 'json') {
+        body.response_format = { type: 'json_object' };
+      }
     }
 
     const response = await fetch(`${this.baseUrl}/chat/completions`, {
@@ -878,7 +886,8 @@ export class OpenAICompatibleProvider implements LLMProvider {
 
     if (!response.ok) {
       const error = await response.text();
-      const err = new Error(error) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
+      const detail = error.trim() || '(empty response body)';
+      const err = new Error(`HTTP ${response.status}: ${detail}`) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
       err.status = response.status;
       err.retryable = response.status === 429 || response.status >= 500;
       if (response.status === 429) {
@@ -975,7 +984,8 @@ export class CopilotProvider implements LLMProvider {
 
     if (!response.ok) {
       const error = await response.text();
-      const err = new Error(error) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
+      const detail = error.trim() || '(empty response body)';
+      const err = new Error(`HTTP ${response.status}: ${detail}`) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
       err.status = response.status;
       err.retryable = response.status === 429 || response.status >= 500;
       if (response.status === 429) {
@@ -1240,7 +1250,8 @@ export class GeminiProvider implements LLMProvider {
 
     if (!response.ok) {
       const error = await response.text();
-      const err = new Error(error) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
+      const detail = error.trim() || '(empty response body)';
+      const err = new Error(`HTTP ${response.status}: ${detail}`) as Error & { status?: number; retryable?: boolean; retryAfterMs?: number };
       err.status = response.status;
       err.retryable = response.status === 429 || response.status >= 500;
       if (response.status === 429) {
@@ -1382,6 +1393,7 @@ export class LLMService {
       costWarningThreshold: options.costWarningThreshold ?? DEFAULT_LLM_COST_WARNING_THRESHOLD,
       logDir: options.logDir ?? `${SPEC_GEN_DIR}/${SPEC_GEN_LOGS_SUBDIR}`,
       enableLogging: options.enableLogging ?? false,
+      disableResponseFormat: options.disableResponseFormat ?? false,
     };
     this.retryConfig = {
       maxRetries: this.options.maxRetries,
@@ -1756,7 +1768,7 @@ export function createLLMService(options: LLMServiceOptions = {}): LLMService {
     if (!baseUrl) {
       throw new Error('openaiCompatBaseUrl must be set in config or OPENAI_COMPAT_BASE_URL env var (e.g. https://api.mistral.ai/v1)');
     }
-    provider = new OpenAICompatibleProvider(apiKey, baseUrl, options.model ?? DEFAULT_OPENAI_COMPAT_MODEL);
+    provider = new OpenAICompatibleProvider(apiKey, baseUrl, options.model ?? DEFAULT_OPENAI_COMPAT_MODEL, options.disableResponseFormat ?? false);
   } else if (providerName === 'copilot') {
     const baseUrl = options.openaiCompatBaseUrl ?? options.apiBase ?? process.env.COPILOT_API_BASE_URL ?? 'http://localhost:4141/v1';
     const apiKey = process.env.COPILOT_API_KEY ?? 'copilot';

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -858,6 +858,8 @@ export class OpenAICompatibleProvider implements LLMProvider {
       ],
       max_tokens: request.maxTokens ?? this.maxOutputTokens,
       temperature: request.temperature ?? 0.3,
+      stream: true,
+      stream_options: { include_usage: true },
       ...(request.stopSequences && { stop: request.stopSequences }),
     };
 
@@ -896,22 +898,49 @@ export class OpenAICompatibleProvider implements LLMProvider {
       throw err;
     }
 
-    const data = await response.json() as {
-      choices: Array<{ message: { content: string }; finish_reason: string }>;
-      usage: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
-      model: string;
-    };
+    let content = '';
+    let usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    let finishReason: 'stop' | 'length' | 'error' = 'stop';
+    let model = this.model;
 
-    return {
-      content: data.choices[0]?.message?.content ?? '',
-      usage: {
-        inputTokens: data.usage.prompt_tokens,
-        outputTokens: data.usage.completion_tokens,
-        totalTokens: data.usage.total_tokens,
-      },
-      model: data.model ?? this.model,
-      finishReason: data.choices[0]?.finish_reason === 'stop' ? 'stop' : data.choices[0]?.finish_reason === 'length' ? 'length' : 'error',
-    };
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    outer: while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6).trim();
+        if (data === '[DONE]') break outer;
+        try {
+          const chunk = JSON.parse(data) as {
+            choices?: Array<{ delta?: { content?: string }; finish_reason?: string }>;
+            usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+            model?: string;
+          };
+          const delta = chunk.choices?.[0]?.delta?.content;
+          if (delta) content += delta;
+          const fr = chunk.choices?.[0]?.finish_reason;
+          if (fr) finishReason = fr === 'length' ? 'length' : 'stop';
+          if (chunk.model) model = chunk.model;
+          if (chunk.usage) {
+            usage = {
+              inputTokens: chunk.usage.prompt_tokens,
+              outputTokens: chunk.usage.completion_tokens,
+              totalTokens: chunk.usage.total_tokens,
+            };
+          }
+        } catch { /* ignore malformed SSE chunks */ }
+      }
+    }
+
+    return { content, usage, model, finishReason };
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,8 @@ export interface GenerationConfig {
   model?: string;
   openaiCompatBaseUrl?: string;
   skipSslVerify?: boolean;
+  /** Disable response_format field in requests (for endpoints that don't support structured output) */
+  disableResponseFormat?: boolean;
   /** LLM request timeout in milliseconds. Default: 120000 (2 minutes) */
   timeout?: number;
   domains: string | string[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,8 @@ export interface GenerationConfig {
   disableResponseFormat?: boolean;
   /** LLM request timeout in milliseconds. Default: 120000 (2 minutes) */
   timeout?: number;
+  /** Max characters per file chunk sent to the LLM. Default: 8000. Increase for large-context models. */
+  chunkMaxChars?: number;
   domains: string | string[];
 }
 

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -186,6 +186,8 @@ export interface PipelineOptions {
    *  schema/service/API file selection in stages 2–4. Falls back to heuristics if absent
    *  or if the search returns no results for a given domain. */
   semanticSearch?: SemanticSearchFn;
+  /** Max characters per file chunk sent to the LLM. Default: 8000. Increase for large-context models. */
+  chunkMaxChars?: number;
 }
 
 // ============================================================================
@@ -194,7 +196,7 @@ export interface PipelineOptions {
 
 export interface PipelineContext {
   llm: LLMService;
-  options: { saveIntermediate: boolean };
+  options: { saveIntermediate: boolean; chunkMaxChars: number };
   saveResult(name: string, data: unknown): Promise<void>;
   chunkContent(content: string, maxChars: number): string[];
   graphPromptFor(filePath: string, content?: string): string | null;


### PR DESCRIPTION
## Problems

Three related issues affecting users running spec-gen against OpenAI-compatible proxies (vLLM, custom gateways):

1. **`response_format` rejected** — some endpoints return `{"detail":"There was an error parsing the body"}` when the request includes `response_format`. They support the chat completions API but not structured output extensions.

2. **vLLM 504 timeouts** — vLLM and similar proxies time out on large requests when using non-streaming mode. The synchronous `/chat/completions` call waits for the full response before returning, hitting gateway timeouts on long generations.

3. **`doctor` checks env vars instead of connecting** — `spec-gen doctor` reported "ok" as long as an API key env var was set, even if the endpoint was misconfigured or unreachable. No way to diagnose proxy issues from the CLI.

**Bonus**: chunk size was hardcoded, making it impossible to tune for models with smaller context windows.

## Fixes

### 1. `disableResponseFormat` option
Add `disableResponseFormat: boolean` to `LLMServiceOptions`, `GenerationConfig`, and `OpenAICompatibleProvider`. When `true`, `response_format` is omitted from requests. The LLM still produces JSON via system prompt instructions; `completeJSON()` handles free-form JSON as it already does for models without schema support.

Also improves error messages: all provider errors now include the HTTP status code (`HTTP 422: ...`) instead of just the raw body.

### 2. SSE streaming for `openai-compat` provider
Switch `OpenAICompatibleProvider` from a single blocking request to SSE streaming (`stream: true`). Streams are reassembled into the same `LLMResponse` shape. This avoids gateway timeouts on long generations without changing the caller interface.

### 3. `chunkMaxChars` config option
Add `generation.chunkMaxChars` to `GenerationConfig` and `PipelineOptions`. Wired through `generate.ts` → `spec-pipeline.ts` → stages 2/3/4. Allows tuning chunk size for smaller-context models (default unchanged).

### 4. Live `doctor` connection checks
Replace static env-var detection with real round-trip probes:
- **LLM connection**: creates `LLMService` and sends a `ping` with 10 s timeout; reports provider, model, and latency on success
- **Embedding connection**: POSTs to `/embeddings` endpoint (skipped if not configured); reports dims and latency
- Supports CLI-based providers (`claude-code`, `gemini-cli`, `cursor-agent`) via binary detection
- Renames check from `LLM provider` to `LLM connection`

## Config

```yaml
generation:
  provider: openai-compat
  openaiCompatBaseUrl: https://your-proxy/v1
  disableResponseFormat: true   # omit response_format for strict proxies
  chunkMaxChars: 6000            # tune for smaller context windows
  model: your-model
```

## Tests

- `disableResponseFormat=true` → `response_format` absent from request body
- `disableResponseFormat=false` → `response_format` present (default unchanged)
- SSE streaming: `OpenAICompatibleProvider` mocked with SSE response
- `doctor`: `createLLMService` mocked; tests cover success, `createLLMService` throw, and `complete()` rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)