### PR TITLE
feat(call-graph): risk scoring, McCabe CC, OVERRIDES edges, external packages, agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,8 +1227,9 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 | `search_code` | Natural-language semantic search over indexed functions. Returns the closest matches by meaning with similarity score, call-graph neighbourhood enrichment, and spec-linked peer functions. Falls back to BM25 keyword search when no embedding server is configured. | Yes (+ embedding) |
 | `suggest_insertion_points` | Semantic search over the vector index to find the best existing functions to extend or hook into when implementing a new feature. Returns ranked candidates with role and strategy. Falls back to BM25 keyword search when no embedding server is configured. | Yes (+ embedding) |
 | `get_subgraph` | Depth-limited subgraph centred on a function. Direction: `downstream` (what it calls), `upstream` (who calls it), or `both`. Output as JSON or Mermaid diagram. External leaf nodes (e.g. `fetch`, `psycopg2.execute`) appear as `[external]` with an `externalKind` field (`http`, `database`, `filesystem`, `stdlib`, `unknown`). Stdlib noise (`Array.isArray`, `os.path.join`, `std::string`) is filtered out automatically; only semantically meaningful externals are shown. | Yes |
-| `get_minimal_context` | Return the minimum context needed to safely modify a function: its body, direct callers (signatures only), direct callees (signatures only), and which test files cover it via `tested_by` edges. Use this instead of `orient` when you already know exactly which function to modify — typically 200–600 tokens vs `orient`'s 2 000+. | Yes |
-| `get_cluster` | Return all functions in the same community (label-propagation cluster) as the given function. Tightly coupled functions land in the same cluster regardless of directory. Use this to understand the blast-radius neighbourhood without manual graph traversal. | Yes |
+| `get_minimal_context` | Return the minimum context needed to safely modify a function: body, direct callers and callees with `callType` (`direct|method|awaited|constructor|callback`) and `isExternal`, test files via `tested_by` edges with `confidence` (`called|imported`), and a `riskLevel` (`high|medium|low`). Use this instead of `orient` when you already know exactly which function to modify — typically 200–600 tokens vs `orient`'s 2 000+. | Yes |
+| `get_cluster` | Return all functions in the same community (label-propagation cluster) as the given function. Includes `clusterDensity = uniqueInternalEdges / (m×(m−1))` — decision guide: `< 0.05` change is isolated, `0.05–0.15` check `internalCallGraph`, `> 0.15` coordinate whole cluster. | Yes |
+| `search_unified` | Search both code functions and spec requirements in one call, then cross-boost results linked through `mapping.json` — a function that implements a matching requirement ranks higher than one found by code search alone. Returns results typed as `"code"`, `"spec"`, or `"both"` with a `mappingBoost` score. Use when you want to know where something is implemented AND what the spec says about it simultaneously. | Yes (+ embedding + generate) |
 | `trace_execution_path` | Find all call-graph paths between two functions (DFS, configurable depth/max-paths). Use this when debugging: "how does request X reach function Y?" Returns shortest path, all paths sorted by hops, and a step-by-step chain per path. | Yes |
 | `get_function_body` | Return the exact source code of a named function in a file. | No |
 | `get_function_skeleton` | Noise-stripped view of a source file: logs, inline comments, and non-JSDoc block comments removed. Signatures, control flow, return/throw, and call expressions preserved. Returns reduction %. | No |
@@ -1274,6 +1275,13 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 | `search_specs` | Semantic search over OpenSpec specifications to find requirements, design notes, and architecture decisions by meaning. Returns linked source files for graph highlighting. Use this when asked "which spec covers X?" or "where should we implement Z?". Requires a spec index built with `spec-gen analyze` or `--reindex-specs`. | Yes (generate) |
 | `list_spec_domains` | List all OpenSpec domains available in this project. Use this to discover what domains exist before doing a targeted `search_specs` call. | Yes (generate) |
 | `audit_spec_coverage` | Parity audit: uncovered functions (in call graph, no spec), hub gaps (high fan-in + no spec), orphan requirements (spec with no implementation found), and stale domains (source changed after spec). Run before starting a feature to understand coverage health. No LLM required. | Yes (analyze) |
+
+**Tests**
+
+| Tool | Description | Requires prior analysis |
+|------|-------------|:---:|
+| `generate_tests` | Generate spec-driven test skeletons from OpenSpec `#### Scenario:` blocks. A THEN-clause pattern engine emits real assertions for common patterns (HTTP status codes, property presence, error messages) without LLM. Pass `useLlm:true` to enrich unmatched clauses from mapped function source. Supports Vitest, Playwright, pytest, Google Test, Catch2 (auto-detected). Defaults to `dryRun:true`. | Yes (generate) |
+| `get_test_coverage` | Report which OpenSpec scenarios have test coverage. Scans test files for `// spec-gen:` metadata tags emitted by `generate_tests`. Returns coverage % by domain, uncovered scenarios, and drift flags. Pass `minCoverage` to enforce a CI gate. | Yes (generate) |
 
 **Decisions**
 
@@ -1414,6 +1422,32 @@ base       string   Git ref to diff against (default: HEAD). Use "HEAD~1" for la
 **`get_external_packages`**
 ```
 directory  string   Absolute path to the project directory
+```
+
+**`search_unified`**
+```
+directory  string   Absolute path to the project directory
+query      string   Natural language query, e.g. "validate user authentication"
+limit      number   Maximum number of results (default: 10)
+language   string   Filter code results by language (e.g. "TypeScript")
+domain     string   Filter spec results by domain name
+section    string   Filter spec results by section type: "requirements" | "purpose" | etc.
+```
+
+**`generate_tests`**
+```
+directory   string    Absolute path to the project directory
+domains     string[]  Only generate tests for these spec domains (omit for all)
+framework   string    "vitest" | "playwright" | "pytest" | "gtest" | "catch2" | "auto" (default: auto)
+useLlm      boolean   Use LLM to fill assertions the pattern engine cannot match
+dryRun      boolean   Preview without writing files (default: true)
+```
+
+**`get_test_coverage`**
+```
+directory    string    Absolute path to the project directory
+domains      string[]  Only check these spec domains (omit for all)
+minCoverage  number    Report belowThreshold:true if coverage drops below this percentage
 ```
 
 **`get_function_skeleton`**

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Scans your codebase using pure static analysis:
 - Builds a full call graph with **`tested_by` edges** derived from import analysis: each test file's imports map to the production functions it covers, making coverage queries accurate even for mock-heavy suites where call edges don't reach the unit under test
 - Runs **label-propagation community detection** on the call graph to group tightly coupled functions into clusters regardless of directory — powering `get_cluster` and the community colours in the graph viewer
 - Clusters related files into structural business domains automatically
-- Extracts DB schema tables (Prisma, TypeORM, Drizzle, SQLAlchemy), HTTP routes (Express, NestJS, Next.js, FastAPI, Flask), UI components (React, Vue, Svelte, Angular), middleware chains, and environment variables — saved as structured JSON artifacts in `.spec-gen/analysis/`
+- Extracts DB schema tables (Prisma, TypeORM, Drizzle, SQLAlchemy), HTTP routes (Express, NestJS, Next.js, FastAPI, Flask), UI components (React, Vue, Svelte, Angular), middleware chains, environment variables, and direct package dependencies (npm, pypi, cargo, go) — saved as structured JSON artifacts in `.spec-gen/analysis/`
+- Computes **McCabe cyclomatic complexity** for every function (CC = 1 + branching keywords); functions with CC ≥ 10 are flagged as `high_complexity` in `get_refactor_report`
 - Generates AI tool config files (`CLAUDE.md`, `.cursorrules`, `.clinerules/`, `.vibe/skills/`, etc.) with `--ai-configs`
 - Produces structured context that makes LLM generation more accurate
 
@@ -1243,18 +1244,19 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 | `get_ui_components` | Detected UI components with framework, props, and source file. Supports React, Vue, Svelte, and Angular. | Yes |
 | `get_env_vars` | Env vars referenced in source code with `required` (no fallback) and `hasDefault` flags. Supports JS/TS, Python, Go, and Ruby. | Yes |
 | `get_middleware_inventory` | Detected middleware with type (auth/cors/rate-limit/validation/logging/error-handler) and framework. | Yes |
+| `get_external_packages` | Direct dependencies parsed from package manifests (npm, pypi, cargo, go). Returns name, version, ecosystem, and `isDev` flag per package. Uses cached artifact when available; falls back to live extraction. | No |
 
 **Change analysis**
 
 | Tool | Description | Requires prior analysis |
 |------|-------------|:---:|
-| `detect_changes` | Detect recently changed functions and rank them by blast radius. Runs `git diff` against a base ref, maps changed lines to call-graph nodes, scores each function by `fanIn + transitive callers` (highest = riskiest to break), and reports test coverage per changed function via `tested_by` edges. First tool to run on any code-review or pre-merge check. | Yes |
+| `detect_changes` | Detect recently changed functions and rank them by risk. Runs `git diff` against a base ref, maps changed lines to call-graph nodes, and scores each function with a multiplicative model: `riskScore = likelihood × impact`. Likelihood combines a semantic change-type modifier (`signature` ×1.5 / `logic` ×1.0 / `config` ×0.4) with a coverage penalty. Impact combines log fan-in, distance-weighted transitive callers (by `callType`), and boundary score (HTTP/DB callees). Each result includes `changeType`, `reason` (human-readable justification), and `testedBy` with confidence. First tool to run on any code-review or pre-merge check. | Yes |
 
 **Code quality**
 
 | Tool | Description | Requires prior analysis |
 |------|-------------|:---:|
-| `get_refactor_report` | Prioritized list of functions with structural issues: unreachable code, hub overload (high fan-in), god functions (high fan-out), SRP violations, cyclic dependencies. | Yes |
+| `get_refactor_report` | Prioritized list of functions with structural issues: unreachable code, hub overload (high fan-in), god functions (high fan-out), SRP violations, cyclic dependencies, and high cyclomatic complexity (McCabe CC ≥ 10). `cyclomaticComplexity` is returned per function; `stats.highComplexity` gives the project-wide count. | Yes |
 | `get_critical_hubs` | Highest-impact hub functions ranked by criticality. Each hub gets a stability score (0-100) and a recommended approach: extract, split, facade, or delegate. | Yes |
 | `get_god_functions` | Detect god functions (high fan-out, likely orchestrators) in the project or in a specific file, and return their call-graph neighborhood. Use this to identify which functions need to be refactored and understand what logical blocks to extract. | Yes |
 | `analyze_impact` | Deep impact analysis for a specific function: fan-in/fan-out, upstream call chain, downstream critical path, risk score (0-100), blast radius, and recommended strategy. | Yes |
@@ -1407,6 +1409,11 @@ functionName  string   Function name to look up the community for
 ```
 directory  string   Absolute path to the project directory
 base       string   Git ref to diff against (default: HEAD). Use "HEAD~1" for last commit, "main" for branch diff.
+```
+
+**`get_external_packages`**
+```
+directory  string   Absolute path to the project directory
 ```
 
 **`get_function_skeleton`**
@@ -1750,6 +1757,7 @@ Static analysis output is stored in `.spec-gen/analysis/`:
 | `spec-snapshot.json` | Compact coverage summary: git state, per-domain coverage %, uncovered hub functions (auto-updated after `analyze` and `generate`) |
 | `audit-report.json` | Latest parity audit report (produced by `spec-gen audit`) |
 | `fingerprint.json` | Content-hash fingerprint (SHA-256 of all source file mtimes+sizes) used for cache invalidation |
+| `external-packages.json` | Direct dependencies parsed from package manifests (produced by `analyze_codebase`) |
 | `vector-index/` | LanceDB semantic index (produced by `--embed`) |
 
 `spec-gen analyze` also writes **`ARCHITECTURE.md`** to your project root -- a Markdown overview of module clusters, entry points, and critical hubs, refreshed on every run.

--- a/examples/mistral-vibe/skills/spec-gen-implement-story/SKILL.md
+++ b/examples/mistral-vibe/skills/spec-gen-implement-story/SKILL.md
@@ -70,6 +70,26 @@ For the top 2 functions returned, get minimal context first (callers, callees, b
 </use_mcp_tool>
 ```
 
+**What to read before proceeding:**
+- `function.riskLevel` — `"high"` = fanIn ≥ 30 or fanOut ≥ 15; tool expanded lists to 24 entries — all are blast-radius members.
+- `callers[*].callType` — all `"awaited"` = async interface frozen; signature change breaks every caller silently in JS. Mixed = looser coupling.
+- `callees[*].isExternal: true` — external boundary; new paths may pass mocked tests but fail in production.
+- `testedBy[*].confidence` — `"called"` = direct test (strong). `"imported"` only = `vi.mock()` can neutralize; treat as untested.
+
+If `riskLevel` is `"high"` or any callee is external, also check the cluster:
+
+```xml
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_cluster</tool_name>
+  <arguments>{"directory": "$PROJECT_ROOT", "functionName": "$FUNCTION_NAME"}</arguments>
+</use_mcp_tool>
+```
+
+- `clusterDensity < 0.05` → isolated, proceed
+- `clusterDensity 0.05–0.15` → check `internalCallGraph` for transitively dependent functions
+- `clusterDensity > 0.15` → dense cluster; coordinate scope with user first
+
 Then check risk:
 
 ```xml

--- a/examples/mistral-vibe/skills/spec-gen-plan-refactor/SKILL.md
+++ b/examples/mistral-vibe/skills/spec-gen-plan-refactor/SKILL.md
@@ -136,7 +136,7 @@ If **all candidates are below 40%**:
 
 ## Step 4 — Get minimal context + analyze impact
 
-First, get condensed view (callers, callees, body, test coverage) in one call:
+Get the condensed view (callers, callees, body, test coverage) in one call:
 
 ```xml
 <use_mcp_tool>
@@ -145,6 +145,11 @@ First, get condensed view (callers, callees, body, test coverage) in one call:
   <arguments>{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}</arguments>
 </use_mcp_tool>
 ```
+
+**What to read before deciding whether to proceed:**
+- `function.riskLevel` — `"high"` = up to 24 callers/callees shown; read all, they are all in scope.
+- `callers[*].callType` — all `"awaited"` = async interface frozen; extracting or splitting requires updating every call site.
+- `testedBy[*].confidence` — `"imported"` only = `vi.mock()` can neutralize; write a characterisation test before refactoring.
 
 Then get full impact analysis:
 
@@ -157,6 +162,20 @@ Then get full impact analysis:
 ```
 
 Note: risk score (0–100), recommended strategy (`extract` / `split` / `facade` / `delegate`), top 5 upstream callers and downstream callees.
+
+**If `riskLevel` is `"high"` or impact risk score ≥ 60**, check cluster scope:
+
+```xml
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_cluster</tool_name>
+  <arguments>{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}</arguments>
+</use_mcp_tool>
+```
+
+- `clusterDensity < 0.05` → extract target independently
+- `clusterDensity 0.05–0.15` → include `internalCallGraph` callers in risk section
+- `clusterDensity > 0.15` → refactor whole cluster together or not at all
 
 ---
 

--- a/examples/mistral-vibe/skills/spec-gen-review-changes/SKILL.md
+++ b/examples/mistral-vibe/skills/spec-gen-review-changes/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: spec-gen-review-changes
+description: Risk-aware code review using detect_changes + get_minimal_context + get_cluster. Surfaces the riskiest changed functions, interprets callType/coverage/cluster density, and produces a go/no-go recommendation. No code written.
+license: MIT
+compatibility: spec-gen MCP server
+user-invocable: true
+allowed-tools:
+  - use_mcp_tool
+  - ask_followup_question
+---
+
+# spec-gen: Review Changes
+
+## When to use this skill
+
+Trigger whenever the user asks to **review, audit, or check the safety of recent changes**:
+- "review my changes"
+- "what did I break?"
+- "is this branch safe to merge?"
+- "pre-PR check" / "what's risky in this diff?"
+- explicit command `/spec-gen-review-changes`
+
+**No code is written.** Output is a risk-ranked review with a go/no-go recommendation.
+
+---
+
+## Step 1 — Confirm directory and base ref
+
+Ask: which project? Diff against which base? (default: `main`)
+
+---
+
+## Step 2 — Detect changed functions and risk scores
+
+```xml
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>detect_changes</tool_name>
+  <arguments>{"directory": "$DIRECTORY", "base": "$BASE_REF"}</arguments>
+</use_mcp_tool>
+```
+
+Risk score is **multiplicative**: `likelihood × impact`.
+- `likelihood` = changeScore × (1 + coveragePenalty) — `"called"` tests count full; `"imported"`-only count 0.3×
+- `impact` = log(fanIn) + distance-weighted transitive callers (weighted by callType) + external boundary calls
+
+Functions with fanIn=0 calling nothing external score 0 — correct; focus on non-zero scores.
+
+Present a risk-ranked table:
+
+| Rank | Function | File | riskScore | blastRadius | fanIn | testedBy |
+|---|---|---|---|---|---|---|
+
+Flag: `≥ 5` → 🔴 HIGH | `2–5` → 🟡 MEDIUM | `< 2` → 🟢 LOW
+
+---
+
+## Step 3 — Deep-inspect each HIGH function
+
+```xml
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_minimal_context</tool_name>
+  <arguments>{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}</arguments>
+</use_mcp_tool>
+```
+
+**What to read:**
+- `function.riskLevel` — `"high"` means up to 24 callers/callees shown; all are in blast radius.
+- `callers[*].callType` — all `"awaited"` = async interface frozen; signature change breaks all callers silently. Mixed = looser.
+- `callees[*].isExternal: true` — external boundary; failures propagate past mocks.
+- `testedBy[*].confidence` — `"called"` = strong. `"imported"` only = `vi.mock()` can neutralize; treat as untested.
+
+State for each HIGH function:
+```
+$FUNCTION_NAME: interface frozen? | external boundary? | effective coverage | verdict
+```
+
+---
+
+## Step 4 — Check cluster density for non-safe HIGH functions
+
+```xml
+<use_mcp_tool>
+  <server_name>spec-gen</server_name>
+  <tool_name>get_cluster</tool_name>
+  <arguments>{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}</arguments>
+</use_mcp_tool>
+```
+
+`stats.clusterDensity`:
+- `< 0.05` → sparse; change isolated; safe to land independently
+- `0.05–0.15` → moderate; review `internalCallGraph` for transitively dependent functions
+- `> 0.15` → dense; coordinate whole cluster; consider feature flag or staged rollout
+
+---
+
+## Step 5 — Coverage gap check
+
+For each HIGH/MEDIUM function with `testedBy` empty or all `"imported"`:
+> "⚠️ `$FUNCTION_NAME` has no direct test coverage. Recommend a characterisation test before merging."
+
+Suggest a concrete test scenario from the function body.
+
+---
+
+## Step 6 — Output
+
+### Summary
+Total changed: N | HIGH: N | MEDIUM: N | Coverage gaps: N
+
+### Risk table (from Step 2)
+
+### Function verdicts (HIGH only)
+
+### Go / No-Go
+- ✅ **Safe to merge** — no HIGH-risk uncovered functions
+- ⚠️ **Merge with caution** — HIGH functions exist but covered by direct tests
+- 🛑 **Do not merge** — HIGH uncovered functions with frozen interfaces or external boundaries
+
+---
+
+## Absolute constraints
+
+- Never skip Step 3 for HIGH functions — riskScore alone is not enough
+- `callType` determines whether interface change is breaking — always interpret it
+- `"imported"` confidence is not strong coverage — always flag it
+- Do not recommend merging: riskScore ≥ 5 + zero direct tests + external callee

--- a/examples/opencode-skills/spec-gen-implement-story/SKILL.md
+++ b/examples/opencode-skills/spec-gen-implement-story/SKILL.md
@@ -56,6 +56,24 @@ For the top 2 functions returned, get minimal context first (callers, callees, b
 }
 ```
 
+**What to read from the result before proceeding:**
+- `function.riskLevel` — `"high"` means fanIn ≥ 30 or fanOut ≥ 15; the tool expanded caller/callee lists to 24. All shown entries are in scope.
+- `callers[*].callType` — all `"awaited"` = async interface frozen; changing signature or return type breaks every caller. Mixed = looser coupling.
+- `callees[*].isExternal: true` — function touches HTTP/DB boundary; new code paths may fail silently in tests (mocked) but loudly in production.
+- `testedBy[*].confidence` — `"called"` = direct test (strong). `"imported"` = test imports module only; `vi.mock()` can nullify it. Only `"imported"` entries = treat as effectively untested.
+
+If `riskLevel` is `"high"` or any callee is external, check the cluster:
+```json
+// get_cluster
+{
+  "directory": "$PROJECT_ROOT",
+  "functionName": "$FUNCTION_NAME"
+}
+```
+- `clusterDensity < 0.05` → sparse, change is isolated, proceed
+- `clusterDensity 0.05–0.15` → check `internalCallGraph` for transitively dependent functions
+- `clusterDensity > 0.15` → dense cluster; coordinate the whole cluster or discuss scope with user
+
 Then check risk:
 ```json
 // analyze_impact

--- a/examples/opencode-skills/spec-gen-plan-refactor/SKILL.md
+++ b/examples/opencode-skills/spec-gen-plan-refactor/SKILL.md
@@ -111,15 +111,29 @@ If **all candidates are below 40%**:
 
 ## Step 4 — Get minimal context + analyze impact
 
-First, get condensed view (callers, callees, body, test coverage) in one call:
+Get the condensed view of the target function (callers, callees, body, test coverage in one call):
 
 Call the spec-gen MCP tool `get_minimal_context` with `{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}`.
+
+**What to read before deciding whether to proceed:**
+- `function.riskLevel` — `"high"` (fanIn ≥ 30 or fanOut ≥ 15) means up to 24 callers/callees shown. Read all — they are all in scope for this refactor.
+- `callers[*].callType` — all `"awaited"` = async interface frozen; extracting or splitting requires updating every call site. `"direct"` / `"method"` = more portable.
+- `testedBy[*].confidence` — `"called"` = direct test, safe to refactor under. `"imported"` only = `vi.mock()` can neutralize it; write a characterisation test **before** refactoring.
 
 Then get the full impact analysis:
 
 Call the spec-gen MCP tool `analyze_impact` with `{"directory": "$DIRECTORY", "symbol": "$FUNCTION_NAME"}`.
 
 Note: risk score (0–100), recommended strategy (`extract` / `split` / `facade` / `delegate`), top 5 upstream callers and downstream callees.
+
+**If `riskLevel` is `"high"` or impact risk score ≥ 60**, check the cluster to set refactor scope:
+
+Call the spec-gen MCP tool `get_cluster` with `{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}`.
+
+Read `stats.clusterDensity`:
+- `< 0.05` — sparse; extract the target independently, others not in scope
+- `0.05–0.15` — moderate; include functions in `internalCallGraph` that call the target in the plan's risk section
+- `> 0.15` — dense; refactor the whole cluster together or not at all; add all members to affected-files list
 
 ---
 

--- a/examples/opencode-skills/spec-gen-review-changes/SKILL.md
+++ b/examples/opencode-skills/spec-gen-review-changes/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: spec-gen-review-changes
+description: Risk-aware code review using detect_changes + get_minimal_context + get_cluster. Surfaces the riskiest changed functions, interprets callType/coverage/cluster density, and produces a go/no-go recommendation. No code written.
+license: MIT
+compatibility: spec-gen MCP server
+---
+
+# spec-gen: Review Changes
+
+## When to use this skill
+
+Trigger this skill whenever the user asks to **review, audit, or check the safety of recent changes**, with phrasings like:
+- "review my changes"
+- "what did I break?"
+- "is this branch safe to merge?"
+- "pre-PR check"
+- "what's risky in this diff?"
+- "check the blast radius of my changes"
+- explicit command `/spec-gen-review-changes`
+
+**No code is written.** Output is a risk-ranked review with a go/no-go recommendation.
+
+---
+
+## Step 1 — Confirm directory and base ref
+
+Ask: which project? Diff against which base? (default: `main`)
+
+Store as `$DIRECTORY` and `$BASE_REF`.
+
+---
+
+## Step 2 — Detect changed functions and risk scores
+
+Call the spec-gen MCP tool `detect_changes` with:
+```json
+{"directory": "$DIRECTORY", "base": "$BASE_REF"}
+```
+
+The risk score is **multiplicative**: `likelihood × impact`.
+- `likelihood` = how much was changed × how poorly covered it is (`"called"` tests count full; `"imported"`-only count 0.3×)
+- `impact` = structural blast radius (log fanIn + distance-weighted transitive callers weighted by callType + external boundary calls)
+
+A function with fanIn=0 calling nothing external scores 0 regardless of change size — correct; focus on non-zero scores.
+
+Present a risk-ranked table:
+
+| Rank | Function | File | riskScore | blastRadius | fanIn | testedBy |
+|---|---|---|---|---|---|---|
+
+Flag:
+- `riskScore ≥ 5` → 🔴 HIGH — must inspect
+- `riskScore 2–5` → 🟡 MEDIUM — inspect if time allows
+- `riskScore < 2` → 🟢 LOW
+
+---
+
+## Step 3 — Deep-inspect each HIGH function
+
+For each function with `riskScore ≥ 5`, call `get_minimal_context`:
+```json
+{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}
+```
+
+**What to read:**
+
+- `function.riskLevel` — `"high"` means the tool expanded caller/callee lists to 24. All shown entries are in the blast radius.
+- `callers[*].callType` — all `"awaited"` = async interface frozen; any signature change breaks every caller without a compile error in JS. Mixed = looser coupling.
+- `callees[*].isExternal: true` — function touches an external boundary (HTTP/DB). Failures here propagate outward and may not be caught in unit tests.
+- `testedBy[*].confidence` — `"called"` = direct test (strong safety net). `"imported"` = test file only imports the module; `vi.mock()` can neutralize it entirely. Only `"imported"` = effectively untested.
+
+For each HIGH function, state:
+```
+$FUNCTION_NAME ($FILE):
+  Interface frozen? [yes — all callers await | no — mixed]
+  External boundary? [yes: $CALLEES | no]
+  Effective coverage: [strong (called) | weak (imported only) | none]
+  Verdict: [safe | needs direct tests first | coordinate with callers before merge]
+```
+
+---
+
+## Step 4 — Check cluster density for non-safe HIGH functions
+
+For any HIGH function whose verdict is not "safe":
+```json
+{"directory": "$DIRECTORY", "functionName": "$FUNCTION_NAME"}
+// get_cluster
+```
+
+Read `stats.clusterDensity`:
+
+| Density | Meaning | Action |
+|---|---|---|
+| < 0.05 | Sparse — shared utilities | Change isolated; safe to land independently |
+| 0.05–0.15 | Moderate coupling | Review `internalCallGraph` for transitively dependent functions |
+| > 0.15 | Dense — tightly interwoven | Coordinate whole cluster; consider feature flag or staged rollout |
+
+---
+
+## Step 5 — Coverage gap check
+
+For each HIGH or MEDIUM function with `testedBy` empty or all `"imported"`:
+
+> "⚠️ `$FUNCTION_NAME` has no direct test coverage. Changes here are not caught by the test suite unless a test directly calls this function. Recommend adding a characterisation test before merging."
+
+Suggest a concrete test scenario based on the function body from `get_minimal_context`.
+
+---
+
+## Step 6 — Output the review
+
+### Summary
+- Total changed: N | HIGH: N | MEDIUM: N | Coverage gaps: N
+
+### Risk table
+(from Step 2)
+
+### Function verdicts (HIGH only)
+(from Steps 3–4)
+
+### Go / No-Go
+- ✅ **Safe to merge** — no HIGH-risk uncovered functions
+- ⚠️ **Merge with caution** — HIGH-risk functions exist but covered by direct tests
+- 🛑 **Do not merge** — HIGH-risk uncovered functions with frozen interfaces or external boundaries
+
+---
+
+## Absolute constraints
+
+- Never skip Step 3 for HIGH-risk functions — riskScore alone is not enough
+- Always interpret `callType` — determines whether interface change is breaking
+- Always interpret `testedBy.confidence` — `"imported"` is not strong coverage
+- Do not recommend merging any function with `riskScore ≥ 5`, zero direct tests, and an external callee

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -71,6 +71,7 @@ import {
   handleGetSchemaInventory,
   handleGetUIComponents,
   handleGetEnvVars,
+  handleGetExternalPackages,
   handleAuditSpecCoverage,
   handleGenerateTests,
   handleGetTestCoverage,
@@ -109,6 +110,7 @@ export {
   handleGetSchemaInventory,
   handleGetUIComponents,
   handleGetEnvVars,
+  handleGetExternalPackages,
   handleAuditSpecCoverage,
   handleGenerateTests,
   handleGetTestCoverage,
@@ -966,6 +968,22 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'get_external_packages',
+    description:
+      'Return all direct external dependencies declared in package manifests: ' +
+      'package.json (npm), pyproject.toml / requirements.txt (pypi), Cargo.toml (cargo), go.mod (go). ' +
+      'Each entry includes name, version, ecosystem, and isDev flag. ' +
+      'Reads the pre-computed external-packages.json artifact when available, ' +
+      'otherwise scans manifests live. Run analyze_codebase first for the fastest results.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directory: { type: 'string', description: 'Absolute path to the project directory' },
+      },
+      required: ['directory'],
+    },
+  },
+  {
     name: 'audit_spec_coverage',
     description:
       'Parity audit: report spec coverage gaps without any LLM call. ' +
@@ -1380,6 +1398,9 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
       } else if (name === 'get_env_vars') {
         const { directory } = args as { directory: string };
         result = await handleGetEnvVars(directory);
+      } else if (name === 'get_external_packages') {
+        const { directory } = args as { directory: string };
+        result = await handleGetExternalPackages(directory);
       } else if (name === 'audit_spec_coverage') {
         const { directory, maxUncovered = 50, hubThreshold = 5 } =
           args as { directory: string; maxUncovered?: number; hubThreshold?: number };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -501,6 +501,12 @@ export const SHALLOW_FUNCTION_DEPTH_MAX = 2;
 /** Score bonus for shallow functions with issues */
 export const SHALLOW_FUNCTION_SCORE_BONUS = 0.5;
 
+/** McCabe cyclomatic complexity threshold above which a function is flagged (≥10 = complex) */
+export const HIGH_COMPLEXITY_THRESHOLD = 10;
+
+/** Priority score boost for high-complexity functions */
+export const HIGH_COMPLEXITY_SCORE_BOOST = 1.5;
+
 // ============================================================================
 // DECISIONS
 // ============================================================================

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,6 +109,9 @@ export const ARTIFACT_UI_INVENTORY = 'ui-inventory.json';
 /** Filename for the environment variable inventory artifact */
 export const ARTIFACT_ENV_INVENTORY = 'env-inventory.json';
 
+/** Filename for the external package inventory artifact */
+export const ARTIFACT_EXTERNAL_PACKAGES = 'external-packages.json';
+
 // ============================================================================
 // LLM / PROVIDER LIMITS
 // ============================================================================

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -507,8 +507,11 @@ export const SHALLOW_FUNCTION_SCORE_BONUS = 0.5;
 /** McCabe cyclomatic complexity threshold above which a function is flagged (≥10 = complex) */
 export const HIGH_COMPLEXITY_THRESHOLD = 10;
 
-/** Priority score boost for high-complexity functions */
+/** Base priority score boost for high-complexity functions (scales with excess above threshold) */
 export const HIGH_COMPLEXITY_SCORE_BOOST = 1.5;
+
+/** Cap on the distance-weighted transitive caller score in detect_changes risk model */
+export const TRANSITIVE_SCORE_MAX = 10;
 
 // ============================================================================
 // DECISIONS

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -85,6 +85,8 @@ export interface FunctionNode {
   communityId?: string;
   /** Human-readable community label (name of the hub function in the community) */
   communityLabel?: string;
+  /** McCabe cyclomatic complexity computed from AST body slice (1 = linear, ≥10 = complex) */
+  cyclomaticComplexity?: number;
 }
 
 /** Broad category of an external (unresolved) call */
@@ -1813,6 +1815,23 @@ function getOrCreateExternalNode(name: string, nodes: Map<string, FunctionNode>)
 }
 
 // ============================================================================
+// CYCLOMATIC COMPLEXITY
+// ============================================================================
+
+const CC_PATTERN_PYTHON = /\bif\s|\belif\s|\bwhile\s|\bfor\s|\bexcept\b|\band\s|\bor\s/g;
+const CC_PATTERN_DEFAULT = /\bif\s*\(|\bwhile\s*\(|\bfor\s*[(]|\bdo\s*[{]|\bcase\s+|\bcatch\s*\(|&&|\|\|/g;
+
+/**
+ * McCabe cyclomatic complexity via regex over function body.
+ * CC = 1 + decision points (if, while, for, case, catch, &&, ||).
+ * Approximate (regex, not AST), suitable for triage/ranking.
+ */
+export function computeCyclomaticComplexity(body: string, language: string): number {
+  const source = language === 'Python' ? CC_PATTERN_PYTHON.source : CC_PATTERN_DEFAULT.source;
+  return 1 + (body.match(new RegExp(source, 'g'))?.length ?? 0);
+}
+
+// ============================================================================
 // CALL GRAPH BUILDER
 // ============================================================================
 
@@ -2217,7 +2236,18 @@ export class CallGraphBuilder {
       }
     }
 
-    // Pass 6: Build class hierarchy (inheritance + grouping)
+    // Pass 6: Cyclomatic complexity — regex over body slice for each internal node
+    for (const node of allNodes.values()) {
+      if (node.isExternal || node.startIndex === undefined || node.endIndex === undefined) continue;
+      const content = fileContents.get(node.filePath);
+      if (!content) continue;
+      node.cyclomaticComplexity = computeCyclomaticComplexity(
+        content.slice(node.startIndex, node.endIndex),
+        node.language,
+      );
+    }
+
+    // Pass 7: Build class hierarchy (inheritance + grouping)
     const relationships = await extractClassRelationships(files);
     const { classes, inheritanceEdges } = buildClassNodes(allNodes, relationships);
 

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -147,7 +147,7 @@ export interface InheritanceEdge {
   parentId: string;
   /** ClassNode id of the child / derived / implementor */
   childId: string;
-  kind: 'extends' | 'implements' | 'embeds';
+  kind: 'extends' | 'implements' | 'embeds' | 'overrides';
 }
 
 export interface CallGraphResult {
@@ -1726,6 +1726,28 @@ function buildClassNodes(
       seenEdges.add(edgeId);
       inheritanceEdges.push({ id: edgeId, parentId: parent.id, childId: cls.id, kind: 'implements' });
     }
+  }
+
+  // OVERRIDES edges: child defines method with same name as parent — language-agnostic
+  const methodNameSet = new Map<string, Set<string>>();
+  for (const [id, cls] of classMap) {
+    const names = new Set<string>();
+    for (const memberId of cls.methodIds) {
+      const fn = allNodes.get(memberId);
+      if (fn && !fn.isExternal) names.add(fn.name);
+    }
+    methodNameSet.set(id, names);
+  }
+  const extendsEdges = inheritanceEdges.filter(e => e.kind === 'extends');
+  for (const edge of extendsEdges) {
+    const childNames = methodNameSet.get(edge.childId);
+    const parentNames = methodNameSet.get(edge.parentId);
+    if (!childNames || !parentNames) continue;
+    if (![...childNames].some(n => parentNames.has(n))) continue;
+    const overrideId = `${edge.parentId}=>${edge.childId}:overrides`;
+    if (seenEdges.has(overrideId)) continue;
+    seenEdges.add(overrideId);
+    inheritanceEdges.push({ id: overrideId, parentId: edge.parentId, childId: edge.childId, kind: 'overrides' });
   }
 
   return { classes: Array.from(classMap.values()), inheritanceEdges };

--- a/src/core/analyzer/external-packages.ts
+++ b/src/core/analyzer/external-packages.ts
@@ -1,0 +1,164 @@
+/**
+ * External package extractor.
+ *
+ * Parses package manifests (npm, pip, cargo, go, cmake) to build a flat list
+ * of direct dependencies. No LLM required — pure filesystem reads.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export type PackageEcosystem = 'npm' | 'pypi' | 'cargo' | 'go' | 'maven' | 'cmake';
+
+export interface ExternalPackage {
+  name: string;
+  version: string;
+  ecosystem: PackageEcosystem;
+  isDev: boolean;
+}
+
+// ============================================================================
+// PARSERS
+// ============================================================================
+
+async function parseNpm(rootDir: string): Promise<ExternalPackage[]> {
+  try {
+    const raw = await readFile(join(rootDir, 'package.json'), 'utf-8');
+    const pkg = JSON.parse(raw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+    const out: ExternalPackage[] = [];
+    for (const [name, version] of Object.entries(pkg.dependencies ?? {})) {
+      out.push({ name, version, ecosystem: 'npm', isDev: false });
+    }
+    for (const [name, version] of Object.entries(pkg.devDependencies ?? {})) {
+      out.push({ name, version, ecosystem: 'npm', isDev: true });
+    }
+    for (const [name, version] of Object.entries(pkg.peerDependencies ?? {})) {
+      if (!out.some(p => p.name === name)) {
+        out.push({ name, version, ecosystem: 'npm', isDev: false });
+      }
+    }
+    return out;
+  } catch { return []; }
+}
+
+async function parsePyproject(rootDir: string): Promise<ExternalPackage[]> {
+  try {
+    const raw = await readFile(join(rootDir, 'pyproject.toml'), 'utf-8');
+    const out: ExternalPackage[] = [];
+    // [project] dependencies = ["requests>=2.0", ...]
+    const depsBlock = raw.match(/^\[project\][\s\S]*?dependencies\s*=\s*\[([^\]]*)\]/m);
+    if (depsBlock) {
+      for (const line of depsBlock[1].split('\n')) {
+        const m = line.match(/["']([a-zA-Z0-9_.-]+)([^"']*)?["']/);
+        if (m) out.push({ name: m[1], version: m[2]?.trim() ?? '*', ecosystem: 'pypi', isDev: false });
+      }
+    }
+    // [project.optional-dependencies] / [tool.poetry.dev-dependencies]
+    const devBlock = raw.match(/\[tool\.poetry\.dev-dependencies\]([\s\S]*?)(?=\[|$)/m);
+    if (devBlock) {
+      for (const line of devBlock[1].split('\n')) {
+        const m = line.match(/^(\w[\w-]*)\s*=\s*["']([^"']+)["']/);
+        if (m) out.push({ name: m[1], version: m[2], ecosystem: 'pypi', isDev: true });
+      }
+    }
+    return out;
+  } catch { return []; }
+}
+
+async function parseRequirements(rootDir: string): Promise<ExternalPackage[]> {
+  const candidates = ['requirements.txt', 'requirements/base.txt', 'requirements/prod.txt'];
+  const out: ExternalPackage[] = [];
+  for (const candidate of candidates) {
+    try {
+      const raw = await readFile(join(rootDir, candidate), 'utf-8');
+      for (const line of raw.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('-')) continue;
+        const m = trimmed.match(/^([a-zA-Z0-9_.-]+)\s*([>=<!][^\s;#]*)?/);
+        if (m) out.push({ name: m[1], version: m[2]?.trim() ?? '*', ecosystem: 'pypi', isDev: false });
+      }
+    } catch { /* file absent */ }
+  }
+  return out;
+}
+
+async function parseCargo(rootDir: string): Promise<ExternalPackage[]> {
+  try {
+    const raw = await readFile(join(rootDir, 'Cargo.toml'), 'utf-8');
+    const out: ExternalPackage[] = [];
+    // [dependencies] and [dev-dependencies]
+    for (const [section, isDev] of [['dependencies', false], ['dev-dependencies', true]] as const) {
+      const block = raw.match(new RegExp(`\\[${section}\\]([\\s\\S]*?)(?=\\[|$)`));
+      if (!block) continue;
+      for (const line of block[1].split('\n')) {
+        const simple = line.match(/^(\w[\w-]*)\s*=\s*["']([^"']+)["']/);
+        if (simple) { out.push({ name: simple[1], version: simple[2], ecosystem: 'cargo', isDev }); continue; }
+        const inline = line.match(/^(\w[\w-]*)\s*=\s*\{[^}]*version\s*=\s*["']([^"']+)["']/);
+        if (inline) out.push({ name: inline[1], version: inline[2], ecosystem: 'cargo', isDev });
+      }
+    }
+    return out;
+  } catch { return []; }
+}
+
+async function parseGoMod(rootDir: string): Promise<ExternalPackage[]> {
+  try {
+    const raw = await readFile(join(rootDir, 'go.mod'), 'utf-8');
+    const out: ExternalPackage[] = [];
+    let inRequire = false;
+    for (const line of raw.split('\n')) {
+      if (line.match(/^require\s*\(/)) { inRequire = true; continue; }
+      if (inRequire && line.trim() === ')') { inRequire = false; continue; }
+      const singleReq = line.match(/^require\s+(\S+)\s+(\S+)/);
+      if (singleReq) { out.push({ name: singleReq[1], version: singleReq[2], ecosystem: 'go', isDev: false }); continue; }
+      if (inRequire) {
+        const m = line.trim().match(/^(\S+)\s+(\S+)/);
+        if (m && !m[1].startsWith('//')) {
+          out.push({ name: m[1], version: m[2], ecosystem: 'go', isDev: false });
+        }
+      }
+    }
+    return out;
+  } catch { return []; }
+}
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+export interface ExternalPackageSummary {
+  total: number;
+  byEcosystem: Partial<Record<PackageEcosystem, number>>;
+  packages: ExternalPackage[];
+}
+
+export async function extractExternalPackages(rootDir: string): Promise<ExternalPackageSummary> {
+  const results = await Promise.all([
+    parseNpm(rootDir),
+    parsePyproject(rootDir),
+    parseRequirements(rootDir),
+    parseCargo(rootDir),
+    parseGoMod(rootDir),
+  ]);
+
+  // Deduplicate by name+ecosystem
+  const seen = new Set<string>();
+  const packages: ExternalPackage[] = [];
+  for (const batch of results) {
+    for (const pkg of batch) {
+      const key = `${pkg.ecosystem}:${pkg.name}`;
+      if (!seen.has(key)) { seen.add(key); packages.push(pkg); }
+    }
+  }
+
+  const byEcosystem: Partial<Record<PackageEcosystem, number>> = {};
+  for (const pkg of packages) {
+    byEcosystem[pkg.ecosystem] = (byEcosystem[pkg.ecosystem] ?? 0) + 1;
+  }
+
+  return { total: packages.length, byEcosystem, packages };
+}

--- a/src/core/analyzer/external-packages.ts
+++ b/src/core/analyzer/external-packages.ts
@@ -1,14 +1,14 @@
 /**
  * External package extractor.
  *
- * Parses package manifests (npm, pip, cargo, go, cmake) to build a flat list
+ * Parses package manifests (npm, pip, cargo, go) to build a flat list
  * of direct dependencies. No LLM required — pure filesystem reads.
  */
 
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
-export type PackageEcosystem = 'npm' | 'pypi' | 'cargo' | 'go' | 'maven' | 'cmake';
+export type PackageEcosystem = 'npm' | 'pypi' | 'cargo' | 'go';
 
 export interface ExternalPackage {
   name: string;
@@ -49,28 +49,40 @@ async function parsePyproject(rootDir: string): Promise<ExternalPackage[]> {
   try {
     const raw = await readFile(join(rootDir, 'pyproject.toml'), 'utf-8');
     const out: ExternalPackage[] = [];
-    // [project] dependencies = ["requests>=2.0", ...]
-    const depsBlock = raw.match(/^\[project\][\s\S]*?dependencies\s*=\s*\[([^\]]*)\]/m);
-    if (depsBlock) {
-      for (const line of depsBlock[1].split('\n')) {
+
+    // PEP 621: [project] dependencies = ["requests>=2.0", ...]
+    const pep621Block = raw.match(/^\[project\]\s*\n([\s\S]*?)(?=^\[)/m);
+    const depsMatch = pep621Block
+      ? pep621Block[1].match(/^dependencies\s*=\s*\[([^\]]*)\]/m)
+      : raw.match(/^dependencies\s*=\s*\[([^\]]*)\]/m);
+    if (depsMatch) {
+      for (const line of depsMatch[1].split('\n')) {
         const m = line.match(/["']([a-zA-Z0-9_.-]+)([^"']*)?["']/);
         if (m) out.push({ name: m[1], version: m[2]?.trim() ?? '*', ecosystem: 'pypi', isDev: false });
       }
     }
-    // [project.optional-dependencies] / [tool.poetry.dev-dependencies]
-    const devBlock = raw.match(/\[tool\.poetry\.dev-dependencies\]([\s\S]*?)(?=\[|$)/m);
-    if (devBlock) {
-      for (const line of devBlock[1].split('\n')) {
+
+    // Poetry: [tool.poetry.dependencies] (prod) and [tool.poetry.dev-dependencies] (dev)
+    for (const [section, isDev] of [
+      ['tool\\.poetry\\.dependencies', false],
+      ['tool\\.poetry\\.dev-dependencies', true],
+      ['tool\\.poetry\\.group\\.dev\\.dependencies', true],
+    ] as const) {
+      const block = raw.match(new RegExp(`\\[${section}\\]([\\s\\S]*?)(?=\\[|$)`));
+      if (!block) continue;
+      for (const line of block[1].split('\n')) {
         const m = line.match(/^(\w[\w-]*)\s*=\s*["']([^"']+)["']/);
-        if (m) out.push({ name: m[1], version: m[2], ecosystem: 'pypi', isDev: true });
+        // skip python version constraint line
+        if (m && m[1] !== 'python') out.push({ name: m[1], version: m[2], ecosystem: 'pypi', isDev });
       }
     }
+
     return out;
   } catch { return []; }
 }
 
 async function parseRequirements(rootDir: string): Promise<ExternalPackage[]> {
-  const candidates = ['requirements.txt', 'requirements/base.txt', 'requirements/prod.txt'];
+  const candidates = ['requirements.txt', 'requirements/base.txt', 'requirements/prod.txt', 'requirements/dev.txt'];
   const out: ExternalPackage[] = [];
   for (const candidate of candidates) {
     try {

--- a/src/core/analyzer/refactor-analyzer.ts
+++ b/src/core/analyzer/refactor-analyzer.ts
@@ -473,8 +473,11 @@ function computePriorityScore(
   // Clone groups: per clone group membership
   if (issues.includes('in_clone_group')) score += CLONE_GROUP_MEMBERSHIP_SCORE;
 
-  // High complexity: proportional to excess above threshold
-  if (issues.includes('high_complexity')) score += HIGH_COMPLEXITY_SCORE_BOOST;
+  // High complexity: base boost + proportional to excess above threshold (capped at 3×)
+  if (issues.includes('high_complexity')) {
+    const excess = Math.max(0, (node.cyclomaticComplexity ?? HIGH_COMPLEXITY_THRESHOLD) - HIGH_COMPLEXITY_THRESHOLD);
+    score += HIGH_COMPLEXITY_SCORE_BOOST * (1 + Math.min(excess / 10, 2));
+  }
 
   // Depth bonus: shallower functions are more impactful to refactor
   if (depth >= 0 && depth <= SHALLOW_FUNCTION_DEPTH_MAX && issues.length > 0) score += SHALLOW_FUNCTION_SCORE_BONUS;

--- a/src/core/analyzer/refactor-analyzer.ts
+++ b/src/core/analyzer/refactor-analyzer.ts
@@ -30,6 +30,8 @@ import {
   CLONE_GROUP_MEMBERSHIP_SCORE,
   SHALLOW_FUNCTION_DEPTH_MAX,
   SHALLOW_FUNCTION_SCORE_BONUS,
+  HIGH_COMPLEXITY_THRESHOLD,
+  HIGH_COMPLEXITY_SCORE_BOOST,
 } from '../../constants.js';
 import type { SerializedCallGraph, FunctionNode } from './call-graph.js';
 import type { DuplicateDetectionResult } from './duplicate-detector.js';
@@ -74,7 +76,8 @@ export type RefactorIssue =
   | 'high_fan_out'
   | 'multi_requirement'
   | 'in_cycle'
-  | 'in_clone_group';
+  | 'in_clone_group'
+  | 'high_complexity';
 
 export interface RefactorEntry {
   function: string;
@@ -89,6 +92,8 @@ export interface RefactorEntry {
   /** Requirement names this function is mapped to */
   requirements: string[];
   issues: RefactorIssue[];
+  /** McCabe cyclomatic complexity (undefined if analysis pre-dates this feature) */
+  cyclomaticComplexity?: number;
   /** Composite priority score for sorting (higher = more urgent) */
   priorityScore: number;
 }
@@ -110,6 +115,7 @@ export interface RefactorReport {
     srpViolations: number;
     cycleParticipants: number;
     cyclesDetected: number;
+    highComplexity: number;
   };
   /** Functions with at least one issue, sorted by priorityScore descending */
   priorities: RefactorEntry[];
@@ -342,6 +348,10 @@ export function analyzeForRefactoring(
       issues.push('in_cycle');
     }
     
+    if ((node.cyclomaticComplexity ?? 0) >= HIGH_COMPLEXITY_THRESHOLD) {
+      issues.push('high_complexity');
+    }
+
     // Check if this function appears in any clone group
     if (duplicates && duplicates.cloneGroups.length > 0) {
       const functionKey = `${node.name}@${node.filePath}`;
@@ -376,6 +386,7 @@ export function analyzeForRefactoring(
       sccSize,
       requirements,
       issues,
+      ...(node.cyclomaticComplexity !== undefined ? { cyclomaticComplexity: node.cyclomaticComplexity } : {}),
       priorityScore,
     });
   }
@@ -409,6 +420,7 @@ export function analyzeForRefactoring(
   const highFanOutCount = entries.filter(e => e.issues.includes('high_fan_out')).length;
   const srpCount = entries.filter(e => e.issues.includes('multi_requirement')).length;
   const cycleParticipants = entries.filter(e => e.issues.includes('in_cycle')).length;
+  const highComplexityCount = entries.filter(e => e.issues.includes('high_complexity')).length;
 
   return {
     generatedAt: new Date().toISOString(),
@@ -421,6 +433,7 @@ export function analyzeForRefactoring(
       srpViolations: srpCount,
       cycleParticipants,
       cyclesDetected: cycles.length,
+      highComplexity: highComplexityCount,
     },
     priorities: withIssues,
     cycles,
@@ -459,6 +472,9 @@ function computePriorityScore(
 
   // Clone groups: per clone group membership
   if (issues.includes('in_clone_group')) score += CLONE_GROUP_MEMBERSHIP_SCORE;
+
+  // High complexity: proportional to excess above threshold
+  if (issues.includes('high_complexity')) score += HIGH_COMPLEXITY_SCORE_BOOST;
 
   // Depth bonus: shallower functions are more impactful to refactor
   if (depth >= 0 && depth <= SHALLOW_FUNCTION_DEPTH_MAX && issues.length > 0) score += SHALLOW_FUNCTION_SCORE_BONUS;

--- a/src/core/generator/stages/stage5-architecture.test.ts
+++ b/src/core/generator/stages/stage5-architecture.test.ts
@@ -394,6 +394,7 @@ describe('Stage 5: Architecture Synthesis', () => {
         cyclesDetected: 4,
         cycleParticipants: 8,
         srpViolations: 6,
+        highComplexity: 0,
       },
       priorities: [
         { function: 'processAll', file: 'src/processor.ts', fanIn: 2, fanOut: 10, depth: 1, sccSize: 1, requirements: [], issues: ['high_fan_out', 'in_cycle'], priorityScore: 9 },
@@ -444,6 +445,7 @@ describe('Stage 5: Architecture Synthesis', () => {
         cyclesDetected: 0,
         cycleParticipants: 0,
         srpViolations: 0,
+        highComplexity: 0,
       },
       priorities: [],
       cycles: [],

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -896,6 +896,13 @@ export async function handleGetMinimalContext(
   if (candidates.length === 0) return { error: `Function "${functionName}" not found. Run analyze_codebase first.` };
   const target = candidates[0];
 
+  // Risk-aware depth: high fan-in/out functions get more caller/callee context
+  const riskLevel: 'high' | 'medium' | 'low' =
+    target.fanIn >= 30 || target.fanOut >= 15 ? 'high' :
+    target.fanIn >= 15 || target.fanOut >= 8  ? 'medium' : 'low';
+  const callerLimit = riskLevel === 'high' ? 24 : riskLevel === 'medium' ? 18 : 12;
+  const calleeLimit = riskLevel === 'high' ? 24 : riskLevel === 'medium' ? 18 : 12;
+
   // Direct callers and callees from calls edges
   const callsEdges = cg.edges.filter(e => !e.kind || e.kind === 'calls');
 
@@ -926,7 +933,7 @@ export async function handleGetMinimalContext(
       return { name: n.name, file: relative(absDir, n.filePath), sig: sig(n), callType: edge?.callType ?? 'direct', isExternal: false };
     })
     .filter((n): n is NonNullable<typeof n> => !!n)
-    .slice(0, 12);
+    .slice(0, callerLimit);
 
   const callees = [...new Set(calleeIds)]
     .map(id => {
@@ -943,7 +950,7 @@ export async function handleGetMinimalContext(
       };
     })
     .filter((n): n is NonNullable<typeof n> => !!n)
-    .slice(0, 12);
+    .slice(0, calleeLimit);
 
   // Test coverage — distinguish import-based vs call-based tracing
   const seenTestNames = new Set<string>();
@@ -974,6 +981,7 @@ export async function handleGetMinimalContext(
       fanIn: target.fanIn,
       fanOut: target.fanOut,
       community: target.communityLabel ?? null,
+      riskLevel,
       body,
     },
     callers,
@@ -1163,11 +1171,11 @@ export async function handleDetectChanges(
 
   const callsEdges = cg.edges.filter(e => !e.kind || e.kind === 'calls');
 
-  // callerIndex: calleeId → callerIds (for upward BFS)
-  const callerIndex = new Map<string, string[]>();
+  // callerIndex: calleeId → [{id, callType}] — callType weights BFS contribution
+  const callerIndex = new Map<string, Array<{ id: string; callType?: string }>>();
   for (const e of callsEdges) {
     if (!callerIndex.has(e.calleeId)) callerIndex.set(e.calleeId, []);
-    callerIndex.get(e.calleeId)!.push(e.callerId);
+    callerIndex.get(e.calleeId)!.push({ id: e.callerId, callType: e.callType });
   }
 
   // calleeIndex: callerId → calleeIds (for boundary score)
@@ -1177,22 +1185,26 @@ export async function handleDetectChanges(
     calleeIndex.get(e.callerId)!.push(e.calleeId);
   }
 
-  // Distance-weighted BFS: Σ 1/d² over all transitive callers
+  // awaited callers are most sensitive to breakage; constructor callers least
+  const callTypeWeight = (ct?: string) =>
+    ct === 'awaited' ? 1.0 : ct === 'direct' ? 0.7 : ct === 'method' ? 0.6 : 0.5;
+
+  // Distance-weighted BFS: Σ weight/d² — clamped to prevent cross-repo drift
   const transitiveScore = (startId: string): number => {
-    const visited = new Map<string, number>(); // id → depth
+    const visited = new Set<string>();
     const queue: Array<{ id: string; depth: number }> = [{ id: startId, depth: 1 }];
     let score = 0;
     while (queue.length) {
       const { id, depth } = queue.shift()!;
-      for (const callerId of callerIndex.get(id) ?? []) {
-        if (!visited.has(callerId)) {
-          visited.set(callerId, depth);
-          score += 1 / (depth * depth);
-          queue.push({ id: callerId, depth: depth + 1 });
+      for (const caller of callerIndex.get(id) ?? []) {
+        if (!visited.has(caller.id)) {
+          visited.add(caller.id);
+          score += callTypeWeight(caller.callType) / (depth * depth);
+          queue.push({ id: caller.id, depth: depth + 1 });
         }
       }
     }
-    return score;
+    return Math.min(score, 10);
   };
 
   // Boundary score: outgoing edges to external nodes; http/db weighted 3×, others 1×; normalized
@@ -1220,18 +1232,23 @@ export async function handleDetectChanges(
     const n = nodeMap.get(id)!;
     const fnLength = Math.max(1, (n.endLine ?? n.startLine ?? 1) - (n.startLine ?? 1) + 1);
     const changed = fnChangedLineCount.get(id) ?? Math.round(fnLength * 0.5);
-    const changeScore = Math.min(changed / fnLength, 1);
-    const testCount = testedByMap.get(id)?.length ?? 0;
-    const coveragePenalty = 1 / (1 + Math.log(1 + testCount));
+    // Blend relative (sensitivity) + absolute (log scale) — prevents tiny fully-changed fns
+    // from outranking large ones; log(201)≈5.3 so 200 changed lines ≈ absScore 1.0
+    const relScore = changed / fnLength;
+    const absScore = Math.log(1 + changed) / Math.log(201);
+    const changeScore = Math.min(0.6 * relScore + 0.4 * absScore, 1);
+    const tests = testedByMap.get(id) ?? [];
+    // called-edges are direct proof; imported-only is weaker (survives vi.mock)
+    const effectiveTests = tests.reduce((s, t) => s + (t.confidence === 'called' ? 1.0 : 0.3), 0);
+    const coveragePenalty = 1 / (1 + Math.log(1 + effectiveTests));
     const tScore = transitiveScore(id);
     const bScore = boundaryScore(id);
-    const riskScore = Math.round((
-      Math.log(1 + n.fanIn) * 0.8 +
-      tScore * 1.2 +
-      bScore * 2.5 +
-      changeScore * 2.0 +
-      coveragePenalty * 2.0
-    ) * 100) / 100;
+    // Multiplicative model: risk = likelihood × impact
+    // Decouples change probability from structural blast radius; prevents correlated
+    // signals (fanIn ↔ transitive) from triple-stacking additively
+    const likelihood = changeScore * (1 + coveragePenalty);
+    const impact = Math.log(1 + n.fanIn) * 0.8 + tScore + bScore;
+    const riskScore = Math.round(likelihood * impact * 100) / 100;
     return {
       name: n.name,
       file: relative(absDir, n.filePath),

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -898,34 +898,63 @@ export async function handleGetMinimalContext(
 
   // Direct callers and callees from calls edges
   const callsEdges = cg.edges.filter(e => !e.kind || e.kind === 'calls');
-  const callerIds = callsEdges.filter(e => e.calleeId === target.id).map(e => e.callerId);
-  const calleeIds = callsEdges.filter(e => e.callerId === target.id).map(e => e.calleeId);
 
   const sig = (n: (typeof cg.nodes)[0]) =>
     n.signature ?? n.name + (n.isExternal ? ' [external]' : '');
 
+  // Build per-callee edge list to get callType
+  const edgesForCallee = new Map<string, Array<{ callerId: string; callType?: string }>>();
+  const edgesForCaller = new Map<string, Array<{ calleeId: string; callType?: string }>>();
+  for (const e of callsEdges) {
+    if (!edgesForCallee.has(e.calleeId)) edgesForCallee.set(e.calleeId, []);
+    edgesForCallee.get(e.calleeId)!.push({ callerId: e.callerId, callType: e.callType });
+    if (!edgesForCaller.has(e.callerId)) edgesForCaller.set(e.callerId, []);
+    edgesForCaller.get(e.callerId)!.push({ calleeId: e.calleeId, callType: e.callType });
+  }
+
+  const callerEdges = edgesForCallee.get(target.id) ?? [];
+  const calleeEdgeList = edgesForCaller.get(target.id) ?? [];
+
+  const callerIds = callerEdges.map(e => e.callerId);
+  const calleeIds = calleeEdgeList.map(e => e.calleeId);
+
   const callers = [...new Set(callerIds)]
-    .map(id => nodeMap.get(id))
-    .filter((n): n is NonNullable<typeof n> => !!n && !n.isExternal)
-    .slice(0, 12)
-    .map(n => ({ name: n.name, file: relative(absDir, n.filePath), sig: sig(n) }));
+    .map(id => {
+      const n = nodeMap.get(id);
+      if (!n || n.isExternal) return null;
+      const edge = callerEdges.find(e => e.callerId === id);
+      return { name: n.name, file: relative(absDir, n.filePath), sig: sig(n), callType: edge?.callType ?? 'direct', isExternal: false };
+    })
+    .filter((n): n is NonNullable<typeof n> => !!n)
+    .slice(0, 12);
 
   const callees = [...new Set(calleeIds)]
-    .map(id => nodeMap.get(id))
+    .map(id => {
+      const n = nodeMap.get(id);
+      if (!n) return null;
+      const edge = calleeEdgeList.find(e => e.calleeId === id);
+      return {
+        name: n.isExternal ? `[external] ${n.name}` : n.name,
+        file: n.isExternal ? 'external' : relative(absDir, n.filePath),
+        sig: sig(n),
+        callType: edge?.callType ?? 'direct',
+        isExternal: n.isExternal ?? false,
+        kind: n.externalKind,
+      };
+    })
     .filter((n): n is NonNullable<typeof n> => !!n)
-    .slice(0, 12)
-    .map(n => ({
-      name: n.isExternal ? `[external] ${n.name}` : n.name,
-      file: n.isExternal ? 'external' : relative(absDir, n.filePath),
-      sig: sig(n),
-      kind: n.externalKind,
-    }));
+    .slice(0, 12);
 
-  // Test coverage
+  // Test coverage — distinguish import-based vs call-based tracing
+  const seenTestNames = new Set<string>();
   const testedBy = cg.edges
     .filter(e => e.kind === 'tested_by' && e.callerId === target.id)
-    .map(e => e.calleeName)
-    .filter((v, i, a) => a.indexOf(v) === i);
+    .flatMap(e => {
+      if (seenTestNames.has(e.calleeName)) return [];
+      seenTestNames.add(e.calleeName);
+      const confidence: 'imported' | 'called' = e.confidence === 'import' ? 'imported' : 'called';
+      return [{ name: e.calleeName, confidence }];
+    });
 
   // Function body (byte-range slice from source)
   let body: string | null = null;
@@ -988,16 +1017,22 @@ export async function handleGetCluster(
   const rawInternal = cg.edges
     .filter(e => (!e.kind || e.kind === 'calls') && memberIds.has(e.callerId) && memberIds.has(e.calleeId));
 
-  // Deduplicate and take top 15 by callee fanIn (most structurally important edges first)
+  // Deduplicate, count all unique internal edges for density, show top 15
   const seen = new Set<string>();
   const callEdges: string[] = [];
+  let uniqueInternalCount = 0;
   for (const e of rawInternal) {
     const key = `${e.callerId}→${e.calleeId}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    callEdges.push(`${nameById.get(e.callerId)} → ${nameById.get(e.calleeId)}`);
-    if (callEdges.length >= 15) break;
+    uniqueInternalCount++;
+    if (callEdges.length < 15) {
+      callEdges.push(`${nameById.get(e.callerId)} → ${nameById.get(e.calleeId)}`);
+    }
   }
+
+  const m = members.length;
+  const clusterDensity = m > 1 ? Math.round((uniqueInternalCount / (m * (m - 1))) * 1000) / 1000 : 0;
 
   // Files the community spans
   const files = [...new Set(members.map(n => relative(absDir, n.filePath)))].sort();
@@ -1006,9 +1041,10 @@ export async function handleGetCluster(
     communityLabel: target.communityLabel,
     communityId: target.communityId,
     stats: {
-      members: members.length,
+      members: m,
       files: files.length,
-      internalEdges: rawInternal.length,
+      internalEdges: uniqueInternalCount,
+      clusterDensity,
     },
     files,
     // Internal call edges show WHY these functions cluster together
@@ -1099,20 +1135,23 @@ export async function handleDetectChanges(
   const cg = ctx.callGraph as SerializedCallGraph;
   const nodeMap = new Map(cg.nodes.map(n => [n.id, n]));
 
-  // Map changed line ranges to function nodes via startLine
+  // Map changed line ranges to function nodes; track overlapping line count per function
   const changedFnIds = new Set<string>();
+  const fnChangedLineCount = new Map<string, number>(); // nodeId → #lines overlapping with diff
   for (const [filePath, ranges] of changedLines) {
     const fileNodes = cg.nodes.filter(n => n.filePath === filePath && !n.isExternal && !n.isTest && n.startLine);
     for (const node of fileNodes) {
       const fnEnd = node.endLine ?? node.startLine!;
+      let overlap = 0;
       for (const [start, end] of ranges) {
-        // True overlap: changed range [start,end] intersects function [startLine,endLine]
         if (node.startLine! <= end && fnEnd >= start) {
           changedFnIds.add(node.id);
+          overlap += Math.min(end, fnEnd) - Math.max(start, node.startLine!) + 1;
         }
       }
+      if (overlap > 0) fnChangedLineCount.set(node.id, (fnChangedLineCount.get(node.id) ?? 0) + overlap);
     }
-    // If no line match found for the file, include all functions in the file as changed
+    // Fallback: no line match — include all functions in the file
     if (fileNodes.length > 0 && !fileNodes.some(n => changedFnIds.has(n.id))) {
       for (const n of fileNodes) changedFnIds.add(n.id);
     }
@@ -1122,41 +1161,86 @@ export async function handleDetectChanges(
     return { changedFunctions: [], message: 'Changed files found but no matching function nodes. Re-run analyze_codebase.' };
   }
 
-  // BFS blast radius: count all transitive callers of each changed function
   const callsEdges = cg.edges.filter(e => !e.kind || e.kind === 'calls');
-  const callerIndex = new Map<string, string[]>(); // calleeId → callerIds
+
+  // callerIndex: calleeId → callerIds (for upward BFS)
+  const callerIndex = new Map<string, string[]>();
   for (const e of callsEdges) {
     if (!callerIndex.has(e.calleeId)) callerIndex.set(e.calleeId, []);
     callerIndex.get(e.calleeId)!.push(e.callerId);
   }
 
-  const blastRadius = (startId: string): number => {
-    const visited = new Set<string>();
-    const queue = [startId];
+  // calleeIndex: callerId → calleeIds (for boundary score)
+  const calleeIndex = new Map<string, string[]>();
+  for (const e of callsEdges) {
+    if (!calleeIndex.has(e.callerId)) calleeIndex.set(e.callerId, []);
+    calleeIndex.get(e.callerId)!.push(e.calleeId);
+  }
+
+  // Distance-weighted BFS: Σ 1/d² over all transitive callers
+  const transitiveScore = (startId: string): number => {
+    const visited = new Map<string, number>(); // id → depth
+    const queue: Array<{ id: string; depth: number }> = [{ id: startId, depth: 1 }];
+    let score = 0;
     while (queue.length) {
-      const id = queue.shift()!;
+      const { id, depth } = queue.shift()!;
       for (const callerId of callerIndex.get(id) ?? []) {
-        if (!visited.has(callerId)) { visited.add(callerId); queue.push(callerId); }
+        if (!visited.has(callerId)) {
+          visited.set(callerId, depth);
+          score += 1 / (depth * depth);
+          queue.push({ id: callerId, depth: depth + 1 });
+        }
       }
     }
-    return visited.size;
+    return score;
   };
+
+  // Boundary score: outgoing edges to external nodes; http/db weighted 3×, others 1×; normalized
+  const boundaryScore = (nodeId: string): number => {
+    let raw = 0;
+    for (const calleeId of calleeIndex.get(nodeId) ?? []) {
+      const callee = nodeMap.get(calleeId);
+      if (!callee?.isExternal) continue;
+      raw += (callee.externalKind === 'http' || callee.externalKind === 'database') ? 3 : 1;
+    }
+    return Math.min(raw / 3, 1);
+  };
+
+  // testedBy map: nodeId → [{name, confidence}]
+  const testedByMap = new Map<string, Array<{ name: string; confidence: 'imported' | 'called' }>>();
+  for (const e of cg.edges.filter(e => e.kind === 'tested_by')) {
+    if (!testedByMap.has(e.callerId)) testedByMap.set(e.callerId, []);
+    const arr = testedByMap.get(e.callerId)!;
+    if (!arr.some(x => x.name === e.calleeName)) {
+      arr.push({ name: e.calleeName, confidence: e.confidence === 'import' ? 'imported' : 'called' });
+    }
+  }
 
   const scored = [...changedFnIds].map(id => {
     const n = nodeMap.get(id)!;
-    const radius = blastRadius(id);
+    const fnLength = Math.max(1, (n.endLine ?? n.startLine ?? 1) - (n.startLine ?? 1) + 1);
+    const changed = fnChangedLineCount.get(id) ?? Math.round(fnLength * 0.5);
+    const changeScore = Math.min(changed / fnLength, 1);
+    const testCount = testedByMap.get(id)?.length ?? 0;
+    const coveragePenalty = 1 / (1 + Math.log(1 + testCount));
+    const tScore = transitiveScore(id);
+    const bScore = boundaryScore(id);
+    const riskScore = Math.round((
+      Math.log(1 + n.fanIn) * 0.8 +
+      tScore * 1.2 +
+      bScore * 2.5 +
+      changeScore * 2.0 +
+      coveragePenalty * 2.0
+    ) * 100) / 100;
     return {
       name: n.name,
       file: relative(absDir, n.filePath),
       startLine: n.startLine ?? null,
       endLine: n.endLine ?? null,
       fanIn: n.fanIn,
-      blastRadius: radius,
-      riskScore: n.fanIn + radius * 2,
-      testedBy: cg.edges
-        .filter(e => e.kind === 'tested_by' && e.callerId === id)
-        .map(e => e.calleeName)
-        .filter((v, i, a) => a.indexOf(v) === i),
+      blastRadius: Math.round(tScore * 100) / 100,
+      riskScore,
+      testedBy: testedByMap.get(id) ?? [],
     };
   }).sort((a, b) => b.riskScore - a.riskScore);
 

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -27,6 +27,7 @@ import {
   ARTIFACT_SCHEMA_INVENTORY,
   ARTIFACT_UI_INVENTORY,
   ARTIFACT_ENV_INVENTORY,
+  ARTIFACT_EXTERNAL_PACKAGES,
 } from '../../../constants.js';
 import { runAnalysis } from '../../../cli/commands/analyze.js';
 import { analyzeForRefactoring } from '../../analyzer/refactor-analyzer.js';
@@ -746,6 +747,32 @@ export async function handleGetEnvVars(
 
   const envVars = await extractEnvVars(filePaths, absDir);
   return { cached: false, total: envVars.length, envVars };
+}
+
+// ============================================================================
+// EXTERNAL PACKAGES HANDLER
+// ============================================================================
+
+/**
+ * Return direct external dependencies from package manifests
+ * (package.json, pyproject.toml, requirements.txt, Cargo.toml, go.mod).
+ * Falls back to live extraction if cached artifact is absent.
+ */
+export async function handleGetExternalPackages(
+  directory: string,
+): Promise<Record<string, unknown>> {
+  const absDir = await validateDirectory(directory);
+  const artifactPath = join(absDir, SPEC_GEN_DIR, SPEC_GEN_ANALYSIS_SUBDIR, ARTIFACT_EXTERNAL_PACKAGES);
+
+  try {
+    const raw = await readFile(artifactPath, 'utf-8');
+    const result = JSON.parse(raw) as Record<string, unknown>;
+    return { cached: true, ...result };
+  } catch { /* not cached */ }
+
+  const { extractExternalPackages } = await import('../../analyzer/external-packages.js');
+  const result = await extractExternalPackages(absDir);
+  return { cached: false, ...result };
 }
 
 /**

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -1127,6 +1127,74 @@ function runGit(args: string[], cwd: string): Promise<string> {
   });
 }
 
+// ── change-type classifier ────────────────────────────────────────────────────
+// Signature line patterns across languages (TS/JS, Python, Go, Rust, Java/C++)
+const SIG_PATTERN =
+  /^\s*(export\s+)?(default\s+)?(async\s+)?function\b|\bdef\s+\w+\s*[([:]|\bfunc\s+(\([^)]*\)\s*)?\w+\s*\(|\bfn\s+\w+\b|\bclass\s+\w+/;
+// Control-flow keywords (broad, multi-language)
+const LOGIC_PATTERN =
+  /\b(if|else|for|while|switch|try|catch|throw|return|yield|await|break|continue|elif|except|raise|match|case)\b/;
+
+type ChangeType = 'signature' | 'logic' | 'config';
+
+function classifyChangeType(
+  node: { startLine?: number; endLine?: number },
+  addedLines: Map<number, string>,
+): ChangeType {
+  const fnStart = node.startLine ?? 1;
+  const fnEnd = node.endLine ?? fnStart;
+  const linesInFn: string[] = [];
+  for (const [ln, content] of addedLines) {
+    if (ln >= fnStart && ln <= fnEnd) linesInFn.push(content);
+  }
+  if (linesInFn.length === 0) return 'logic';
+  // Signature change: function's own declaration line was modified
+  const sigLine = addedLines.get(fnStart);
+  if (sigLine !== undefined && SIG_PATTERN.test(sigLine)) return 'signature';
+  // Logic change: any added line has a control-flow keyword
+  if (linesInFn.some(l => LOGIC_PATTERN.test(l))) return 'logic';
+  return 'config';
+}
+
+const CHANGE_TYPE_MULTIPLIER: Record<ChangeType, number> = {
+  signature: 1.5, // breaking-change candidate
+  logic: 1.0,     // default
+  config: 0.4,    // literal / comment / config tweak
+};
+
+function buildReason(params: {
+  changeType: ChangeType;
+  directCallers: Array<{ callType?: string }>;
+  tests: Array<{ confidence: 'imported' | 'called' }>;
+  bScore: number;
+  fanIn: number;
+}): string {
+  const { changeType, directCallers, tests, bScore, fanIn } = params;
+  const parts: string[] = [];
+
+  if (changeType === 'signature') parts.push('signature change');
+  else if (changeType === 'config') parts.push('config/literal change');
+
+  if (fanIn > 0) {
+    const awaitedCount = directCallers.filter(c => c.callType === 'awaited').length;
+    const total = directCallers.length || fanIn;
+    if (awaitedCount === total && awaitedCount > 0) parts.push('all callers awaited');
+    else if (awaitedCount > 0) parts.push(`${awaitedCount} awaited callers`);
+    else parts.push(`${fanIn} callers`);
+  }
+
+  const calledTests = tests.filter(t => t.confidence === 'called').length;
+  if (tests.length === 0) parts.push('no tests');
+  else if (calledTests === 0) parts.push('import-only tests');
+  else parts.push(`${calledTests} direct test${calledTests > 1 ? 's' : ''}`);
+
+  if (bScore >= 0.67) parts.push('HTTP/DB boundary');
+  else if (bScore > 0) parts.push('external boundary');
+
+  return parts.join(' · ') || 'low-risk change';
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
  * Detect recently changed functions and rank them by blast radius (fanIn of callers via BFS).
  * Runs git diff to find changed files/lines, maps to function nodes, scores by impact.
@@ -1152,21 +1220,34 @@ export async function handleDetectChanges(
 
   if (!diffOutput.trim()) return { changedFunctions: [], message: 'No changes detected.' };
 
-  // Parse changed file→line ranges from unified diff
-  const changedLines = new Map<string, Array<[number, number]>>(); // absFilePath → [[start,end],…]
+  // Parse unified diff: collect line ranges AND added-line content per file.
+  // --unified=0 means no context lines; only '+' and '-' lines appear in hunks.
+  const changedFileData = new Map<string, {
+    ranges: Array<[number, number]>;
+    addedLines: Map<number, string>; // new-file line# → content
+  }>();
   let curFile: string | null = null;
+  let newLineNum = 0;
   for (const line of diffOutput.split('\n')) {
     const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
-    if (fileMatch) { curFile = join(absDir, fileMatch[1]); continue; }
+    if (fileMatch) { curFile = join(absDir, fileMatch[1]); newLineNum = 0; continue; }
     const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
     if (hunkMatch && curFile) {
-      const start = parseInt(hunkMatch[1], 10);
+      newLineNum = parseInt(hunkMatch[1], 10);
       const count = hunkMatch[2] !== undefined ? parseInt(hunkMatch[2], 10) : 1;
-      if (count === 0) continue; // deletion only, no added lines
-      if (!changedLines.has(curFile)) changedLines.set(curFile, []);
-      changedLines.get(curFile)!.push([start, start + count - 1]);
+      if (count === 0) continue;
+      if (!changedFileData.has(curFile)) changedFileData.set(curFile, { ranges: [], addedLines: new Map() });
+      changedFileData.get(curFile)!.ranges.push([newLineNum, newLineNum + count - 1]);
+      continue;
     }
+    if (!curFile || !changedFileData.has(curFile)) continue;
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      changedFileData.get(curFile)!.addedLines.set(newLineNum++, line.slice(1));
+    }
+    // '-' lines don't advance new-file position; no context lines with --unified=0
   }
+  // Backward-compat: changedLines used by the node-overlap loop below
+  const changedLines = new Map([...changedFileData.entries()].map(([k, v]) => [k, v.ranges]));
 
   const cg = ctx.callGraph as SerializedCallGraph;
   const nodeMap = new Map(cg.nodes.map(n => [n.id, n]));
@@ -1265,7 +1346,10 @@ export async function handleDetectChanges(
     // from outranking large ones; log(201)≈5.3 so 200 changed lines ≈ absScore 1.0
     const relScore = changed / fnLength;
     const absScore = Math.log(1 + changed) / Math.log(201);
-    const changeScore = Math.min(0.6 * relScore + 0.4 * absScore, 1);
+    const rawChangeScore = Math.min(0.6 * relScore + 0.4 * absScore, 1);
+    // Semantic modifier: signature changes are higher risk than config/literal tweaks
+    const changeType = classifyChangeType(n, changedFileData.get(n.filePath)?.addedLines ?? new Map());
+    const changeScore = Math.min(rawChangeScore * CHANGE_TYPE_MULTIPLIER[changeType], 1);
     const tests = testedByMap.get(id) ?? [];
     // called-edges are direct proof; imported-only is weaker (survives vi.mock)
     const effectiveTests = tests.reduce((s, t) => s + (t.confidence === 'called' ? 1.0 : 0.3), 0);
@@ -1278,6 +1362,8 @@ export async function handleDetectChanges(
     const likelihood = changeScore * (1 + coveragePenalty);
     const impact = Math.log(1 + n.fanIn) * 0.8 + tScore + bScore;
     const riskScore = Math.round(likelihood * impact * 100) / 100;
+    const directCallers = callerIndex.get(id) ?? [];
+    const reason = buildReason({ changeType, directCallers, tests, bScore, fanIn: n.fanIn });
     return {
       name: n.name,
       file: relative(absDir, n.filePath),
@@ -1285,7 +1371,9 @@ export async function handleDetectChanges(
       endLine: n.endLine ?? null,
       fanIn: n.fanIn,
       blastRadius: Math.round(tScore * 100) / 100,
+      changeType,
       riskScore,
+      reason,
       testedBy: testedByMap.get(id) ?? [],
     };
   }).sort((a, b) => b.riskScore - a.riskScore);

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -28,6 +28,7 @@ import {
   ARTIFACT_UI_INVENTORY,
   ARTIFACT_ENV_INVENTORY,
   ARTIFACT_EXTERNAL_PACKAGES,
+  TRANSITIVE_SCORE_MAX,
 } from '../../../constants.js';
 import { runAnalysis } from '../../../cli/commands/analyze.js';
 import { analyzeForRefactoring } from '../../analyzer/refactor-analyzer.js';
@@ -1212,9 +1213,10 @@ export async function handleDetectChanges(
     calleeIndex.get(e.callerId)!.push(e.calleeId);
   }
 
-  // awaited callers are most sensitive to breakage; constructor callers least
+  // awaited callers most sensitive; callback least (detached, survives interface change)
   const callTypeWeight = (ct?: string) =>
-    ct === 'awaited' ? 1.0 : ct === 'direct' ? 0.7 : ct === 'method' ? 0.6 : 0.5;
+    ct === 'awaited' ? 1.0 : ct === 'direct' ? 0.7 : ct === 'method' ? 0.6 :
+    ct === 'callback' ? 0.4 : 0.5; // 0.5 default covers 'constructor' and unknown
 
   // Distance-weighted BFS: Σ weight/d² — clamped to prevent cross-repo drift
   const transitiveScore = (startId: string): number => {
@@ -1231,7 +1233,7 @@ export async function handleDetectChanges(
         }
       }
     }
-    return Math.min(score, 10);
+    return Math.min(score, TRANSITIVE_SCORE_MAX);
   };
 
   // Boundary score: outgoing edges to external nodes; http/db weighted 3×, others 1×; normalized


### PR DESCRIPTION
## Summary

### Risk scoring & edge semantics (`detect_changes`)

- **Multiplicative risk model**: `riskScore = likelihood × impact`, where likelihood = `changeScore × (1 + coveragePenalty)` and impact combines log fan-in, distance-weighted transitive callers (`Σ callTypeWeight/d²`, capped at `TRANSITIVE_SCORE_MAX=10`), and boundary score (HTTP/DB callees ×3).
- **Change-type semantic modifier**: diff content classified per function into `signature` (×1.5), `logic` (×1.0), or `config` (×0.4) — fixes config tweaks outranking meaningful logic rewrites. Extended diff parser captures added-line content (new-file line# → string) alongside line ranges.
- **Human-readable `reason` field**: surfaces change type, dominant callType, test confidence, and boundary presence per changed function. e.g. `"signature change · all callers awaited · no tests · HTTP/DB boundary"`
- **callType weights**: `awaited=1.0 > direct=0.7 > method=0.6 > constructor=0.5 > callback=0.4` — explicit for all five call types.
- **`get_minimal_context`**: returns `callType` and `isExternal` on every caller/callee; `testedBy` as `{name, confidence: 'imported'|'called'}`.
- **`get_cluster` density**: `clusterDensity = uniqueInternalEdges / (m×(m−1))` — decision table: `< 0.05` isolate freely, `0.05–0.15` check `internalCallGraph`, `> 0.15` coordinate whole cluster.

### Agent skills

- **`spec-gen-review-changes`** skill (Claude Code + OpenCode + Mistral Vibe): `detect_changes` → rank by `riskScore` → `get_minimal_context` on HIGH functions → `get_cluster` if density uncertain → go/no-go recommendation.
- Updated `spec-gen-implement-story` and `spec-gen-plan-refactor` with `callType` payoff explanations and `clusterDensity` decision table.

### Code quality metrics

- **Cyclomatic complexity (McCabe CC)**: computed at build time via regex over body slice. CC ≥ 10 flagged as `high_complexity`. Score boost scales with excess: CC=10 → +1.5, CC=20 → +3.0, CC=30+ → +4.5 (capped at 3× base). Adds `cyclomaticComplexity` to `FunctionNode`, `RefactorEntry`, and `highComplexity` to `RefactorReport.stats`. On spec-gen: 155/1195 functions flagged (13%).

### Call graph classifiers

- **OVERRIDES edges**: `InheritanceEdge { kind: 'overrides' }` when a child class defines a method with the same name as a parent method — one edge per parent-child pair.
- **`get_external_packages`** MCP tool: parses npm, pypi (PEP 621 + Poetry prod/dev/group, requirements.txt/base/prod/dev), cargo, and go.mod. `PackageEcosystem` is `npm | pypi | cargo | go`. Cached as `external-packages.json`; live fallback when absent.

## Test plan

- [x] `npm test` green (2538 tests)
- [x] `detect_changes`: `changeType` + `reason` fields present; config change scores lower than logic change for same function
- [x] `detect_changes`: `blastRadius` float, `testedBy` objects, ranking correct (small untested fn > large tested fn)
- [x] `get_minimal_context(validateDirectory)`: `riskLevel:"high"`, 24 callers, `callType:"awaited"`
- [x] `get_cluster(validateDirectory)`: `clusterDensity:0.028`, 75 members
- [x] `get_refactor_report` shows `highComplexity` in stats and `cyclomaticComplexity` on entries
- [x] `get_external_packages` returns parsed deps from `package.json`
- [ ] OVERRIDES edges visible in class graph for Python/C++ targets (requires multi-class codebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)