### PR TITLE
fix(llm): normalize OpenAI structured output schemas

### DIFF
--- a/openspec/specs/llm/spec.md
+++ b/openspec/specs/llm/spec.md
@@ -345,6 +345,42 @@ The system SHALL include `cursor-agent` in provider pricing lookup with zero per
 - **WHEN** `lookupPricing` is called for provider `cursor-agent` and any model identifier
 - **THEN** returned input and output per-million token rates are zero
 
+### Requirement: OpenAI structured output schema normalization
+
+The system SHALL normalize JSON schemas sent through OpenAI and OpenAI-compatible `response_format.json_schema.schema` so that every object schema is closed, every object property is required, and properties that were optional in the caller schema remain nullable in the provider schema.
+
+#### Scenario: OpenAI object schemas are closed
+- **WHEN** `OpenAIProvider` sends a JSON schema with an object schema through `response_format.json_schema.schema`
+- **THEN** the provider schema object has `additionalProperties: false`
+
+#### Scenario: OpenAI object required includes all properties
+- **WHEN** `OpenAIProvider` sends a JSON schema with object `properties`
+- **THEN** the provider schema object's `required` array contains every property key
+
+#### Scenario: Optional OpenAI properties become nullable
+- **WHEN** `OpenAIProvider` sends a JSON schema where an object property is absent from the caller schema's original `required` array
+- **THEN** the corresponding provider schema property allows `null`
+
+#### Scenario: Nested OpenAI object schemas are normalized
+- **WHEN** `OpenAIProvider` sends a JSON schema containing nested object schemas
+- **THEN** each nested object schema has `additionalProperties: false` and a `required` array containing every nested property key
+
+#### Scenario: Top-level OpenAI array schemas are wrapped as closed objects
+- **WHEN** `OpenAIProvider` sends a top-level array JSON schema through `response_format.json_schema.schema`
+- **THEN** the provider schema root is an object with an `items` property, `required` contains `items`, and the root has `additionalProperties: false`
+
+#### Scenario: Caller schemas are not mutated
+- **WHEN** OpenAI schema normalization prepares a provider schema
+- **THEN** the caller-provided JSON schema remains unchanged
+
+#### Scenario: OpenAI-compatible schemas use the same normalization
+- **WHEN** `OpenAICompatibleProvider` sends a JSON schema through `response_format.json_schema.schema`
+- **THEN** the provider schema follows the same object closure, required-property, nullable optional-property, and top-level array wrapper rules as `OpenAIProvider`
+
+#### Scenario: Disabled OpenAI-compatible response format remains omitted
+- **WHEN** `OpenAICompatibleProvider` is configured with `disableResponseFormat=true`
+- **THEN** the request body does not include `response_format`
+
 ## Technical Notes
 
 - **Implementation**: `src/core/services/llm-service.ts`

--- a/src/core/services/llm-service.test.ts
+++ b/src/core/services/llm-service.test.ts
@@ -890,11 +890,107 @@ describe('OpenAIProvider', () => {
     const fetchMock = vi.fn().mockResolvedValue(mockResponse(SUCCESS_BODY));
     vi.stubGlobal('fetch', fetchMock);
     const provider = new OpenAIProvider('key');
-    const schema = { type: 'object', properties: { name: { type: 'string' } } };
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        nickname: { type: 'string' },
+        meta: {
+          type: 'object',
+          properties: {
+            count: { type: 'number' },
+            note: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+          },
+          required: ['count'],
+        },
+        nullableMeta: {
+          type: ['object', 'null'],
+          properties: {
+            enabled: { type: 'boolean' },
+            label: { type: 'string' },
+          },
+          required: ['enabled'],
+        },
+        flexible: { enum: ['a', 'b'] },
+      },
+      required: ['name', 'meta'],
+    };
+    const originalSchema = JSON.parse(JSON.stringify(schema));
     await provider.generateCompletion({ systemPrompt: '', userPrompt: 'hi', responseFormat: 'json', jsonSchema: schema });
     const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    const normalizedSchema = body.response_format.json_schema.schema;
+
     expect(body.response_format.type).toBe('json_schema');
-    expect(body.response_format.json_schema.schema).toEqual(schema);
+    expect(normalizedSchema).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        nickname: { type: ['string', 'null'] },
+        meta: {
+          type: 'object',
+          properties: {
+            count: { type: 'number' },
+            note: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+          },
+          required: ['count', 'note'],
+          additionalProperties: false,
+        },
+        nullableMeta: {
+          type: ['object', 'null'],
+          properties: {
+            enabled: { type: 'boolean' },
+            label: { type: ['string', 'null'] },
+          },
+          required: ['enabled', 'label'],
+          additionalProperties: false,
+        },
+        flexible: { anyOf: [{ enum: ['a', 'b'] }, { type: 'null' }] },
+      },
+      required: ['name', 'nickname', 'meta', 'nullableMeta', 'flexible'],
+      additionalProperties: false,
+    });
+    expect(schema).toEqual(originalSchema);
+  });
+
+  it('wraps top-level array schemas as closed OpenAI response objects', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(SUCCESS_BODY));
+    vi.stubGlobal('fetch', fetchMock);
+    const provider = new OpenAIProvider('key');
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          score: { type: 'number' },
+        },
+        required: ['name'],
+      },
+    };
+
+    await provider.generateCompletion({ systemPrompt: '', userPrompt: 'hi', responseFormat: 'json', jsonSchema: schema });
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    const normalizedSchema = body.response_format.json_schema.schema;
+
+    expect(normalizedSchema).toEqual({
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              score: { type: ['number', 'null'] },
+            },
+            required: ['name', 'score'],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ['items'],
+      additionalProperties: false,
+    });
   });
 
   it('sends json_object response_format when responseFormat=json without schema', async () => {
@@ -942,10 +1038,27 @@ describe('OpenAICompatibleProvider', () => {
     const fetchMock = vi.fn().mockResolvedValue(mockResponse(SUCCESS_BODY));
     vi.stubGlobal('fetch', fetchMock);
     const provider = new OpenAICompatibleProvider('key', 'https://api.mistral.ai/v1');
-    const schema = { type: 'array' };
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        score: { type: 'number' },
+      },
+      required: ['name'],
+    };
     await provider.generateCompletion({ systemPrompt: '', userPrompt: 'hi', responseFormat: 'json', jsonSchema: schema });
     const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+
     expect(body.response_format.type).toBe('json_schema');
+    expect(body.response_format.json_schema.schema).toEqual({
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        score: { type: ['number', 'null'] },
+      },
+      required: ['name', 'score'],
+      additionalProperties: false,
+    });
   });
 
   it('omits response_format when disableResponseFormat=true', async () => {

--- a/src/core/services/llm-service.ts
+++ b/src/core/services/llm-service.ts
@@ -645,6 +645,86 @@ function wrapArraySchema(schema: object): object {
   return schema;
 }
 
+function isSchemaRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function schemaAllowsNull(schema: unknown): boolean {
+  if (!isSchemaRecord(schema)) return false;
+
+  const type = schema.type;
+  if (type === 'null') return true;
+  if (Array.isArray(type) && type.includes('null')) return true;
+
+  for (const key of ['anyOf', 'oneOf']) {
+    const schemas = schema[key];
+    if (Array.isArray(schemas) && schemas.some(schemaAllowsNull)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function makeSchemaNullable(schema: unknown): unknown {
+  if (schemaAllowsNull(schema)) return schema;
+
+  if (isSchemaRecord(schema)) {
+    const type = schema.type;
+    if (typeof type === 'string') {
+      schema.type = [type, 'null'];
+      return schema;
+    }
+  }
+
+  return { anyOf: [schema, { type: 'null' }] };
+}
+
+function normalizeOpenAISchemaNode(node: unknown): void {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      normalizeOpenAISchemaNode(item);
+    }
+    return;
+  }
+
+  if (!isSchemaRecord(node)) return;
+
+  const isObjectSchema = node.type === 'object' || (Array.isArray(node.type) && node.type.includes('object'));
+
+  if (isObjectSchema) {
+    const properties = isSchemaRecord(node.properties) ? node.properties : {};
+    const originalRequired = new Set(
+      Array.isArray(node.required)
+        ? node.required.filter((field): field is string => typeof field === 'string')
+        : [],
+    );
+
+    node.properties = properties;
+    node.additionalProperties = false;
+    node.required = Object.keys(properties);
+
+    for (const [key, propertySchema] of Object.entries(properties)) {
+      normalizeOpenAISchemaNode(propertySchema);
+      if (!originalRequired.has(key)) {
+        properties[key] = makeSchemaNullable(properties[key]);
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (isObjectSchema && key === 'properties') continue;
+    normalizeOpenAISchemaNode(value);
+  }
+}
+
+function normalizeOpenAIResponseSchema(schema: object): object {
+  const clonedSchema = JSON.parse(JSON.stringify(schema)) as object;
+  const wrappedSchema = wrapArraySchema(clonedSchema);
+  normalizeOpenAISchemaNode(wrappedSchema);
+  return wrappedSchema;
+}
+
 /**
  * OpenAI provider
  */
@@ -690,7 +770,7 @@ export class OpenAIProvider implements LLMProvider {
         type: 'json_schema',
         json_schema: {
           name: 'response',
-          schema: wrapArraySchema(request.jsonSchema),
+          schema: normalizeOpenAIResponseSchema(request.jsonSchema),
         },
       };
     } else if (request.responseFormat === 'json') {
@@ -869,7 +949,7 @@ export class OpenAICompatibleProvider implements LLMProvider {
           type: 'json_schema',
           json_schema: {
             name: 'response',
-            schema: wrapArraySchema(request.jsonSchema),
+            schema: normalizeOpenAIResponseSchema(request.jsonSchema),
           },
         };
       } else if (request.responseFormat === 'json') {


### PR DESCRIPTION
## Summary

- Normalize OpenAI/OpenAI-compatible `response_format.json_schema.schema` payloads before sending structured output requests.
- Close every object schema, require all object properties, and preserve optional semantics by allowing `null`.
- Keep `CopilotProvider` on the existing array-wrapper behavior.
- Add LLM spec coverage for the OpenAI structured output normalization contract.

## Problem

`spec-gen generate` could fail during the OpenAI generation flow when stage schemas were sent as structured outputs. In Stage 2, OpenAI returned HTTP 400 errors like:

```text
Invalid schema for response_format 'response': In context=(), 'additionalProperties' is required to be supplied and to be false.
```

## Implementation

This adds provider-local schema normalization for OpenAI structured outputs:

- Top-level array schemas are still wrapped as an object with an `items` property.
- Every object schema is recursively given `additionalProperties: false`.
- Every object schema gets `required` set to all keys under `properties`.
- Properties that were optional in the caller-provided schema are made nullable in the provider schema.
- The caller-provided schema is deep-cloned before normalization so prompts, validation, and non-OpenAI paths still use the original schema.
- `OpenAIProvider` and `OpenAICompatibleProvider` use the normalized schema.
- `CopilotProvider` is unchanged.

## Tests

- `npm run test:run -- src/core/services/llm-service.test.ts`
- `npm run typecheck`
- `openspec validate llm`
- `git diff --check`
- Manually verified built `spec-gen generate` with the OpenAI provider now completes successfully.

## Notes

Follow-up to #52: that change handled OpenAI's top-level array root restriction; this PR handles the remaining OpenAI Structured Outputs schema requirements for object schemas.

`openspec validate --all` still reports an unrelated existing `spec/analyzer` failure; `spec/llm` validates successfully.