### PR TITLE
feat(decisions): gate hardening, decision tiers, RAG indexing, and test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm ci
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - run: npm ci
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,36 +340,35 @@ record_decision({
 })
 ```
 
-Decisions are consolidated and cross-checked against the git diff before each commit.
+Decisions are consolidated in the background immediately after `record_decision` is called — the pre-commit gate reads the already-consolidated store and adds no LLM latency.
 
 **Performance note**: if you skip `record_decision`, the gate detects unrecorded source changes at commit time and triggers a slow LLM extraction on the *next* commit (~10-30s). Calling `record_decision` proactively keeps every commit instant.
 
 ## When git commit is blocked by the decisions gate
 
-If `git commit` fails and the output is JSON with `"gated": true`, do NOT approve decisions yourself. Always present them to the user first.
-
+If `git commit` fails and the output is JSON with `"gated": true`, do NOT retry silently.
 Check the `reason` field and act accordingly:
 
 **`reason: "verified"` — decisions await review:**
 Present each decision to the user:
 > "The commit is blocked — I found N architectural decision(s) to validate:
 > 1. **[id]** Title — rationale
-> Do you approve? (yes/no)"
-
+Do you approve? (yes/no)"
 For each approval call `approve_decision`, for rejections call `reject_decision`.
 Then run `spec-gen decisions --sync` and retry `git commit`.
+
+**`reason: "approved_not_synced"` — decisions approved but not written to specs:**
+Run `spec-gen decisions --sync` then retry `git commit`. Do not skip this step.
 
 **`reason: "drafts_pending_consolidation"` — drafts were recorded but not yet consolidated:**
 Present to the user:
 > "N decision draft(s) were recorded but never consolidated. Run consolidation now? (~10-30s)"
-
 If yes: run `spec-gen decisions --consolidate --gate` and handle the result.
 If no: retry with `git commit --no-verify` to skip the gate.
 
 **`reason: "no_decisions_recorded"` — source files staged but nothing recorded:**
 Present to the user:
 > "Source files are staged but no architectural decisions were recorded. Run fallback extraction to check for undocumented decisions? (~10-30s)"
-
 If yes: run `spec-gen decisions --consolidate --gate` and handle the result.
 If no: retry with `git commit --no-verify` to skip the gate.
 <!-- end-spec-gen-decisions-instructions -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,9 +48,12 @@ Check the `reason` field and act accordingly:
 Present each decision to the user:
 > "The commit is blocked — I found N architectural decision(s) to validate:
 > 1. **[id]** Title — rationale
-> Do you approve? (yes/no)"
+Do you approve? (yes/no)"
 For each approval call `approve_decision`, for rejections call `reject_decision`.
 Then run `spec-gen decisions --sync` and retry `git commit`.
+
+**`reason: "approved_not_synced"` — decisions approved but not written to specs:**
+Run `spec-gen decisions --sync` then retry `git commit`. Do not skip this step.
 
 **`reason: "drafts_pending_consolidation"` — drafts were recorded but not yet consolidated:**
 Present to the user:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # spec-gen
 
-**Persistent architectural memory for AI coding agents.**
+**Persistent architectural memory and structural cognition for AI coding agents.**
 
-spec-gen turns any codebase into a navigable knowledge graph backed by [OpenSpec](https://github.com/Fission-AI/OpenSpec) living specifications. It extracts and maintains specs, detects spec/code drift, gates architectural decisions, and exposes everything through graph-native MCP tools — so agents start every session already knowing the codebase instead of re-discovering it.
+spec-gen turns any evolving codebase into a navigable knowledge graph backed by [OpenSpec](https://github.com/Fission-AI/OpenSpec) living specifications. It maintains persistent architectural context across agent sessions: graph structure, specs, decisions, drift state, and semantic retrieval — so agents start each task already oriented instead of re-discovering the system from file reads.
 
 ---
 
@@ -15,7 +15,9 @@ AI agents are powerful but amnesiac. On every new task:
 - They have no link between specs and code — drift is invisible
 - File-by-file navigation often burns **15,000–50,000 tokens** per orientation pass, before a single line of useful code is written
 
-spec-gen closes this loop. Run a full analysis once, then keep the graph incrementally updated during development. Wire two files into your agent's context — every subsequent session starts informed.
+spec-gen closes this loop. Run a full analysis once, then keep the graph incrementally updated as the codebase evolves. Even greenfield projects become cognitively "brownfield" after only a few agent sessions — architectural context fragments, decisions disappear, and agents repeatedly reconstruct the same understanding from scratch.
+
+spec-gen persists that context continuously: structure, specs, decisions, drift state, and graph relationships remain queryable across sessions.
 
 ---
 
@@ -29,7 +31,7 @@ Three layers, each usable independently:
 | **2. Spec Layer** | LLM-generated living specs, ADRs, drift detection, decision gates | For generation |
 | **3. Agent Runtime** | 45 MCP tools — `orient()`, semantic search, graph expansion | No |
 
-You can use layer 1 alone to give agents structural context. Add layer 2 for spec coverage. Layer 3 is always-on once `spec-gen mcp` is running.
+You can use layer 1 alone to give agents structural context. Add layer 2 for semantic intent and architectural governance through OpenSpec-compatible living specifications. Layer 3 keeps that context continuously accessible through graph-native MCP tools once `spec-gen mcp` is running.
 
 ---
 
@@ -43,6 +45,7 @@ You can use layer 1 alone to give agents structural context. Add layer 2 for spe
 | Offline structural analysis | ❌ | ❌ | ✓ |
 | Token-efficient orient() | ❌ | ❌ | ✓ ~1–3k vs 15–50k tokens |
 | Living spec generation | ❌ | ❌ | ✓ |
+| Persistent cross-session architectural memory | ❌ | Partial | ✓ |
 
 Traditional coding agents reconstruct architecture from repeated file reads every session. spec-gen persists it as a queryable graph.
 
@@ -62,7 +65,7 @@ spec-gen mcp              # start MCP server
 
 Then ask your agent: **`orient("add a new payment method")`**
 
-That single call returns the relevant functions, their call neighbours, matching spec sections, and insertion-point candidates — in one round-trip instead of a dozen file reads, costing ~1,000 tokens instead of ~30,000.
+That single call returns the relevant functions, their call neighbours, matching spec sections, and insertion-point candidates — preserving architectural continuity across sessions instead of forcing the agent to repeatedly reconstruct context from raw file reads. In practice, this often reduces orientation cost from ~30,000 exploratory tokens to ~1,000 targeted tokens.
 
 **Full pipeline** (specs + decisions — optional and additive):
 
@@ -142,7 +145,7 @@ One graph query replaces most exploratory file reads. The agent knows exactly wh
 
 **Analyze** (no API key)
 
-Scans your codebase with pure static analysis. Builds a full call graph persisted to SQLite, runs label-propagation community detection to cluster tightly coupled functions, computes McCabe cyclomatic complexity for every function, and extracts DB schemas, HTTP routes, UI components, middleware chains, and environment variables. Outputs `.spec-gen/analysis/CODEBASE.md` — a ~600-token structural digest that compresses the equivalent of tens of thousands of exploratory tokens into a small, queryable summary.
+Continuously maintains a structural representation of your codebase using pure static analysis. Builds a full call graph persisted to SQLite, runs label-propagation community detection to cluster tightly coupled functions, computes McCabe cyclomatic complexity for every function, and extracts DB schemas, HTTP routes, UI components, middleware chains, and environment variables. Outputs `.spec-gen/analysis/CODEBASE.md` — a ~600-token structural digest that compresses the equivalent of tens of thousands of exploratory tokens into a small, queryable summary.
 
 With `--watch-auto`, the call graph updates incrementally on every file save: changed file and its direct callers are re-parsed and the graph is atomically swapped. Orient and BFS queries remain live between full analyze runs.
 
@@ -156,17 +159,20 @@ Compares git changes against spec mappings in milliseconds. Detects: Gap (code c
 
 **MCP** (no API key)
 
-45 graph-native tools exposed over stdio. `orient()` is the main entry point — one call replaces 10+ file reads. `detect_changes` risk-scores changed functions using call graph centrality × change type multiplier. See [docs/mcp-tools.md](docs/mcp-tools.md).
+45 graph-native tools exposed over stdio. Together they act as a persistent architectural runtime for coding agents: orientation, graph traversal, semantic retrieval, drift awareness, decision context, and structural risk analysis.
+`orient()` is the main entry point — one call replaces 10+ file reads. `detect_changes` risk-scores changed functions using call graph centrality × change type multiplier. See [docs/mcp-tools.md](docs/mcp-tools.md).
 
 `orient()` runs in **~430µs p50** against a 15k-node codebase (TypeScript compiler, ~79k edges). Full benchmark results: [scripts/BENCHMARKS.md](scripts/BENCHMARKS.md).
 
 **Decisions** (API key for consolidation)
 
-Agents call `record_decision` before writing code. Consolidation runs immediately in the background. At commit time, a pre-commit hook gates the commit until all verified decisions are reviewed and written back as requirements in `spec.md` files.
+Agents call `record_decision` before writing code. Consolidation runs immediately in the background. At commit time, a pre-commit hook gates the commit until all verified decisions are reviewed and written back as requirements in `spec.md` files. Decisions are classified by scope (`local / component / cross-domain / system`); only `cross-domain` and `system` decisions produce ADR files, keeping the decision log signal-dense.
 
 ---
 
 ## Architecture
+
+OpenSpec provides semantic intent and workflow structure. spec-gen maintains the evolving implementation as a continuously queryable architectural graph for agents.
 
 ```
 Codebase
@@ -245,7 +251,7 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 ```bash
 npm install
 npm run build
-npm test          # 2580+ unit tests
+npm test          # 2660+ unit tests
 npm run typecheck
 ```
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 - **LLM spec quality varies**: generated specs reflect the model's understanding. Review sections covering complex business logic before treating them as authoritative.
 - **Embedding is optional**: without an embedding endpoint, `orient` and `search_code` fall back to BM25 keyword search (still useful, less accurate for semantic queries).
 - **Large monorepos**: `spec-gen analyze` on large codebases may take several minutes. Graph storage itself has no practical limit — the pipeline (AST parsing, symbol extraction) is the bottleneck.
-- **`node:sqlite` experimental warning**: Node.js prints `ExperimentalWarning: SQLite is an experimental feature` to stderr on startup. This is cosmetic — the API has been stable since Node 22.5.0 and is marked "release candidate" (Node.js [PR #61262](https://github.com/nodejs/node/pull/61262)). Suppress it with `NODE_NO_WARNINGS=1 spec-gen analyze` if it bothers you.
+- **`node:sqlite` experimental warning on Node 22**: Node.js 22 prints `ExperimentalWarning: SQLite is an experimental feature` to stderr. The warning is gone on Node 24+. Suppress on Node 22 with `NODE_NO_WARNINGS=1 spec-gen analyze`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 
 ## Requirements
 
-- Node.js 20+
+- Node.js 22.5+
 - API key for `generate`, `verify`, and `drift --use-llm`:
   ```bash
   export ANTHROPIC_API_KEY=sk-ant-...    # default provider

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 - **LLM spec quality varies**: generated specs reflect the model's understanding. Review sections covering complex business logic before treating them as authoritative.
 - **Embedding is optional**: without an embedding endpoint, `orient` and `search_code` fall back to BM25 keyword search (still useful, less accurate for semantic queries).
 - **Large monorepos**: `spec-gen analyze` on large codebases may take several minutes. Graph storage itself has no practical limit — the pipeline (AST parsing, symbol extraction) is the bottleneck.
+- **`node:sqlite` experimental warning**: Node.js prints `ExperimentalWarning: SQLite is an experimental feature` to stderr on startup. This is cosmetic — the API has been stable since Node 22.5.0 and is marked "release candidate" (Node.js [PR #61262](https://github.com/nodejs/node/pull/61262)). Suppress it with `NODE_NO_WARNINGS=1 spec-gen analyze` if it bothers you.
 
 ---
 

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -98,6 +98,36 @@ Wire the generated digest into your agent's context:
 `search_code` · `suggest_insertion_points` · `get_spec <domain>` · `search_specs` · `analyze_impact` · `get_function_body` · `get_function_skeleton`
 ```
 
+**Claude Code — MCP config (token-efficient two-server setup)**
+
+MCP clients load all tool schemas at session start. With 45 tools, this costs ~8–77k tokens before any work begins. Claude Code supports `alwaysLoad: false` (deferred, default) — tools load only when the agent searches for them via Tool Search.
+
+The recommended setup uses two server entries: one always-visible core server and one deferred full server:
+
+```json
+{
+  "mcpServers": {
+    "spec-gen-core": {
+      "type": "stdio",
+      "command": "spec-gen",
+      "args": ["mcp", "--minimal"],
+      "alwaysLoad": true
+    },
+    "spec-gen": {
+      "type": "stdio",
+      "command": "spec-gen",
+      "args": ["mcp"],
+      "alwaysLoad": false
+    }
+  }
+}
+```
+
+- **`spec-gen-core`** exposes 5 tools always visible in context (~500 tokens): `orient`, `search_code`, `record_decision`, `detect_changes`, `check_spec_drift`. These are the tools most likely to be called at session start.
+- **`spec-gen`** exposes all 45 tools deferred — loaded on demand when the agent uses Tool Search (e.g. "find tool for BFS graph traversal").
+
+If you only need one server entry, use `alwaysLoad: false` (the default) with the standard `spec-gen mcp` command — all tools are deferred and searchable via Tool Search.
+
 **Cline / Roo Code / Kilocode** — create `.clinerules/spec-gen.md`:
 
 ```markdown

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -25,6 +25,17 @@ spec-gen setup --tools claude         # Install (also installs Claude Code skill
 spec-gen decisions --uninstall-hook   # Remove decisions hook only
 ```
 
+When the gate blocks, the JSON output includes a `reason` field:
+
+| Reason | Meaning | Action |
+|--------|---------|--------|
+| `verified` | Decisions consolidated and verified — await human review | Present to user, call `approve_decision` / `reject_decision`, then `--sync` |
+| `approved_not_synced` | Decisions approved but not written to specs yet | Run `spec-gen decisions --sync`, retry commit |
+| `drafts_pending_consolidation` | Drafts recorded but consolidation never ran | Run `spec-gen decisions --consolidate --gate` |
+| `no_decisions_recorded` | Source files staged but no decisions recorded | Run `spec-gen decisions --consolidate --gate` for fallback extraction |
+
+The gate uses a sentinel file (`.git/SPEC_GEN_GATE_RAN`) written by the pre-commit hook and checked by the post-commit hook. If a commit bypasses the gate via `--no-verify`, the post-commit hook detects the missing sentinel and logs a warning.
+
 **How they relate**: they address different failure modes and do not substitute for each other.
 
 The decisions gate asks: *"has this architectural choice been reviewed by a human?"* It operates on decisions recorded during development — it has no knowledge of which spec files cover which source files.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -140,12 +140,15 @@ spec-gen setup                   # workflow skills
 spec-gen decisions [options]
   --list                 # List decisions, optionally filtered by --status
   --status <status>      # Filter by status: draft, consolidated, verified, approved, synced, phantom
-  --approve <id>         # Approve a decision by ID
+                         # Note: synced/rejected/phantom are purged from store after --sync
+  --approve <id>         # Approve a decision by ID (blocked if already synced)
   --reject <id>          # Reject a decision by ID
   --reason <text>        # Rejection reason (used with --reject)
-  --sync                 # Write approved decisions into specs and ADRs
+  --sync                 # Write approved decisions into specs and ADRs, then purge inactive entries
   --dry-run              # Preview sync without writing files
   --gate                 # Run commit gate check (reads pending.json, no LLM — used by pre-commit hook)
+                         # Gate reason codes: verified | approved_not_synced |
+                         #   drafts_pending_consolidation | no_decisions_recorded
   --consolidate          # Manually trigger LLM consolidation + diff verification of drafts
   --json                 # Machine-readable output
   --uninstall-hook       # Remove decisions pre-commit hook (install via: spec-gen setup --tools claude)

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -160,7 +160,7 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 | `get_mapping` | Requirement->function mapping produced by `spec-gen generate`. Shows which functions implement which spec requirements, confidence level, and orphan functions with no spec coverage. | Yes (generate) |
 | `get_decisions` | List or search Architecture Decision Records (ADRs) stored in `openspec/decisions/`. Optional keyword query. | Yes (generate) |
 | `check_spec_drift` | Detect code changes not reflected in OpenSpec specs. Compares git-changed files against spec coverage maps. Issues: gap / stale / uncovered / orphaned-spec / adr-gap. | Yes (generate) |
-| `search_specs` | Semantic search over OpenSpec specifications to find requirements, design notes, and architecture decisions by meaning. Returns linked source files for graph highlighting. Use this when asked "which spec covers X?" or "where should we implement Z?". Requires a spec index built with `spec-gen analyze` or `--reindex-specs`. | Yes (generate) |
+| `search_specs` | Semantic search over OpenSpec specifications to find requirements, design notes, and architecture decisions by meaning. Also searches ADR files (`openspec/decisions/adr-*.md`) indexed under domain `decisions`. Returns linked source files for graph highlighting. Use this when asked "which spec covers X?" or "where should we implement Z?" or "what decisions were made about Y?". Requires a spec index built with `spec-gen analyze` or `--reindex-specs`. | Yes (generate) |
 | `list_spec_domains` | List all OpenSpec domains available in this project. Use this to discover what domains exist before doing a targeted `search_specs` call. | Yes (generate) |
 | `audit_spec_coverage` | Parity audit: uncovered functions (in call graph, no spec), hub gaps (high fan-in + no spec), orphan requirements (spec with no implementation found), and stale domains (source changed after spec). Run before starting a feature to understand coverage health. No LLM required. | Yes (analyze) |
 
@@ -172,7 +172,7 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 | `list_decisions` | List decisions in the store, optionally filtered by status (`draft`, `consolidated`, `verified`, `approved`, `synced`, `phantom`). | No |
 | `approve_decision` | Approve one or more decisions by ID, marking them ready to sync into specs and ADRs. | No |
 | `reject_decision` | Reject a decision by ID with a reason. Rejected decisions are excluded from sync. | No |
-| `sync_decisions` | Write approved decisions into OpenSpec spec.md files (as requirements) and create ADR files in `openspec/decisions/`. Append-only — never rewrites existing content. Pass `dryRun: true` to preview. | No |
+| `sync_decisions` | Write approved decisions into OpenSpec spec.md files (as requirements) and create ADR files in `openspec/decisions/`. Append-only — never rewrites existing content. After sync, inactive decisions (synced/rejected/phantom) are purged from the store — their content lives in ADRs and git. Pass `dryRun: true` to preview. | No |
 
 **Story Management**
 
@@ -441,7 +441,9 @@ dryRun     boolean   Preview changes without writing files (default: false)
    #   - call-graph neighbourhood for each top function
    #   - best insertion-point candidates
    #   - spec-linked peer functions (cross-graph traversal)
-   #   - matching spec sections
+   #   - matching spec sections AND matching ADRs (domain "decisions")
+   #   - active decisions touching the task's domains (pendingDecisions)
+   #   - approved decisions always surfaced — must sync before committing
 2. get_spec({ directory, domain: "..." })             # read full spec before writing code
 3. check_spec_drift({ directory })                    # verify after implementation
 ```
@@ -462,6 +464,11 @@ dryRun     boolean   Preview changes without writing files (default: false)
 2. [implement the feature / refactor]
 3. git commit  # decisions hook consolidates drafts, cross-checks against diff,
                # blocks commit if unreviewed decisions remain
+   # If blocked, check "reason":
+   #   "verified"              → present decisions to user, approve/reject, then sync
+   #   "approved_not_synced"   → run sync_decisions, then retry commit
+   #   "drafts_pending_consolidation" → run spec-gen decisions --consolidate --gate
+   #   "no_decisions_recorded" → run spec-gen decisions --consolidate --gate
 4. list_decisions({ directory, status: "verified" })
    # Review the consolidated + verified decisions
 5. approve_decision({ directory, ids: ["<id>"] })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "spec-gen": "dist/cli/index.js"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.5.0"
   },
   "scripts": {
     "dev": "tsx watch src/cli/index.ts",
@@ -85,7 +85,6 @@
     "@modelcontextprotocol/server-memory": "^2026.1.26",
     "@vitejs/plugin-react": "^5.0.2",
     "apache-arrow": "^21.1.0",
-    "better-sqlite3": "^12.9.0",
     "chalk": "^5.3.0",
     "chokidar": "^5.0.0",
     "commander": "^12.1.0",
@@ -113,7 +112,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.10.5",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.17.0",

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -22,6 +22,7 @@ import {
   MAX_VALIDATION_FILES,
   OPENSPEC_DIR,
   OPENSPEC_SPECS_SUBDIR,
+  OPENSPEC_DECISIONS_SUBDIR,
   SPEC_GEN_ANALYSIS_REL_PATH,
   SPEC_GEN_CONFIG_REL_PATH,
 } from '../../constants.js';
@@ -855,7 +856,8 @@ async function runSpecIndexing(
   const mappingJsonPath = pathJoin(outputPath, 'mapping.json');
 
   try {
-    const { recordCount } = await SpecVectorIndex.build(outputPath, specsDir, embedSvc, mappingJsonPath);
+    const decisionsDir = pathJoin(rootPath, OPENSPEC_DIR, OPENSPEC_DECISIONS_SUBDIR);
+    const { recordCount } = await SpecVectorIndex.build(outputPath, specsDir, embedSvc, mappingJsonPath, decisionsDir);
     console.log(`    ✓ Spec index built (${recordCount} sections)`);
     console.log(`    → ${outputPath.replace(rootPath + '/', '')}vector-index/`);
   } catch (err) {

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -26,6 +26,7 @@ import {
   replaceDecisions,
   patchDecision,
   getDecisionsByStatus,
+  INACTIVE_STATUSES,
 } from '../../core/decisions/store.js';
 import { consolidateDrafts } from '../../core/decisions/consolidator.js';
 import { extractFromDiff } from '../../core/decisions/extractor.js';
@@ -476,6 +477,11 @@ Examples:
         process.exitCode = 1;
         return;
       }
+      if (decision.status === 'synced') {
+        logger.error(`Decision ${id} is already synced to spec files — re-approval not allowed.`);
+        process.exitCode = 1;
+        return;
+      }
       const updated = patchDecision(store, id, {
         status: 'approved',
         reviewedAt: new Date().toISOString(),
@@ -617,12 +623,19 @@ Examples:
       // Reject all original drafts — they've been replaced by consolidated decisions.
       // Also reject any explicitly superseded IDs from prior sessions.
       const originalDraftIds = new Set(drafts.map((d) => d.id));
+      const originalById = new Map(store.decisions.map((d) => [d.id, d]));
       for (const id of [...originalDraftIds, ...supersededIds]) {
         updatedStore = patchDecision(updatedStore, id, { status: 'rejected' });
       }
+      // Preserve recordedAt from original draft — consolidated decisions share the same
+      // deterministic ID, so overwriting would erase when the decision was first recorded.
+      const withProvenance = [...verified, ...phantom].map((d) => {
+        const original = originalById.get(d.id);
+        return original ? { ...d, recordedAt: original.recordedAt } : d;
+      });
       // replaceDecisions (not upsertDecisions) — consolidated decisions share IDs
       // with their original drafts; upsert would silently no-op after the reject above.
-      updatedStore = replaceDecisions(updatedStore, [...verified, ...phantom]);
+      updatedStore = replaceDecisions(updatedStore, withProvenance);
       updatedStore = { ...updatedStore, lastConsolidatedAt: new Date().toISOString() };
       await saveDecisionStore(rootPath, updatedStore);
 
@@ -778,7 +791,7 @@ Examples:
         // Phantom decisions ("recorded but no code evidence") are excluded — stale phantoms from
         // previous sessions would otherwise silently bypass the gate for all future commits.
         const activeDecisions = store.decisions.filter(
-          (d) => !['rejected', 'synced', 'phantom'].includes(d.status),
+          (d) => !INACTIVE_STATUSES.has(d.status),
         );
         if (activeDecisions.length === 0 && await isGitRepository(rootPath)) {
           try {

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -627,11 +627,20 @@ Examples:
       for (const id of [...originalDraftIds, ...supersededIds]) {
         updatedStore = patchDecision(updatedStore, id, { status: 'rejected' });
       }
-      // Preserve recordedAt from original draft — consolidated decisions share the same
-      // deterministic ID, so overwriting would erase when the decision was first recorded.
+      // Preserve recordedAt provenance:
+      // - Direct match: consolidated decision ID matches original draft → use its recordedAt.
+      // - Merged decision (new ID, no match): use earliest recordedAt across all superseded
+      //   drafts so the audit trail reflects when the underlying work was first captured.
+      const earliestSupersededAt = supersededIds
+        .map((id) => originalById.get(id)?.recordedAt)
+        .filter((t): t is string => t !== undefined)
+        .sort()[0];
       const withProvenance = [...verified, ...phantom].map((d) => {
         const original = originalById.get(d.id);
-        return original ? { ...d, recordedAt: original.recordedAt } : d;
+        if (original) return { ...d, recordedAt: original.recordedAt };
+        // Merged decision — anchor to earliest superseded draft's recordedAt
+        if (earliestSupersededAt) return { ...d, recordedAt: earliestSupersededAt };
+        return d;
       });
       // replaceDecisions (not upsertDecisions) — consolidated decisions share IDs
       // with their original drafts; upsert would silently no-op after the reject above.

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -40,6 +40,7 @@ import {
   DECISIONS_EXTRACTION_MAX_FILES,
   DECISIONS_DIFF_MAX_CHARS,
   CONSOLIDATION_GRACE_PERIOD_MS,
+  GATE_REASONS,
 } from '../../constants.js';
 import type { PendingDecision } from '../../types/index.js';
 import { runTuiApproval } from '../tui-approval.js';
@@ -385,9 +386,16 @@ function displayDecision(d: PendingDecision, verbose = false): void {
     d.confidence === 'medium' ? '\x1b[33mmedium\x1b[0m' :
                                 '\x1b[31mlow\x1b[0m';
 
-  console.log(`${icon} [${d.id}] ${d.title}`);
+  const scopeLabel = d.scope ?? 'component';
+  const scopeBadge =
+    scopeLabel === 'system'       ? `\x1b[31m[${scopeLabel}]\x1b[0m` :
+    scopeLabel === 'cross-domain' ? `\x1b[33m[${scopeLabel}]\x1b[0m` :
+    scopeLabel === 'component'    ? `\x1b[34m[${scopeLabel}]\x1b[0m` :
+                                    `\x1b[90m[${scopeLabel}]\x1b[0m`;
+
+  console.log(`${icon} [${d.id}] ${scopeBadge} ${d.title}`);
   if (verbose) {
-    console.log(`   Status     : ${d.status}  Confidence: ${confidence}`);
+    console.log(`   Status     : ${d.status}  Confidence: ${confidence}  Scope: ${scopeLabel}`);
     console.log(`   Rationale  : ${d.rationale}`);
     if (d.affectedDomains.length) console.log(`   Domains    : ${d.affectedDomains.join(', ')}`);
     if (d.proposedRequirement) console.log(`   Requirement: ${d.proposedRequirement}`);
@@ -754,7 +762,7 @@ Examples:
       if (approved.length > 0) {
         const payload = {
           gated: true,
-          reason: 'approved_not_synced',
+          reason: GATE_REASONS.APPROVED_NOT_SYNCED,
           message: `${approved.length} approved decision(s) must be synced to spec files before committing.`,
           approved: approved.map((d) => ({ id: d.id, title: d.title })),
           actions: { sync: 'spec-gen decisions --sync' },
@@ -774,7 +782,7 @@ Examples:
           // Output structured JSON so the agent can relay to the user and act on the answer.
           const payload = {
             gated: true,
-            reason: 'drafts_pending_consolidation',
+            reason: GATE_REASONS.DRAFTS_PENDING_CONSOLIDATION,
             message: `${drafts.length} draft decision(s) were recorded but never consolidated.`,
             drafts: drafts.map((d) => ({ id: d.id, title: d.title, recordedAt: d.recordedAt })),
             actions: {
@@ -815,7 +823,7 @@ Examples:
               // Source files staged but nothing recorded — output JSON for agent to relay.
               const payload = {
                 gated: true,
-                reason: 'no_decisions_recorded',
+                reason: GATE_REASONS.NO_DECISIONS_RECORDED,
                 message: 'Source files are staged but no architectural decisions were recorded.',
                 actions: {
                   consolidateAndGate: 'spec-gen decisions --consolidate --gate',
@@ -855,6 +863,7 @@ Examples:
       // Non-TTY: JSON for ACP/agent consumption
       const payload = {
         gated: true,
+        reason: GATE_REASONS.VERIFIED,
         verified: verified.map((d) => ({
           id: d.id,
           title: d.title,
@@ -898,13 +907,16 @@ Examples:
       const specMap = await buildSpecMap({ rootPath, openspecPath });
       const approved = getDecisionsByStatus(store, 'approved');
 
-      if (approved.length === 0) {
+      if (approved.length === 0 && !options.json) {
         console.log('No approved decisions to sync. Use --approve <id> first.');
-        return;
       }
 
-      if (!options.json) logger.discovery(`Syncing ${approved.length} approved decision(s)...`);
+      if (approved.length > 0 && !options.json) {
+        logger.discovery(`Syncing ${approved.length} approved decision(s)...`);
+      }
 
+      // Always call syncApprovedDecisions so purgeInactiveDecisions runs on the store
+      // even when there are no approved decisions to sync.
       const { result } = await syncApprovedDecisions(store, {
         rootPath,
         openspecPath,

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -38,6 +38,7 @@ import {
   OPENSPEC_SPECS_SUBDIR,
   DECISIONS_EXTRACTION_MAX_FILES,
   DECISIONS_DIFF_MAX_CHARS,
+  CONSOLIDATION_GRACE_PERIOD_MS,
 } from '../../constants.js';
 import type { PendingDecision } from '../../types/index.js';
 import { runTuiApproval } from '../tui-approval.js';
@@ -149,8 +150,8 @@ fi
 if [ "$DECISIONS_EXIT" -ne 0 ]; then
   exit "$DECISIONS_EXIT"
 fi
-# Sentinel: post-commit hook checks this to detect --no-verify bypass.
-touch .git/SPEC_GEN_GATE_RAN 2>/dev/null || true
+# Sentinel written on successful gate pass. Post-commit checks for its absence to detect --no-verify bypass.
+touch "$(git rev-parse --git-dir 2>/dev/null || echo .git)/SPEC_GEN_GATE_RAN" 2>/dev/null || true
 # end-spec-gen-decisions-hook
 `;
 
@@ -158,7 +159,7 @@ const POST_COMMIT_HOOK_MARKER = '# spec-gen-decisions-post-hook';
 const POST_COMMIT_HOOK_CONTENT = `${POST_COMMIT_HOOK_MARKER}
 # Warn when the pre-commit gate was bypassed via --no-verify.
 # post-commit is NOT skipped by --no-verify (only pre-commit and commit-msg are).
-SENTINEL=".git/SPEC_GEN_GATE_RAN"
+SENTINEL="$(git rev-parse --git-dir 2>/dev/null || echo .git)/SPEC_GEN_GATE_RAN"
 if [ -f "$SENTINEL" ]; then
   rm -f "$SENTINEL"
 else
@@ -744,7 +745,7 @@ Examples:
       const verified = getDecisionsByStatus(store, 'verified');
       const missing: Array<{ file: string; description: string }> = [];
 
-      if (verified.length === 0 && missing.length === 0) {
+      if (verified.length === 0) {
         const drafts = getDecisionsByStatus(store, 'draft');
         if (drafts.length > 0) {
           // Drafts recorded but consolidation never completed.
@@ -767,7 +768,7 @@ Examples:
 
         // If consolidation already ran recently, trust it found nothing — skip the warning.
         const consolidatedRecently = store.lastConsolidatedAt
-          && (Date.now() - new Date(store.lastConsolidatedAt).getTime()) < 60 * 60 * 1000;
+          && (Date.now() - new Date(store.lastConsolidatedAt).getTime()) < CONSOLIDATION_GRACE_PERIOD_MS;
         if (consolidatedRecently) {
           process.exitCode = 0;
           return;

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -121,7 +121,26 @@ fi
 if [ "$DECISIONS_EXIT" -ne 0 ]; then
   exit "$DECISIONS_EXIT"
 fi
+# Sentinel: post-commit hook checks this to detect --no-verify bypass.
+touch .git/SPEC_GEN_GATE_RAN 2>/dev/null || true
 # end-spec-gen-decisions-hook
+`;
+
+const POST_COMMIT_HOOK_MARKER = '# spec-gen-decisions-post-hook';
+const POST_COMMIT_HOOK_CONTENT = `${POST_COMMIT_HOOK_MARKER}
+# Warn when the pre-commit gate was bypassed via --no-verify.
+# post-commit is NOT skipped by --no-verify (only pre-commit and commit-msg are).
+SENTINEL=".git/SPEC_GEN_GATE_RAN"
+if [ -f "$SENTINEL" ]; then
+  rm -f "$SENTINEL"
+else
+  echo "" >&2
+  echo "⚠️  spec-gen: pre-commit gate was bypassed (--no-verify)." >&2
+  echo "    Architectural decisions were NOT reviewed for this commit." >&2
+  echo "    Run: spec-gen decisions --consolidate --gate" >&2
+  echo "" >&2
+fi
+# end-spec-gen-decisions-post-hook
 `;
 
 async function ensureGitignored(rootPath: string, entry: string): Promise<void> {
@@ -165,6 +184,21 @@ export async function installPreCommitHook(rootPath: string): Promise<void> {
   await chmod(hookPath, 0o755);
   logger.success('Pre-commit hook installed at .git/hooks/pre-commit');
   logger.discovery('Commits will be gated until decisions are approved. Use --no-verify to skip.');
+
+  // Install post-commit hook to detect --no-verify bypass
+  const postCommitPath = join(hooksDir, 'post-commit');
+  let existingPostContent = '';
+  if (await fileExists(postCommitPath)) {
+    existingPostContent = await readFile(postCommitPath, 'utf-8');
+    if (!existingPostContent.includes(POST_COMMIT_HOOK_MARKER)) {
+      const strippedPost = existingPostContent.trimEnd().replace(/\n*\nexit 0\s*$/, '');
+      await writeFile(postCommitPath, strippedPost + '\n\n' + POST_COMMIT_HOOK_CONTENT, 'utf-8');
+    }
+  } else {
+    await writeFile(postCommitPath, '#!/bin/sh\n\n' + POST_COMMIT_HOOK_CONTENT, 'utf-8');
+  }
+  await chmod(postCommitPath, 0o755);
+  logger.success('Post-commit hook installed at .git/hooks/post-commit (bypass detector)');
 
   // Ensure pending decisions store is not accidentally committed
   await ensureGitignored(rootPath, '.spec-gen/decisions/');
@@ -211,6 +245,25 @@ export async function uninstallPreCommitHook(rootPath: string): Promise<void> {
   } else {
     await writeFile(hookPath, newContent + '\n', 'utf-8');
     logger.success('Spec-gen decisions gate removed from pre-commit hook.');
+  }
+
+  // Remove post-commit bypass detector
+  const postCommitPath = join(rootPath, '.git', 'hooks', 'post-commit');
+  if (await fileExists(postCommitPath)) {
+    const postContent = await readFile(postCommitPath, 'utf-8');
+    if (postContent.includes(POST_COMMIT_HOOK_MARKER)) {
+      const newPostContent = postContent
+        .replace(/\n*# spec-gen-decisions-post-hook[\s\S]*?# end-spec-gen-decisions-post-hook\n*/g, '')
+        .trim();
+      if (!newPostContent || newPostContent === '#!/bin/sh') {
+        const { unlink } = await import('node:fs/promises');
+        await unlink(postCommitPath);
+        logger.success('Post-commit hook removed.');
+      } else {
+        await writeFile(postCommitPath, newPostContent + '\n', 'utf-8');
+        logger.success('Spec-gen bypass detector removed from post-commit hook.');
+      }
+    }
   }
 
   // Remove record_decision instructions from agent context files

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -69,6 +69,34 @@ record_decision({
 Decisions are consolidated in the background immediately after \`record_decision\` is called — the pre-commit gate reads the already-consolidated store and adds no LLM latency.
 
 **Performance note**: if you skip \`record_decision\`, the gate detects unrecorded source changes at commit time and triggers a slow LLM extraction on the *next* commit (~10-30s). Calling \`record_decision\` proactively keeps every commit instant.
+
+## When git commit is blocked by the decisions gate
+
+If \`git commit\` fails and the output is JSON with \`"gated": true\`, do NOT retry silently.
+Check the \`reason\` field and act accordingly:
+
+**\`reason: "verified"\` — decisions await review:**
+Present each decision to the user:
+> "The commit is blocked — I found N architectural decision(s) to validate:
+> 1. **[id]** Title — rationale
+Do you approve? (yes/no)"
+For each approval call \`approve_decision\`, for rejections call \`reject_decision\`.
+Then run \`spec-gen decisions --sync\` and retry \`git commit\`.
+
+**\`reason: "approved_not_synced"\` — decisions approved but not written to specs:**
+Run \`spec-gen decisions --sync\` then retry \`git commit\`. Do not skip this step.
+
+**\`reason: "drafts_pending_consolidation"\` — drafts were recorded but not yet consolidated:**
+Present to the user:
+> "N decision draft(s) were recorded but never consolidated. Run consolidation now? (~10-30s)"
+If yes: run \`spec-gen decisions --consolidate --gate\` and handle the result.
+If no: retry with \`git commit --no-verify\` to skip the gate.
+
+**\`reason: "no_decisions_recorded"\` — source files staged but nothing recorded:**
+Present to the user:
+> "Source files are staged but no architectural decisions were recorded. Run fallback extraction to check for undocumented decisions? (~10-30s)"
+If yes: run \`spec-gen decisions --consolidate --gate\` and handle the result.
+If no: retry with \`git commit --no-verify\` to skip the gate.
 <!-- end-spec-gen-decisions-instructions -->
 `;
 
@@ -698,6 +726,21 @@ Examples:
 
     // ── Gate only (no consolidation — consolidation happens on record_decision) ──
     if (options.gate && !options.consolidate) {
+      // Block if approved decisions haven't been synced to spec files yet.
+      const approved = getDecisionsByStatus(store, 'approved');
+      if (approved.length > 0) {
+        const payload = {
+          gated: true,
+          reason: 'approved_not_synced',
+          message: `${approved.length} approved decision(s) must be synced to spec files before committing.`,
+          approved: approved.map((d) => ({ id: d.id, title: d.title })),
+          actions: { sync: 'spec-gen decisions --sync' },
+        };
+        process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+        process.exitCode = 1;
+        return;
+      }
+
       const verified = getDecisionsByStatus(store, 'verified');
       const missing: Array<{ file: string; description: string }> = [];
 

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -676,8 +676,10 @@ Examples:
         }
 
         // If source files are staged but nothing was recorded, offer to run the fallback extractor.
+        // Phantom decisions ("recorded but no code evidence") are excluded — stale phantoms from
+        // previous sessions would otherwise silently bypass the gate for all future commits.
         const activeDecisions = store.decisions.filter(
-          (d) => !['rejected', 'synced'].includes(d.status),
+          (d) => !['rejected', 'synced', 'phantom'].includes(d.status),
         );
         if (activeDecisions.length === 0 && await isGitRepository(rootPath)) {
           try {

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -23,7 +23,7 @@ import { isGitRepository, getChangedFiles, getFileDiff, getCommitMessages, resol
 import {
   loadDecisionStore,
   saveDecisionStore,
-  upsertDecisions,
+  replaceDecisions,
   patchDecision,
   getDecisionsByStatus,
 } from '../../core/decisions/store.js';
@@ -538,7 +538,9 @@ Examples:
       for (const id of [...originalDraftIds, ...supersededIds]) {
         updatedStore = patchDecision(updatedStore, id, { status: 'rejected' });
       }
-      updatedStore = upsertDecisions(updatedStore, [...verified, ...phantom]);
+      // replaceDecisions (not upsertDecisions) — consolidated decisions share IDs
+      // with their original drafts; upsert would silently no-op after the reject above.
+      updatedStore = replaceDecisions(updatedStore, [...verified, ...phantom]);
       updatedStore = { ...updatedStore, lastConsolidatedAt: new Date().toISOString() };
       await saveDecisionStore(rootPath, updatedStore);
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1161,6 +1161,11 @@ export const TOOL_DEFINITIONS = [
           type: 'string',
           description: 'ID of a prior decision this one replaces (optional)',
         },
+        scope: {
+          type: 'string',
+          enum: ['local', 'component', 'cross-domain', 'system'],
+          description: 'Decision scope. local: single file; component: single module/service; cross-domain: multiple spec domains or service contracts; system: global constraint. Only cross-domain and system generate ADR files. Defaults to component; auto-promoted to cross-domain when multiple domains inferred.',
+        },
       },
       required: ['directory', 'title', 'rationale'],
     },
@@ -1430,9 +1435,9 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
         const { directory, base } = args as { directory: string; base?: string };
         result = await handleDetectChanges(directory, base);
       } else if (name === 'record_decision') {
-        const { directory, title, rationale, consequences, affectedFiles, supersedes } =
-          args as { directory: string; title: string; rationale: string; consequences?: string; affectedFiles?: string[]; supersedes?: string };
-        result = await handleRecordDecision(directory, title, rationale, consequences, affectedFiles, supersedes);
+        const { directory, title, rationale, consequences, affectedFiles, supersedes, scope } =
+          args as { directory: string; title: string; rationale: string; consequences?: string; affectedFiles?: string[]; supersedes?: string; scope?: import('../../types/index.js').DecisionScope };
+        result = await handleRecordDecision(directory, title, rationale, consequences, affectedFiles, supersedes, scope);
       } else if (name === 'list_decisions') {
         const { directory, status } = args as { directory: string; status?: string };
         result = await handleListDecisions(directory, status);

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1246,20 +1246,53 @@ export const TOOL_DEFINITIONS = [
 // MCP SERVER
 // ============================================================================
 
+// Annotations improve Tool Search relevance in Claude Code (BM25/regex ranking).
+// RO = read-only queries, RW_I = writes but idempotent, RW = non-idempotent writes.
+const _RO  = { readOnlyHint: true,  destructiveHint: false, idempotentHint: true  } as const;
+const _RWI = { readOnlyHint: false, destructiveHint: false, idempotentHint: true  } as const;
+const _RW  = { readOnlyHint: false, destructiveHint: false, idempotentHint: false } as const;
+
+const TOOL_ANNOTATIONS: Record<string, typeof _RO | typeof _RWI | typeof _RW> = {
+  orient: _RO, analyze_codebase: _RWI, get_architecture_overview: _RO,
+  get_refactor_report: _RO, get_call_graph: _RO, get_duplicate_report: _RO,
+  get_signatures: _RO, get_subgraph: _RO, trace_execution_path: _RO,
+  get_mapping: _RO, check_spec_drift: _RO, analyze_impact: _RO,
+  get_low_risk_refactor_candidates: _RO, get_leaf_functions: _RO,
+  get_critical_hubs: _RO, get_function_skeleton: _RO, get_god_functions: _RO,
+  suggest_insertion_points: _RO, search_code: _RO, list_spec_domains: _RO,
+  search_specs: _RO, search_unified: _RO, get_spec: _RO, get_function_body: _RO,
+  get_file_dependencies: _RO, generate_change_proposal: _RW, annotate_story: _RW,
+  get_decisions: _RO, get_route_inventory: _RO, get_middleware_inventory: _RO,
+  get_schema_inventory: _RO, get_ui_components: _RO, get_env_vars: _RO,
+  get_external_packages: _RO, audit_spec_coverage: _RO, generate_tests: _RW,
+  get_test_coverage: _RO, get_minimal_context: _RO, get_cluster: _RO,
+  detect_changes: _RO, record_decision: _RW, list_decisions: _RO,
+  approve_decision: _RWI, reject_decision: _RWI, sync_decisions: _RWI,
+};
+
+const MINIMAL_TOOLS = new Set([
+  'orient', 'search_code', 'record_decision', 'detect_changes', 'check_spec_drift',
+]);
+
 interface McpServerOptions {
   watch?: string;
   watchAuto?: boolean;
   watchDebounce?: string;
+  minimal?: boolean;
 }
 
 async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
+  const activeTools = options.minimal
+    ? TOOL_DEFINITIONS.filter(t => MINIMAL_TOOLS.has(t.name))
+    : TOOL_DEFINITIONS;
+
   const server = new Server(
     { name: 'spec-gen', version: '1.0.0' },
     { capabilities: { tools: {} } }
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: TOOL_DEFINITIONS,
+    tools: activeTools.map(t => ({ ...t, annotations: TOOL_ANNOTATIONS[t.name] })),
   }));
 
   // --watch-auto: start the watcher on the first tool call that carries a directory
@@ -1498,4 +1531,5 @@ export const mcpCommand = new Command('mcp')
   .option('--watch <directory>', 'Watch a project directory and incrementally re-index signatures on file changes')
   .option('--watch-auto', 'Auto-detect the project directory from the first tool call and start watching', true)
   .option('--watch-debounce <ms>', 'Debounce delay in ms before re-indexing after a file change (default: 400)', '400')
+  .option('--minimal', 'Expose only core 5 tools (orient, search_code, record_decision, detect_changes, check_spec_drift). Pair with alwaysLoad: true in Claude Code for always-visible core tools.')
   .action((options: McpServerOptions) => startMcpServer(options));

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -305,16 +305,16 @@ export const setupCommand = new Command('setup')
         message: 'Which agent tools do you want to install skills for?',
         choices: [
           {
-            name: 'Mistral Vibe  (.vibe/skills/spec-gen-{name}/SKILL.md — 8 skills)',
-            value: 'vibe' as ToolName,
+            name: 'Claude Code   (.claude/skills/ — 8 skills + pre-commit & PostToolUse hooks)',
+            value: 'claude' as ToolName,
           },
           {
             name: 'Cline / Roo   (.clinerules/workflows/spec-gen-{name}.md — 7 workflows)',
             value: 'cline' as ToolName,
           },
           {
-            name: 'Claude Code   (.claude/skills/ — 8 skills + pre-commit & PostToolUse hooks)',
-            value: 'claude' as ToolName,
+            name: 'Mistral Vibe  (.vibe/skills/spec-gen-{name}/SKILL.md — 8 skills)',
+            value: 'vibe' as ToolName,
           },
           {
             name: 'OpenCode      (.opencode/skills/spec-gen-{name}/SKILL.md — 8 skills + agent-guard plugin)',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -153,6 +153,9 @@ export const ANALYSIS_STALE_THRESHOLD_MS = 60 * 60 * 1000;
 /** How old (ms) an analysis can be before being re-used in 'run' (1 hour) */
 export const ANALYSIS_REUSE_THRESHOLD_MS = 60 * 60 * 1000;
 
+/** Grace period after consolidation during which the gate skips the no_decisions_recorded check (1 hour) */
+export const CONSOLIDATION_GRACE_PERIOD_MS = 60 * 60 * 1000;
+
 // ============================================================================
 // VIEWER / SERVER
 // ============================================================================

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -156,6 +156,15 @@ export const ANALYSIS_REUSE_THRESHOLD_MS = 60 * 60 * 1000;
 /** Grace period after consolidation during which the gate skips the no_decisions_recorded check (1 hour) */
 export const CONSOLIDATION_GRACE_PERIOD_MS = 60 * 60 * 1000;
 
+/** Canonical gate block reason codes — shared by gate handler, docs, tests, and AGENTS.md */
+export const GATE_REASONS = {
+  VERIFIED: 'verified',
+  APPROVED_NOT_SYNCED: 'approved_not_synced',
+  DRAFTS_PENDING_CONSOLIDATION: 'drafts_pending_consolidation',
+  NO_DECISIONS_RECORDED: 'no_decisions_recorded',
+} as const;
+export type GateReason = typeof GATE_REASONS[keyof typeof GATE_REASONS];
+
 // ============================================================================
 // VIEWER / SERVER
 // ============================================================================

--- a/src/core/analyzer/spec-vector-index.ts
+++ b/src/core/analyzer/spec-vector-index.ts
@@ -195,6 +195,59 @@ function buildText(domain: string, section: ParsedSection): string {
 }
 
 // ============================================================================
+// ADR PARSER
+// ============================================================================
+
+interface AdrRecord {
+  id: string;
+  domain: string;
+  section: string;
+  title: string;
+  text: string;
+  linkedFiles: string;
+}
+
+async function findAdrFiles(decisionsDir: string): Promise<string[]> {
+  if (!(await fileExists(decisionsDir))) return [];
+  try {
+    const entries = await readdir(decisionsDir);
+    return entries
+      .filter((f) => /^adr-\d+.*\.md$/i.test(f))
+      .map((f) => join(decisionsDir, f));
+  } catch {
+    return [];
+  }
+}
+
+async function parseAdrFiles(decisionsDir: string): Promise<AdrRecord[]> {
+  const files = await findAdrFiles(decisionsDir);
+  const records: AdrRecord[] = [];
+
+  for (const filePath of files) {
+    try {
+      const content = await readFile(filePath, 'utf-8');
+      const titleMatch = content.match(/^#\s+(ADR-\d+):\s+(.+)$/m);
+      if (!titleMatch) continue;
+      const adrNum = titleMatch[1];
+      const title = titleMatch[2].trim();
+
+      records.push({
+        id: `decisions.${adrNum.toLowerCase()}`,
+        domain: 'decisions',
+        section: adrNum,
+        title: `${adrNum}: ${title}`,
+        text: `[decision] ${adrNum}: ${title}\n${content}`,
+        linkedFiles: '[]',
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  return records;
+}
+
+// ============================================================================
 // SPEC VECTOR INDEX
 // ============================================================================
 
@@ -211,7 +264,8 @@ export class SpecVectorIndex {
     outputDir: string,
     specsDir: string,
     embedSvc: EmbeddingService,
-    mappingJsonPath?: string
+    mappingJsonPath?: string,
+    decisionsDir?: string
   ): Promise<{ recordCount: number }> {
     const { connect } = await import('@lancedb/lancedb');
 
@@ -266,6 +320,12 @@ export class SpecVectorIndex {
           linkedFiles: JSON.stringify(linkedFiles),
         });
       }
+    }
+
+    // Also index ADR files from openspec/decisions/ if decisionsDir provided
+    if (decisionsDir) {
+      const adrRecords = await parseAdrFiles(decisionsDir);
+      records.push(...adrRecords);
     }
 
     if (records.length === 0) {

--- a/src/core/decisions/consolidator.test.ts
+++ b/src/core/decisions/consolidator.test.ts
@@ -292,4 +292,34 @@ describe('consolidateDrafts — ID reuse', () => {
     const parsed = JSON.parse(call.userPrompt as string);
     expect(parsed.existing).toHaveLength(0);
   });
+
+  it('maps scope from LLM response onto PendingDecision.scope', async () => {
+    const response = JSON.stringify([{
+      title: 'Cross-service auth contract',
+      rationale: 'JWT validated by both API and worker',
+      consequences: 'Shared secret required',
+      affectedDomains: ['api'],
+      affectedFiles: ['src/auth.ts'],
+      proposedRequirement: null,
+      supersededIds: [],
+      scope: 'cross-domain',
+    }]);
+    const { decisions } = await consolidateDrafts(makeStore([{ title: 'Auth draft' }]), makeLLM(response));
+    expect(decisions[0].scope).toBe('cross-domain');
+  });
+
+  it('defaults scope to component when LLM omits the field', async () => {
+    const response = JSON.stringify([{
+      title: 'Use retry helper',
+      rationale: 'Shared retry logic',
+      consequences: 'None',
+      affectedDomains: ['api'],
+      affectedFiles: ['src/retry.ts'],
+      proposedRequirement: null,
+      supersededIds: [],
+      // no scope field
+    }]);
+    const { decisions } = await consolidateDrafts(makeStore([{ title: 'Retry draft' }]), makeLLM(response));
+    expect(decisions[0].scope).toBe('component');
+  });
 });

--- a/src/core/decisions/consolidator.test.ts
+++ b/src/core/decisions/consolidator.test.ts
@@ -23,26 +23,33 @@ function makeLLM(response: string): LLMService {
   } as unknown as LLMService;
 }
 
-function makeStore(drafts: Partial<PendingDecision>[] = []): DecisionStore {
+function makeDecision(overrides: Partial<PendingDecision> = {}, index = 0): PendingDecision {
+  return {
+    id: `draft${String(index).padStart(4, '0')}`,
+    status: 'draft' as const,
+    title: `Decision ${index}`,
+    rationale: 'Some rationale',
+    consequences: 'Some consequences',
+    proposedRequirement: null,
+    affectedDomains: ['api'],
+    affectedFiles: [],
+    sessionId: 'sess001aabbcc',
+    recordedAt: '2026-01-01T00:00:00.000Z',
+    confidence: 'medium' as const,
+    syncedToSpecs: [],
+    ...overrides,
+  };
+}
+
+function makeStore(drafts: Partial<PendingDecision>[] = [], extra: PendingDecision[] = []): DecisionStore {
   return {
     version: '1',
     sessionId: 'sess001aabbcc',
     updatedAt: '2026-01-01T00:00:00.000Z',
-    decisions: drafts.map((d, i) => ({
-      id: `draft${String(i).padStart(4, '0')}`,
-      status: 'draft' as const,
-      title: `Decision ${i}`,
-      rationale: 'Some rationale',
-      consequences: 'Some consequences',
-      proposedRequirement: null,
-      affectedDomains: ['api'],
-      affectedFiles: [],
-      sessionId: 'sess001aabbcc',
-      recordedAt: '2026-01-01T00:00:00.000Z',
-      confidence: 'medium' as const,
-      syncedToSpecs: [],
-      ...d,
-    })),
+    decisions: [
+      ...drafts.map((d, i) => makeDecision({ status: 'draft', ...d }, i)),
+      ...extra,
+    ],
   };
 }
 
@@ -200,5 +207,89 @@ describe('consolidateDrafts — consolidation warning', () => {
     const store = makeStore([{ title: 'Draft' }]);
     await consolidateDrafts(store, llm);
     expect(vi.mocked(logger.warning)).toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// ID reuse — traceability across consolidation runs
+// ============================================================================
+
+describe('consolidateDrafts — ID reuse', () => {
+  const existingDecision = makeDecision(
+    { id: 'abc12345', status: 'approved', title: 'Use Redis for caching' },
+  );
+
+  it('reuses existing decision ID when LLM returns it in response', async () => {
+    const responseWithId = JSON.stringify([{
+      id: 'abc12345',
+      title: 'Use Redis for caching',
+      rationale: 'Reduces DB load',
+      consequences: 'Cache invalidation needed',
+      affectedDomains: ['cache'],
+      affectedFiles: ['src/cache.ts'],
+      proposedRequirement: null,
+      supersededIds: [],
+    }]);
+    const llm = makeLLM(responseWithId);
+    const store = makeStore([{ title: 'Draft about caching' }], [existingDecision]);
+    const { decisions } = await consolidateDrafts(store, llm);
+    expect(decisions[0].id).toBe('abc12345');
+  });
+
+  it('ignores LLM-supplied ID when it does not match any existing decision', async () => {
+    const responseWithFakeId = JSON.stringify([{
+      id: 'deadbeef',
+      title: 'Use Redis for caching',
+      rationale: 'Reduces DB load',
+      consequences: 'Cache invalidation needed',
+      affectedDomains: ['cache'],
+      affectedFiles: ['src/cache.ts'],
+      proposedRequirement: null,
+      supersededIds: [],
+    }]);
+    const llm = makeLLM(responseWithFakeId);
+    const store = makeStore([{ title: 'Draft about caching' }], [existingDecision]);
+    const { decisions } = await consolidateDrafts(store, llm);
+    expect(decisions[0].id).not.toBe('deadbeef');
+    expect(decisions[0].id).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('mints new ID when LLM omits id field (genuinely new decision)', async () => {
+    const responseNoId = JSON.stringify([{
+      title: 'Use Kafka for events',
+      rationale: 'Async processing',
+      consequences: 'Ops complexity',
+      affectedDomains: ['events'],
+      affectedFiles: ['src/events.ts'],
+      proposedRequirement: null,
+      supersededIds: [],
+    }]);
+    const llm = makeLLM(responseNoId);
+    const store = makeStore([{ title: 'Draft about events' }], [existingDecision]);
+    const { decisions } = await consolidateDrafts(store, llm);
+    expect(decisions[0].id).not.toBe('abc12345');
+    expect(decisions[0].id).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('includes existing non-draft decisions in LLM user prompt', async () => {
+    const llm = makeLLM('[]');
+    const store = makeStore([{ title: 'Draft A' }], [existingDecision]);
+    await consolidateDrafts(store, llm);
+    const call = vi.mocked(llm.complete).mock.calls[0][0];
+    const parsed = JSON.parse(call.userPrompt as string);
+    expect(parsed.existing).toHaveLength(1);
+    expect(parsed.existing[0].id).toBe('abc12345');
+    expect(parsed.drafts).toHaveLength(1);
+  });
+
+  it('excludes rejected and phantom decisions from existing set passed to LLM', async () => {
+    const rejected = makeDecision({ id: 'rej00001', status: 'rejected', title: 'Rejected decision' });
+    const phantom = makeDecision({ id: 'pht00001', status: 'phantom', title: 'Phantom decision' });
+    const llm = makeLLM('[]');
+    const store = makeStore([{ title: 'Draft A' }], [rejected, phantom]);
+    await consolidateDrafts(store, llm);
+    const call = vi.mocked(llm.complete).mock.calls[0][0];
+    const parsed = JSON.parse(call.userPrompt as string);
+    expect(parsed.existing).toHaveLength(0);
   });
 });

--- a/src/core/decisions/consolidator.ts
+++ b/src/core/decisions/consolidator.ts
@@ -17,7 +17,7 @@ import { matchFileToDomains } from '../drift/spec-mapper.js';
 
 const SYSTEM_PROMPT = `You are an architectural decision consolidator for a software project.
 
-You receive a list of architectural decision drafts recorded by an AI agent during a coding session. Some decisions may contradict each other or be superseded by later decisions. Your task is to produce a clean, consolidated set representing the final architectural state after the session.
+You receive a list of architectural decision drafts recorded by an AI agent during a coding session, plus the set of decisions already recorded in prior sessions (with their stable IDs). Some decisions may contradict each other or be superseded by later decisions. Your task is to produce a clean, consolidated set representing the final architectural state after the session.
 
 Rules:
 - Keep only decisions that represent the FINAL state (most recent wins for contradictions)
@@ -26,6 +26,12 @@ Rules:
 - Typically produce 1-3 consolidated decisions; never more than 5
 - Preserve the original rationale and consequences from the drafts
 - proposedRequirement should be a single sentence starting with "The system SHALL", or null
+
+ID REUSE (critical for traceability):
+- If a consolidated decision covers the same concept as an existing decision (provided in the "existing" section of the input), set "id" to that decision's exact ID string
+- Only reuse an ID if you are confident the concept is the same — same architectural choice, same affected area
+- If the consolidated decision is genuinely new, omit "id" entirely
+- Never invent a new ID — either reuse an existing one or omit the field
 
 Keep a decision if it describes ANY of:
 - A new feature, command, flag, or capability added to the system
@@ -44,6 +50,7 @@ Bad examples: "Use TypeScript interfaces for type safety", "Add error handling",
 
 Respond with a JSON array only. Each element:
 {
+  "id": string (optional — only set when reusing an existing decision ID),
   "title": string,
   "rationale": string,
   "consequences": string,
@@ -56,6 +63,7 @@ Respond with a JSON array only. Each element:
 If there are genuinely no decisions worth keeping, return [].`;
 
 interface ConsolidatedRaw {
+  id?: string;
   title: string;
   rationale: string;
   consequences: string;
@@ -78,17 +86,29 @@ export async function consolidateDrafts(
   const drafts = store.decisions.filter((d) => d.status === 'draft');
   if (drafts.length === 0) return { decisions: [], supersededIds: [] };
 
+  // Non-draft decisions passed to LLM so it can reuse their IDs when the same concept recurs.
+  const existing = store.decisions.filter((d) => d.status !== 'draft' && d.status !== 'rejected' && d.status !== 'phantom');
+  const existingIds = new Set(existing.map((d) => d.id));
+
   const userContent = JSON.stringify(
-    drafts.map((d) => ({
-      id: d.id,
-      title: d.title,
-      rationale: d.rationale,
-      consequences: d.consequences,
-      affectedDomains: d.affectedDomains,
-      affectedFiles: d.affectedFiles,
-      supersedes: d.supersedes,
-      recordedAt: d.recordedAt,
-    })),
+    {
+      drafts: drafts.map((d) => ({
+        id: d.id,
+        title: d.title,
+        rationale: d.rationale,
+        consequences: d.consequences,
+        affectedDomains: d.affectedDomains,
+        affectedFiles: d.affectedFiles,
+        supersedes: d.supersedes,
+        recordedAt: d.recordedAt,
+      })),
+      existing: existing.map((d) => ({
+        id: d.id,
+        title: d.title,
+        rationale: d.rationale,
+        status: d.status,
+      })),
+    },
     null,
     2,
   );
@@ -115,8 +135,14 @@ export async function consolidateDrafts(
     // Falls back to LLM names if specMap is absent or files yield no match.
     const resolvedDomains = resolveDomainsFromFiles(c.affectedFiles, c.affectedDomains, specMap);
     const domain = resolvedDomains[0] ?? 'unknown';
+    // Prefer LLM-supplied ID when it matches a known existing decision — this is the
+    // traceability anchor that prevents duplicate IDs across consolidation runs.
+    const id =
+      c.id && existingIds.has(c.id)
+        ? c.id
+        : makeDecisionId(store.sessionId, domain, c.title);
     return {
-      id: makeDecisionId(store.sessionId, domain, c.title),
+      id,
       status: 'consolidated',
       title: c.title,
       rationale: c.rationale,

--- a/src/core/decisions/consolidator.ts
+++ b/src/core/decisions/consolidator.ts
@@ -10,7 +10,7 @@ import {
 } from '../../constants.js';
 import { logger } from '../../utils/logger.js';
 import type { LLMService } from '../services/llm-service.js';
-import type { PendingDecision, DecisionStore, SpecMap } from '../../types/index.js';
+import type { PendingDecision, DecisionStore, SpecMap, DecisionScope } from '../../types/index.js';
 import { makeDecisionId } from './store.js';
 import { parseJSON } from '../../utils/misc.js';
 import { matchFileToDomains } from '../drift/spec-mapper.js';
@@ -48,6 +48,23 @@ Only discard decisions that are ALL of:
 Good examples: "Move hook installation from decisions to setup command", "Use system prompt injection instead of tool-output blocking for completion guard", "Prefer local dist/cli/index.js over global spec-gen in pre-commit hook"
 Bad examples: "Use TypeScript interfaces for type safety", "Add error handling", "Follow existing service pattern"
 
+SCOPE CLASSIFICATION (required):
+Classify each consolidated decision with one of these scopes:
+- "local": single file, no cross-cutting concern (refactors, extractions, renames)
+- "component": single component/service/module, no cross-boundary contract impact
+- "cross-domain": touches multiple spec domains AND changes behavioral contracts or public interfaces
+- "system": global architectural constraint (auth strategy, data model, infra, API protocol)
+
+Only "cross-domain" and "system" decisions will generate ADR files. Be conservative.
+
+DO NOT classify as "cross-domain" when:
+- multiple files changed but within one logical module
+- helper utilities were extracted to a shared file
+- tests were updated alongside implementation
+- config/constants changed
+- middleware was added inside a single service
+- internal refactors touched shared code without changing contracts
+
 Respond with a JSON array only. Each element:
 {
   "id": string (optional — only set when reusing an existing decision ID),
@@ -57,7 +74,8 @@ Respond with a JSON array only. Each element:
   "affectedDomains": string[],
   "affectedFiles": string[],
   "proposedRequirement": string | null,
-  "supersededIds": string[]
+  "supersededIds": string[],
+  "scope": string
 }
 
 If there are genuinely no decisions worth keeping, return [].`;
@@ -71,6 +89,7 @@ interface ConsolidatedRaw {
   affectedFiles: string[];
   proposedRequirement: string | null;
   supersededIds: string[];
+  scope?: string;
 }
 
 export interface ConsolidateResult {
@@ -87,6 +106,9 @@ export async function consolidateDrafts(
   if (drafts.length === 0) return { decisions: [], supersededIds: [] };
 
   // Non-draft decisions passed to LLM so it can reuse their IDs when the same concept recurs.
+  // Includes 'synced' intentionally — if a synced concept resurfaces in a new session, the LLM
+  // should reuse the stable ID for traceability rather than minting a duplicate. Synced decisions
+  // are purged from the store after sync, so this set is empty in the common case.
   const existing = store.decisions.filter((d) => d.status !== 'draft' && d.status !== 'rejected' && d.status !== 'phantom');
   const existingIds = new Set(existing.map((d) => d.id));
 
@@ -150,6 +172,7 @@ export async function consolidateDrafts(
       proposedRequirement: c.proposedRequirement,
       affectedDomains: resolvedDomains,
       affectedFiles: c.affectedFiles,
+      scope: (c.scope as DecisionScope) ?? 'component',
       confidence: 'medium',
       sessionId: store.sessionId,
       recordedAt: now,

--- a/src/core/decisions/extractor.ts
+++ b/src/core/decisions/extractor.ts
@@ -18,7 +18,7 @@ import { getChangedFiles, getFileDiff, resolveBaseRef } from '../drift/git-diff.
 const execFileAsync = promisify(execFile);
 import { matchFileToDomains, getSpecContent } from '../drift/spec-mapper.js';
 import type { LLMService } from '../services/llm-service.js';
-import type { PendingDecision, SpecMap } from '../../types/index.js';
+import type { PendingDecision, SpecMap, DecisionScope } from '../../types/index.js';
 import { makeDecisionId } from './store.js';
 import { parseJSON } from '../../utils/misc.js';
 
@@ -34,13 +34,23 @@ Rules:
 - For trivial changes return []
 - proposedRequirement: one sentence in imperative form ("The system SHALL …"), or null
 
+SCOPE CLASSIFICATION (required):
+Each extraction call processes one spec domain at a time, so cross-domain scope cannot be
+determined here. Classify only within the local/component axis:
+- "local": single file, no cross-cutting concern (refactors, extractions, renames)
+- "component": this component/service/module, may affect its public interface
+
+Scope upgrade to "cross-domain" or "system" happens at consolidation time when the full
+session context across all domains is visible.
+
 Respond with a JSON array only. Each element:
 {
   "title": string,
   "rationale": string,
   "consequences": string,
   "affectedFiles": string[],
-  "proposedRequirement": string | null
+  "proposedRequirement": string | null,
+  "scope": string
 }`;
 
 interface ExtractedRaw {
@@ -49,6 +59,7 @@ interface ExtractedRaw {
   consequences: string;
   affectedFiles: string[];
   proposedRequirement: string | null;
+  scope?: string;
 }
 
 export interface ExtractFromDiffOptions {
@@ -161,6 +172,7 @@ export async function extractFromDiff(options: ExtractFromDiffOptions): Promise<
         rationale: e.rationale,
         consequences: e.consequences,
         proposedRequirement: e.proposedRequirement,
+        scope: (e.scope as DecisionScope) ?? 'component',
         affectedDomains: [domain],
         affectedFiles: e.affectedFiles.length ? e.affectedFiles : domainFiles.map((f) => f.path),
         sessionId,

--- a/src/core/decisions/store.test.ts
+++ b/src/core/decisions/store.test.ts
@@ -10,6 +10,7 @@ import {
   makeDecisionId,
   newSessionId,
   upsertDecisions,
+  replaceDecisions,
   patchDecision,
   getDecisionsByStatus,
   loadDecisionStore,
@@ -140,6 +141,53 @@ describe('upsertDecisions', () => {
     const store: DecisionStore = { ...emptyStore(), decisions: [d] };
     const result = upsertDecisions(store, []);
     expect(result.decisions).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// replaceDecisions
+// ============================================================================
+
+describe('replaceDecisions', () => {
+  it('adds new decisions to an empty store', () => {
+    const d = makeDecision({ id: 'aaaa0001' });
+    const store: DecisionStore = { ...emptyStore(), decisions: [] };
+    const result = replaceDecisions(store, [d]);
+    expect(result.decisions).toHaveLength(1);
+  });
+
+  it('overwrites an existing decision with the same id', () => {
+    const existing = makeDecision({ id: 'aaaa0001', status: 'rejected', title: 'Old' });
+    const incoming = makeDecision({ id: 'aaaa0001', status: 'verified', title: 'New' });
+    const store: DecisionStore = { ...emptyStore(), decisions: [existing] };
+    const result = replaceDecisions(store, [incoming]);
+    expect(result.decisions).toHaveLength(1);
+    expect(result.decisions[0].status).toBe('verified');
+    expect(result.decisions[0].title).toBe('New');
+  });
+
+  it('models the consolidation scenario: rejected draft replaced by verified', () => {
+    // Simulate: patchDecision marks draft rejected, then replaceDecisions overwrites with verified
+    const draft = makeDecision({ id: 'aaaa0001', status: 'draft', title: 'Use SQLite' });
+    let store: DecisionStore = { ...emptyStore(), decisions: [draft] };
+    store = patchDecision(store, 'aaaa0001', { status: 'rejected' });
+    expect(store.decisions[0].status).toBe('rejected');
+    // replaceDecisions must overwrite the rejected placeholder
+    const verified = makeDecision({ id: 'aaaa0001', status: 'verified', title: 'Use SQLite' });
+    store = replaceDecisions(store, [verified]);
+    expect(store.decisions).toHaveLength(1);
+    expect(store.decisions[0].status).toBe('verified');
+  });
+
+  it('preserves unrelated decisions when replacing a subset', () => {
+    const d1 = makeDecision({ id: 'aaaa0001', status: 'approved' });
+    const d2 = makeDecision({ id: 'bbbb0002', status: 'draft' });
+    const store: DecisionStore = { ...emptyStore(), decisions: [d1, d2] };
+    const replacement = makeDecision({ id: 'bbbb0002', status: 'verified' });
+    const result = replaceDecisions(store, [replacement]);
+    expect(result.decisions).toHaveLength(2);
+    expect(result.decisions.find(d => d.id === 'aaaa0001')?.status).toBe('approved');
+    expect(result.decisions.find(d => d.id === 'bbbb0002')?.status).toBe('verified');
   });
 });
 

--- a/src/core/decisions/store.test.ts
+++ b/src/core/decisions/store.test.ts
@@ -12,6 +12,7 @@ import {
   upsertDecisions,
   replaceDecisions,
   patchDecision,
+  purgeInactiveDecisions,
   getDecisionsByStatus,
   loadDecisionStore,
   saveDecisionStore,
@@ -188,6 +189,65 @@ describe('replaceDecisions', () => {
     expect(result.decisions).toHaveLength(2);
     expect(result.decisions.find(d => d.id === 'aaaa0001')?.status).toBe('approved');
     expect(result.decisions.find(d => d.id === 'bbbb0002')?.status).toBe('verified');
+  });
+});
+
+// ============================================================================
+// purgeInactiveDecisions
+// ============================================================================
+
+describe('purgeInactiveDecisions', () => {
+  it('removes synced decisions', () => {
+    const store: DecisionStore = {
+      ...emptyStore(),
+      decisions: [
+        makeDecision({ id: 'aaaa0001', status: 'synced' }),
+        makeDecision({ id: 'bbbb0002', status: 'approved' }),
+      ],
+    };
+    const result = purgeInactiveDecisions(store);
+    expect(result.decisions).toHaveLength(1);
+    expect(result.decisions[0].id).toBe('bbbb0002');
+  });
+
+  it('removes rejected and phantom decisions', () => {
+    const store: DecisionStore = {
+      ...emptyStore(),
+      decisions: [
+        makeDecision({ id: 'aaaa0001', status: 'rejected' }),
+        makeDecision({ id: 'bbbb0002', status: 'phantom' }),
+        makeDecision({ id: 'cccc0003', status: 'verified' }),
+      ],
+    };
+    const result = purgeInactiveDecisions(store);
+    expect(result.decisions).toHaveLength(1);
+    expect(result.decisions[0].id).toBe('cccc0003');
+  });
+
+  it('preserves all active statuses', () => {
+    const store: DecisionStore = {
+      ...emptyStore(),
+      decisions: [
+        makeDecision({ id: 'aaaa0001', status: 'draft' }),
+        makeDecision({ id: 'bbbb0002', status: 'consolidated' }),
+        makeDecision({ id: 'cccc0003', status: 'verified' }),
+        makeDecision({ id: 'dddd0004', status: 'approved' }),
+      ],
+    };
+    const result = purgeInactiveDecisions(store);
+    expect(result.decisions).toHaveLength(4);
+  });
+
+  it('returns empty decisions when all inactive', () => {
+    const store: DecisionStore = {
+      ...emptyStore(),
+      decisions: [
+        makeDecision({ id: 'aaaa0001', status: 'synced' }),
+        makeDecision({ id: 'bbbb0002', status: 'rejected' }),
+      ],
+    };
+    const result = purgeInactiveDecisions(store);
+    expect(result.decisions).toHaveLength(0);
   });
 });
 

--- a/src/core/decisions/store.ts
+++ b/src/core/decisions/store.ts
@@ -60,6 +60,20 @@ export function upsertDecisions(store: DecisionStore, incoming: PendingDecision[
   return { ...store, decisions: [...byId.values()] };
 }
 
+/**
+ * Merge incoming decisions into the store, always overwriting by id.
+ * Use this for consolidation output — consolidated decisions share IDs with
+ * their original drafts (makeDecisionId is deterministic), so upsertDecisions
+ * would silently no-op after patchDecision marks the originals rejected.
+ */
+export function replaceDecisions(store: DecisionStore, incoming: PendingDecision[]): DecisionStore {
+  const byId = new Map(store.decisions.map((d) => [d.id, d]));
+  for (const d of incoming) {
+    byId.set(d.id, d);
+  }
+  return { ...store, decisions: [...byId.values()] };
+}
+
 /** Patch a single decision by id. Returns the updated store (not yet saved). */
 export function patchDecision(
   store: DecisionStore,

--- a/src/core/decisions/store.ts
+++ b/src/core/decisions/store.ts
@@ -112,6 +112,14 @@ export const INACTIVE_STATUSES: ReadonlySet<DecisionStatus> = new Set([
   'rejected', 'synced', 'phantom',
 ]);
 
+/** Drop all inactive decisions — their content is already in ADRs / spec.md. */
+export function purgeInactiveDecisions(store: DecisionStore): DecisionStore {
+  return {
+    ...store,
+    decisions: store.decisions.filter((d) => !INACTIVE_STATUSES.has(d.status)),
+  };
+}
+
 /** Stable 8-char ID derived from session + domain + title. */
 export function makeDecisionId(sessionId: string, domain: string, title: string): string {
   return createHash('sha256').update(`${sessionId}:${domain}:${title}`).digest('hex').slice(0, 8);

--- a/src/core/decisions/store.ts
+++ b/src/core/decisions/store.ts
@@ -97,6 +97,21 @@ export function getDecisionCount(store: DecisionStore): number {
   return store.decisions.length;
 }
 
+/** Status blocks the commit gate until resolved. */
+export function isBlockingStatus(status: DecisionStatus): boolean {
+  return status === 'verified' || status === 'approved';
+}
+
+/** Status requires a --sync run before committing. */
+export function requiresSync(status: DecisionStatus): boolean {
+  return status === 'approved';
+}
+
+/** Statuses excluded from the "activeDecisions" gate guard. */
+export const INACTIVE_STATUSES: ReadonlySet<DecisionStatus> = new Set([
+  'rejected', 'synced', 'phantom',
+]);
+
 /** Stable 8-char ID derived from session + domain + title. */
 export function makeDecisionId(sessionId: string, domain: string, title: string): string {
   return createHash('sha256').update(`${sessionId}:${domain}:${title}`).digest('hex').slice(0, 8);

--- a/src/core/decisions/syncer.test.ts
+++ b/src/core/decisions/syncer.test.ts
@@ -211,7 +211,8 @@ describe('syncApprovedDecisions — filesystem writes', () => {
 
   it('skips decisions where domain not found in specMap (logs warning)', async () => {
     const { logger } = await import('../../utils/logger.js');
-    const decision = makeDecision({ affectedDomains: ['nonexistent-domain'] });
+    // scope: cross-domain so ADR is written despite missing spec domain
+    const decision = makeDecision({ affectedDomains: ['nonexistent-domain'], scope: 'cross-domain' });
     const store = makeStore([decision]);
     const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
 
@@ -222,7 +223,7 @@ describe('syncApprovedDecisions — filesystem writes', () => {
     });
 
     expect(result.synced).toHaveLength(1);
-    // ADR always written; no spec file written (domain missing)
+    // ADR written (cross-domain scope); no spec file written (domain missing)
     expect(result.modifiedSpecs).toHaveLength(1);
     expect(result.modifiedSpecs[0]).toMatch(/^openspec\/decisions\/adr-/);
     expect(logger.warning).toHaveBeenCalledWith(
@@ -310,10 +311,11 @@ describe('ADR creation — always writes ADR regardless of content', () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('creates ADR placeholder in dryRun for any decision', async () => {
+  it('creates ADR placeholder in dryRun for cross-domain decision', async () => {
     const decision = makeDecision({
       title: 'Add retry logic',
       rationale: 'Retry failed HTTP requests up to 3 times.',
+      scope: 'cross-domain',
     });
     const store = makeStore([decision]);
     const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
@@ -333,10 +335,11 @@ describe('ADR creation — always writes ADR regardless of content', () => {
     expect(result.modifiedSpecs.some((p) => p.startsWith('openspec/decisions/adr-'))).toBe(true);
   });
 
-  it('writes ADR file on disk for every approved decision', async () => {
+  it('writes ADR file on disk for cross-domain approved decision', async () => {
     const decision = makeDecision({
       title: 'Add retry logic',
       rationale: 'Retry failed HTTP requests up to 3 times.',
+      scope: 'cross-domain',
     });
     const store = makeStore([decision]);
     const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
@@ -357,8 +360,8 @@ describe('ADR creation — always writes ADR regardless of content', () => {
   });
 
   it('increments ADR number for each successive decision', async () => {
-    const d1 = makeDecision({ id: 'aaa00001', title: 'First decision' });
-    const d2 = makeDecision({ id: 'bbb00002', title: 'Second decision', status: 'approved' });
+    const d1 = makeDecision({ id: 'aaa00001', title: 'First decision', scope: 'cross-domain' });
+    const d2 = makeDecision({ id: 'bbb00002', title: 'Second decision', status: 'approved', scope: 'system' });
     const specDir = join(tmpDir, 'openspec', 'specs', 'services');
     await mkdir(specDir, { recursive: true });
     const { writeFile, readdir } = await import('node:fs/promises');
@@ -443,5 +446,75 @@ describe('appendDecisionSection via full sync', () => {
     // Only one ## Decisions header
     const occurrences = (content.match(/^## Decisions/gm) ?? []).length;
     expect(occurrences).toBe(1);
+  });
+});
+
+// ============================================================================
+// ADR scope gate — qualifiesForADR via syncApprovedDecisions
+// ============================================================================
+
+describe('ADR scope gate', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => { tmpDir = await createTempDir(); });
+  afterEach(async () => { await rm(tmpDir, { recursive: true, force: true }); });
+
+  async function syncWithScope(scope: PendingDecision['scope']): Promise<string[]> {
+    const specDir = join(tmpDir, 'openspec', 'specs', 'services');
+    await mkdir(specDir, { recursive: true });
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(join(specDir, 'spec.md'), MINIMAL_SPEC, 'utf-8');
+    const decision = makeDecision({ scope });
+    const { result } = await syncApprovedDecisions(makeStore([decision]), {
+      rootPath: tmpDir,
+      openspecPath: join(tmpDir, 'openspec'),
+      specMap: makeSpecMap('services', 'openspec/specs/services/spec.md'),
+      dryRun: true,
+    });
+    return result.modifiedSpecs;
+  }
+
+  it('cross-domain scope → ADR included in modifiedSpecs', async () => {
+    const specs = await syncWithScope('cross-domain');
+    expect(specs.some((p) => p.startsWith('openspec/decisions/adr-'))).toBe(true);
+  });
+
+  it('system scope → ADR included in modifiedSpecs', async () => {
+    const specs = await syncWithScope('system');
+    expect(specs.some((p) => p.startsWith('openspec/decisions/adr-'))).toBe(true);
+  });
+
+  it('component scope → no ADR in modifiedSpecs', async () => {
+    const specs = await syncWithScope('component');
+    expect(specs.some((p) => p.startsWith('openspec/decisions/adr-'))).toBe(false);
+  });
+
+  it('local scope → no ADR in modifiedSpecs', async () => {
+    const specs = await syncWithScope('local');
+    expect(specs.some((p) => p.startsWith('openspec/decisions/adr-'))).toBe(false);
+  });
+
+  it('undefined scope (backward compat) → no ADR in modifiedSpecs', async () => {
+    const specs = await syncWithScope(undefined);
+    expect(specs.some((p) => p.startsWith('openspec/decisions/adr-'))).toBe(false);
+  });
+
+  it('component scope → still syncs to spec file', async () => {
+    const specs = await syncWithScope('component');
+    expect(specs).toContain('openspec/specs/services/spec.md');
+  });
+
+  it('system scope writes ADR file on disk', async () => {
+    const specDir = join(tmpDir, 'openspec', 'specs', 'services');
+    await mkdir(specDir, { recursive: true });
+    const { writeFile, readdir } = await import('node:fs/promises');
+    await writeFile(join(specDir, 'spec.md'), MINIMAL_SPEC, 'utf-8');
+    await syncApprovedDecisions(makeStore([makeDecision({ scope: 'system' })]), {
+      rootPath: tmpDir,
+      openspecPath: join(tmpDir, 'openspec'),
+      specMap: makeSpecMap('services', 'openspec/specs/services/spec.md'),
+    });
+    const files = await readdir(join(tmpDir, 'openspec', 'decisions'));
+    expect(files.some((f) => f.startsWith('adr-'))).toBe(true);
   });
 });

--- a/src/core/decisions/syncer.test.ts
+++ b/src/core/decisions/syncer.test.ts
@@ -268,6 +268,31 @@ describe('syncApprovedDecisions — filesystem writes', () => {
 
     expect(result.synced).toHaveLength(0);
   });
+
+  it('purges inactive decisions from store before saving', async () => {
+    const { saveDecisionStore } = await import('./store.js');
+    const approved = makeDecision({ id: 'app00001', status: 'approved', affectedDomains: ['services'] });
+    const rejected = makeDecision({ id: 'rej00001', status: 'rejected' });
+    const synced = makeDecision({ id: 'syn00001', status: 'synced' });
+    const verified = makeDecision({ id: 'ver00001', status: 'verified' });
+    const store = makeStore([approved, rejected, synced, verified]);
+    const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
+
+    await syncApprovedDecisions(store, {
+      rootPath: tmpDir,
+      openspecPath: join(tmpDir, 'openspec'),
+      specMap,
+    });
+
+    const saved = vi.mocked(saveDecisionStore).mock.calls.at(-1)?.[1];
+    expect(saved).toBeDefined();
+    const ids = saved!.decisions.map((d) => d.id);
+    // rejected + synced (original) purged; newly-synced approved also purged; verified kept
+    expect(ids).not.toContain('rej00001');
+    expect(ids).not.toContain('syn00001');
+    expect(ids).not.toContain('app00001');
+    expect(ids).toContain('ver00001');
+  });
 });
 
 // ============================================================================

--- a/src/core/decisions/syncer.test.ts
+++ b/src/core/decisions/syncer.test.ts
@@ -222,7 +222,9 @@ describe('syncApprovedDecisions — filesystem writes', () => {
     });
 
     expect(result.synced).toHaveLength(1);
-    expect(result.modifiedSpecs).toHaveLength(0);
+    // ADR always written; no spec file written (domain missing)
+    expect(result.modifiedSpecs).toHaveLength(1);
+    expect(result.modifiedSpecs[0]).toMatch(/^openspec\/decisions\/adr-/);
     expect(logger.warning).toHaveBeenCalledWith(
       expect.stringContaining('nonexistent-domain'),
     );
@@ -269,10 +271,10 @@ describe('syncApprovedDecisions — filesystem writes', () => {
 });
 
 // ============================================================================
-// isArchitectural — 2-keyword threshold
+// ADR creation — always writes an ADR for every synced decision
 // ============================================================================
 
-describe('isArchitectural — exported via dryRun ADR path', () => {
+describe('ADR creation — always writes ADR regardless of content', () => {
   let tmpDir: string;
 
   beforeEach(async () => {
@@ -283,32 +285,7 @@ describe('isArchitectural — exported via dryRun ADR path', () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
-  it('creates ADR placeholder in dryRun for architectural decisions', async () => {
-    // "authentication" + "database" — 2 keywords → architectural
-    const decision = makeDecision({
-      title: 'Authentication database schema',
-      rationale: 'We chose PostgreSQL for authentication and database storage.',
-    });
-    const store = makeStore([decision]);
-    const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
-
-    const specDir = join(tmpDir, 'openspec', 'specs', 'services');
-    await mkdir(specDir, { recursive: true });
-    const { writeFile } = await import('node:fs/promises');
-    await writeFile(join(specDir, 'spec.md'), MINIMAL_SPEC, 'utf-8');
-
-    const { result } = await syncApprovedDecisions(store, {
-      rootPath: tmpDir,
-      openspecPath: join(tmpDir, 'openspec'),
-      specMap,
-      dryRun: true,
-    });
-
-    expect(result.modifiedSpecs.some((p) => p.startsWith('openspec/decisions/adr-'))).toBe(true);
-  });
-
-  it('does not create ADR for non-architectural decisions', async () => {
-    // No keyword matches at all
+  it('creates ADR placeholder in dryRun for any decision', async () => {
     const decision = makeDecision({
       title: 'Add retry logic',
       rationale: 'Retry failed HTTP requests up to 3 times.',
@@ -328,31 +305,54 @@ describe('isArchitectural — exported via dryRun ADR path', () => {
       dryRun: true,
     });
 
-    expect(result.modifiedSpecs.every((p) => !p.startsWith('openspec/decisions/adr-'))).toBe(true);
+    expect(result.modifiedSpecs.some((p) => p.startsWith('openspec/decisions/adr-'))).toBe(true);
   });
 
-  it('requires 2 keyword matches — single match is not architectural', async () => {
-    // Only "authentication" — 1 keyword → not architectural
+  it('writes ADR file on disk for every approved decision', async () => {
     const decision = makeDecision({
-      title: 'Add authentication endpoint',
-      rationale: 'Standard JWT-based login flow.',
+      title: 'Add retry logic',
+      rationale: 'Retry failed HTTP requests up to 3 times.',
     });
     const store = makeStore([decision]);
     const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
 
     const specDir = join(tmpDir, 'openspec', 'specs', 'services');
     await mkdir(specDir, { recursive: true });
-    const { writeFile } = await import('node:fs/promises');
+    const { writeFile, readdir } = await import('node:fs/promises');
     await writeFile(join(specDir, 'spec.md'), MINIMAL_SPEC, 'utf-8');
 
-    const { result } = await syncApprovedDecisions(store, {
+    await syncApprovedDecisions(store, {
       rootPath: tmpDir,
       openspecPath: join(tmpDir, 'openspec'),
       specMap,
-      dryRun: true,
     });
 
-    expect(result.modifiedSpecs.every((p) => !p.startsWith('openspec/decisions/adr-'))).toBe(true);
+    const files = await readdir(join(tmpDir, 'openspec', 'decisions'));
+    expect(files.some((f) => f.startsWith('adr-'))).toBe(true);
+  });
+
+  it('increments ADR number for each successive decision', async () => {
+    const d1 = makeDecision({ id: 'aaa00001', title: 'First decision' });
+    const d2 = makeDecision({ id: 'bbb00002', title: 'Second decision', status: 'approved' });
+    const specDir = join(tmpDir, 'openspec', 'specs', 'services');
+    await mkdir(specDir, { recursive: true });
+    const { writeFile, readdir } = await import('node:fs/promises');
+    await writeFile(join(specDir, 'spec.md'), MINIMAL_SPEC, 'utf-8');
+    const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
+
+    // Sync first
+    await syncApprovedDecisions(makeStore([d1]), {
+      rootPath: tmpDir, openspecPath: join(tmpDir, 'openspec'), specMap,
+    });
+    // Sync second
+    await syncApprovedDecisions(makeStore([d2]), {
+      rootPath: tmpDir, openspecPath: join(tmpDir, 'openspec'), specMap,
+    });
+
+    const files = await readdir(join(tmpDir, 'openspec', 'decisions'));
+    expect(files.filter((f) => f.startsWith('adr-'))).toHaveLength(2);
+    expect(files.some((f) => f.startsWith('adr-0001-'))).toBe(true);
+    expect(files.some((f) => f.startsWith('adr-0002-'))).toBe(true);
   });
 });
 

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -11,8 +11,19 @@ import { join } from 'node:path';
 import { fileExists } from '../../utils/command-helpers.js';
 import { logger } from '../../utils/logger.js';
 import { parseSpecHeader } from '../drift/spec-mapper.js';
-import type { PendingDecision, DecisionStore, SpecMap } from '../../types/index.js';
+import type { PendingDecision, DecisionStore, SpecMap, DecisionScope } from '../../types/index.js';
 import { patchDecision, purgeInactiveDecisions, saveDecisionStore } from './store.js';
+
+/**
+ * ADRs are durable architectural memory, not a log of every implementation choice.
+ * Only cross-domain and system decisions are persisted as ADRs to avoid semantic
+ * dilution and retrieval pollution in the vector index.
+ */
+const ADR_SCOPES = new Set<DecisionScope>(['cross-domain', 'system']);
+
+function qualifiesForADR(decision: PendingDecision): boolean {
+  return ADR_SCOPES.has(decision.scope ?? 'component');
+}
 
 export interface SyncOptions {
   rootPath: string;
@@ -55,6 +66,10 @@ export async function syncApprovedDecisions(
   }
 
   if (!options.dryRun) {
+    // Purge happens only after all per-decision syncs complete (errors kept in store).
+    // Invariant: store and ADR files agree — a decision is removed from store only after
+    // status='synced', which is set only after spec + ADR writes succeed (or are skipped).
+    // Partial failure leaves the decision in store at status='approved', safe to retry.
     await saveDecisionStore(options.rootPath, purgeInactiveDecisions(updatedStore));
   }
 
@@ -88,13 +103,14 @@ async function syncDecision(
     }
   }
 
-  // Every approved decision gets an ADR — significance filtering happens at record time via the LLM extractor.
-  if (options.dryRun) {
-    const slug = toKebabCase(decision.title);
-    modified.push(`openspec/decisions/adr-XXXX-${slug}.md`);
-  } else {
-    const adrPath = await createADR(decision, options);
-    if (adrPath) modified.push(adrPath);
+  if (qualifiesForADR(decision)) {
+    if (options.dryRun) {
+      const slug = toKebabCase(decision.title);
+      modified.push(`openspec/decisions/adr-XXXX-${slug}.md`);
+    } else {
+      const adrPath = await createADR(decision, options);
+      if (adrPath) modified.push(adrPath);
+    }
   }
 
   return modified;

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -88,6 +88,7 @@ async function syncDecision(
     }
   }
 
+  // Every approved decision gets an ADR — significance filtering happens at record time via the LLM extractor.
   if (options.dryRun) {
     const slug = toKebabCase(decision.title);
     modified.push(`openspec/decisions/adr-XXXX-${slug}.md`);

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -12,7 +12,7 @@ import { fileExists } from '../../utils/command-helpers.js';
 import { logger } from '../../utils/logger.js';
 import { parseSpecHeader } from '../drift/spec-mapper.js';
 import type { PendingDecision, DecisionStore, SpecMap } from '../../types/index.js';
-import { patchDecision, saveDecisionStore } from './store.js';
+import { patchDecision, purgeInactiveDecisions, saveDecisionStore } from './store.js';
 
 export interface SyncOptions {
   rootPath: string;
@@ -55,7 +55,7 @@ export async function syncApprovedDecisions(
   }
 
   if (!options.dryRun) {
-    await saveDecisionStore(options.rootPath, updatedStore);
+    await saveDecisionStore(options.rootPath, purgeInactiveDecisions(updatedStore));
   }
 
   return {

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -88,14 +88,12 @@ async function syncDecision(
     }
   }
 
-  if (isArchitectural(decision)) {
-    if (options.dryRun) {
-      const slug = toKebabCase(decision.title);
-      modified.push(`openspec/decisions/adr-XXXX-${slug}.md`);
-    } else {
-      const adrPath = await createADR(decision, options);
-      if (adrPath) modified.push(adrPath);
-    }
+  if (options.dryRun) {
+    const slug = toKebabCase(decision.title);
+    modified.push(`openspec/decisions/adr-XXXX-${slug}.md`);
+  } else {
+    const adrPath = await createADR(decision, options);
+    if (adrPath) modified.push(adrPath);
   }
 
   return modified;
@@ -234,28 +232,6 @@ ${decision.consequences}
 
   await writeFile(adrPath, content, 'utf-8');
   return `openspec/decisions/${filename}`;
-}
-
-function isArchitectural(decision: PendingDecision): boolean {
-  // Require at least 2 keyword matches across title + rationale to avoid ADR explosion.
-  // Broad terms like "api" or "service" alone are too common; structural weight matters.
-  const keywords = [
-    /\barchitect(ure|ural)?\b/i,
-    /\bdesign pattern\b/i,
-    /\binterface contract\b/i,
-    /\bpublic api\b/i,
-    /\bschema\b/i,
-    /\bframework\b/i,
-    /\bdependency\b/i,
-    /\blayer(ing|ed)?\b/i,
-    /\bauthentication\b|\bauthorization\b/i,
-    /\bdatabase\b|\bdata store\b/i,
-    /\bcaching strategy\b/i,
-    /\bmessage queue\b|\bevent bus\b/i,
-  ];
-  const combined = `${decision.title} ${decision.rationale}`;
-  const matches = keywords.filter((re) => re.test(combined)).length;
-  return matches >= 2;
 }
 
 function toPascalCase(str: string): string {

--- a/src/core/services/edge-store.ts
+++ b/src/core/services/edge-store.ts
@@ -4,6 +4,7 @@ import { DatabaseSync, type StatementSync } from 'node:sqlite';
 import type { CallEdge, FunctionNode, ClassNode, InheritanceEdge } from '../analyzer/call-graph.js';
 import { ARTIFACT_CALL_GRAPH_DB } from '../../constants.js';
 
+
 function openDatabase(dbPath: string): DatabaseSync {
   const db = new DatabaseSync(dbPath);
   db.exec('PRAGMA journal_mode = WAL');

--- a/src/core/services/edge-store.ts
+++ b/src/core/services/edge-store.ts
@@ -1,25 +1,52 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { createRequire } from 'node:module';
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
 import type { CallEdge, FunctionNode, ClassNode, InheritanceEdge } from '../analyzer/call-graph.js';
 import { ARTIFACT_CALL_GRAPH_DB } from '../../constants.js';
 
-const require = createRequire(import.meta.url);
-
-function openDatabase(dbPath: string): import('better-sqlite3').Database {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const DatabaseCtor = require('better-sqlite3') as any;
-  const db: import('better-sqlite3').Database = new DatabaseCtor(dbPath) as import('better-sqlite3').Database;
-  db.pragma('journal_mode = WAL');
-  db.pragma('synchronous = NORMAL');
+function openDatabase(dbPath: string): DatabaseSync {
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA journal_mode = WAL');
+  db.exec('PRAGMA synchronous = NORMAL');
   return db;
+}
+
+// Track nesting depth per db instance to support nested transactions via SAVEPOINT
+const txDepth = new WeakMap<DatabaseSync, number>();
+
+function runTransaction(db: DatabaseSync, fn: () => void): void {
+  const depth = txDepth.get(db) ?? 0;
+  const sp = `sp${depth}`;
+  if (depth === 0) {
+    db.exec('BEGIN');
+  } else {
+    db.exec(`SAVEPOINT ${sp}`);
+  }
+  txDepth.set(db, depth + 1);
+  try {
+    fn();
+    if (depth === 0) {
+      db.exec('COMMIT');
+    } else {
+      db.exec(`RELEASE ${sp}`);
+    }
+  } catch (err) {
+    if (depth === 0) {
+      db.exec('ROLLBACK');
+    } else {
+      db.exec(`ROLLBACK TO ${sp}`);
+    }
+    throw err;
+  } finally {
+    txDepth.set(db, depth);
+  }
 }
 
 /** Bump when schema changes. Old DBs are dropped and rebuilt on next analyze --force. */
 const SCHEMA_VERSION = 2;
 
 export class EdgeStore {
-  private constructor(private readonly db: import('better-sqlite3').Database) {
+  private constructor(private readonly db: DatabaseSync) {
     this.initSchema();
   }
 
@@ -119,17 +146,17 @@ export class EdgeStore {
   getCallerFiles(calleeFile: string): string[] {
     const rows = this.db
       .prepare('SELECT DISTINCT caller_file FROM edges WHERE callee_file = ?')
-      .all(calleeFile) as Array<{ caller_file: string }>;
+      .all(calleeFile) as unknown as Array<{ caller_file: string }>;
     return rows.map(r => r.caller_file);
   }
 
   /** All outgoing + incoming edges touching a file. */
   getEdgesForFile(file: string): { outgoing: CallEdge[]; incoming: CallEdge[] } {
     const outgoing = (
-      this.db.prepare('SELECT * FROM edges WHERE caller_file = ?').all(file) as RawEdge[]
+      this.db.prepare('SELECT * FROM edges WHERE caller_file = ?').all(file) as unknown as RawEdge[]
     ).map(rawToCallEdge);
     const incoming = (
-      this.db.prepare('SELECT * FROM edges WHERE callee_file = ?').all(file) as RawEdge[]
+      this.db.prepare('SELECT * FROM edges WHERE callee_file = ?').all(file) as unknown as RawEdge[]
     ).map(rawToCallEdge);
     return { outgoing, incoming };
   }
@@ -137,14 +164,14 @@ export class EdgeStore {
   /** Outgoing edges from a node ID (its direct callees). */
   getCallees(nodeId: string): CallEdge[] {
     return (
-      this.db.prepare('SELECT * FROM edges WHERE caller_id = ?').all(nodeId) as RawEdge[]
+      this.db.prepare('SELECT * FROM edges WHERE caller_id = ?').all(nodeId) as unknown as RawEdge[]
     ).map(rawToCallEdge);
   }
 
   /** Incoming edges to a node ID (its direct callers). */
   getCallers(nodeId: string): CallEdge[] {
     return (
-      this.db.prepare('SELECT * FROM edges WHERE callee_id = ?').all(nodeId) as RawEdge[]
+      this.db.prepare('SELECT * FROM edges WHERE callee_id = ?').all(nodeId) as unknown as RawEdge[]
     ).map(rawToCallEdge);
   }
 
@@ -153,7 +180,7 @@ export class EdgeStore {
     if (callerIds.length === 0) return [];
     const placeholders = callerIds.map(() => '?').join(',');
     return (
-      this.db.prepare(`SELECT * FROM edges WHERE caller_id IN (${placeholders})`).all(...callerIds) as RawEdge[]
+      this.db.prepare(`SELECT * FROM edges WHERE caller_id IN (${placeholders})`).all(...callerIds) as unknown as RawEdge[]
     ).map(rawToCallEdge);
   }
 
@@ -162,7 +189,7 @@ export class EdgeStore {
     if (calleeIds.length === 0) return [];
     const placeholders = calleeIds.map(() => '?').join(',');
     return (
-      this.db.prepare(`SELECT * FROM edges WHERE callee_id IN (${placeholders})`).all(...calleeIds) as RawEdge[]
+      this.db.prepare(`SELECT * FROM edges WHERE callee_id IN (${placeholders})`).all(...calleeIds) as unknown as RawEdge[]
     ).map(rawToCallEdge);
   }
 
@@ -180,41 +207,39 @@ export class EdgeStore {
 
   /** Bulk-insert edges in a single transaction. */
   insertEdges(edges: CallEdge[]): void {
-    const stmt = this.db.prepare(`
+    const stmt: StatementSync = this.db.prepare(`
       INSERT INTO edges (caller_id, caller_file, callee_id, callee_file, callee_name, line, confidence, kind, call_type)
       VALUES (@callerId, @callerFile, @calleeId, @calleeFile, @calleeName, @line, @confidence, @kind, @callType)
     `);
-    const insert = this.db.transaction((batch: CallEdge[]) => {
-      for (const e of batch) {
+    runTransaction(this.db, () => {
+      for (const e of edges) {
         const callerFile = e.callerId.includes('::') ? e.callerId.split('::')[0] : e.callerId;
         const calleeFile = e.calleeId.includes('::') ? e.calleeId.split('::')[0] : null;
         stmt.run({
-          callerId:   e.callerId,
-          callerFile,
-          calleeId:   e.calleeId,
-          calleeFile,
-          calleeName: e.calleeName,
-          line:       e.line ?? null,
-          confidence: e.confidence,
-          kind:       e.kind ?? null,
-          callType:   e.callType ?? null,
+          '@callerId':   e.callerId,
+          '@callerFile': callerFile,
+          '@calleeId':   e.calleeId,
+          '@calleeFile': calleeFile,
+          '@calleeName': e.calleeName,
+          '@line':       e.line ?? null,
+          '@confidence': e.confidence,
+          '@kind':       e.kind ?? null,
+          '@callType':   e.callType ?? null,
         });
       }
     });
-    insert(edges);
   }
 
   /** Bulk-insert inheritance edges in a single transaction. */
   insertInheritanceEdges(edges: InheritanceEdge[]): void {
-    const stmt = this.db.prepare(
+    const stmt: StatementSync = this.db.prepare(
       'INSERT INTO inheritance_edges (parent_id, child_id, kind) VALUES (@parentId, @childId, @kind)'
     );
-    const insert = this.db.transaction((batch: InheritanceEdge[]) => {
-      for (const e of batch) {
-        stmt.run({ parentId: e.parentId, childId: e.childId, kind: e.kind ?? null });
+    runTransaction(this.db, () => {
+      for (const e of edges) {
+        stmt.run({ '@parentId': e.parentId, '@childId': e.childId, '@kind': e.kind ?? null });
       }
     });
-    insert(edges);
   }
 
   // ── Node queries ──────────────────────────────────────────────────────────────
@@ -226,7 +251,7 @@ export class EdgeStore {
 
   getNodesForFile(file: string): FunctionNode[] {
     return (
-      this.db.prepare('SELECT * FROM nodes WHERE file_path = ?').all(file) as RawNode[]
+      this.db.prepare('SELECT * FROM nodes WHERE file_path = ?').all(file) as unknown as RawNode[]
     ).map(rawToFunctionNode);
   }
 
@@ -241,13 +266,13 @@ export class EdgeStore {
             WHERE nodes_fts MATCH ? AND n.is_external = 0
             LIMIT ?
           `)
-          .all(pattern, limit) as RawNode[]
+          .all(pattern, limit) as unknown as RawNode[]
       ).map(rawToFunctionNode);
     }
     return (
       this.db
         .prepare('SELECT * FROM nodes WHERE name LIKE ? AND is_external = 0 LIMIT ?')
-        .all(`%${pattern}%`, limit) as RawNode[]
+        .all(`%${pattern}%`, limit) as unknown as RawNode[]
     ).map(rawToFunctionNode);
   }
 
@@ -255,7 +280,7 @@ export class EdgeStore {
     return (
       this.db
         .prepare('SELECT * FROM nodes WHERE is_hub = 1 AND is_external = 0 ORDER BY fan_in DESC LIMIT ?')
-        .all(limit) as RawNode[]
+        .all(limit) as unknown as RawNode[]
     ).map(rawToFunctionNode);
   }
 
@@ -263,7 +288,7 @@ export class EdgeStore {
     return (
       this.db
         .prepare('SELECT * FROM nodes WHERE is_entry_point = 1 AND is_external = 0 ORDER BY fan_out DESC LIMIT ?')
-        .all(limit) as RawNode[]
+        .all(limit) as unknown as RawNode[]
     ).map(rawToFunctionNode);
   }
 
@@ -276,7 +301,7 @@ export class EdgeStore {
 
   deleteNodesForFile(file: string): void {
     const ids = (
-      this.db.prepare('SELECT id FROM nodes WHERE file_path = ?').all(file) as Array<{ id: string }>
+      this.db.prepare('SELECT id FROM nodes WHERE file_path = ?').all(file) as unknown as Array<{ id: string }>
     ).map(r => r.id);
     this.db.prepare('DELETE FROM nodes WHERE file_path = ?').run(file);
     if (ids.length > 0) {
@@ -290,7 +315,7 @@ export class EdgeStore {
    * omit them during incremental watcher updates (flags preserved from last analyze).
    */
   insertNodes(nodes: FunctionNode[], hubIds?: Set<string>, entryIds?: Set<string>): void {
-    const stmt = this.db.prepare(`
+    const stmt: StatementSync = this.db.prepare(`
       INSERT OR REPLACE INTO nodes
         (id, name, file_path, class_name, is_async, language, start_index, end_index,
          fan_in, fan_out, docstring, signature, is_external, external_kind, is_hub, is_entry_point)
@@ -298,31 +323,30 @@ export class EdgeStore {
         (@id, @name, @filePath, @className, @isAsync, @language, @startIndex, @endIndex,
          @fanIn, @fanOut, @docstring, @signature, @isExternal, @externalKind, @isHub, @isEntryPoint)
     `);
-    const ftsStmt = this.db.prepare('INSERT OR REPLACE INTO nodes_fts (node_id, name) VALUES (?, ?)');
-    const insert = this.db.transaction((batch: FunctionNode[]) => {
-      for (const n of batch) {
+    const ftsStmt: StatementSync = this.db.prepare('INSERT OR REPLACE INTO nodes_fts (node_id, name) VALUES (?, ?)');
+    runTransaction(this.db, () => {
+      for (const n of nodes) {
         stmt.run({
-          id:           n.id,
-          name:         n.name,
-          filePath:     n.filePath,
-          className:    n.className ?? null,
-          isAsync:      n.isAsync ? 1 : 0,
-          language:     n.language,
-          startIndex:   n.startIndex,
-          endIndex:     n.endIndex,
-          fanIn:        n.fanIn,
-          fanOut:       n.fanOut,
-          docstring:    n.docstring ?? null,
-          signature:    n.signature ?? null,
-          isExternal:   n.isExternal ? 1 : 0,
-          externalKind: n.externalKind ?? null,
-          isHub:        hubIds ? (hubIds.has(n.id) ? 1 : 0) : 0,
-          isEntryPoint: entryIds ? (entryIds.has(n.id) ? 1 : 0) : 0,
+          '@id':           n.id,
+          '@name':         n.name,
+          '@filePath':     n.filePath,
+          '@className':    n.className ?? null,
+          '@isAsync':      n.isAsync ? 1 : 0,
+          '@language':     n.language,
+          '@startIndex':   n.startIndex,
+          '@endIndex':     n.endIndex,
+          '@fanIn':        n.fanIn,
+          '@fanOut':       n.fanOut,
+          '@docstring':    n.docstring ?? null,
+          '@signature':    n.signature ?? null,
+          '@isExternal':   n.isExternal ? 1 : 0,
+          '@externalKind': n.externalKind ?? null,
+          '@isHub':        hubIds ? (hubIds.has(n.id) ? 1 : 0) : 0,
+          '@isEntryPoint': entryIds ? (entryIds.has(n.id) ? 1 : 0) : 0,
         });
         if (!n.isExternal) ftsStmt.run(n.id, n.name);
       }
     });
-    insert(nodes);
   }
 
   // ── Class queries ─────────────────────────────────────────────────────────────
@@ -334,7 +358,7 @@ export class EdgeStore {
 
   getClassesForFile(file: string): ClassNode[] {
     return (
-      this.db.prepare('SELECT * FROM classes WHERE file_path = ?').all(file) as RawClass[]
+      this.db.prepare('SELECT * FROM classes WHERE file_path = ?').all(file) as unknown as RawClass[]
     ).map(rawToClassNode);
   }
 
@@ -345,29 +369,28 @@ export class EdgeStore {
   }
 
   insertClasses(classes: ClassNode[]): void {
-    const stmt = this.db.prepare(`
+    const stmt: StatementSync = this.db.prepare(`
       INSERT OR REPLACE INTO classes
         (id, name, file_path, language, parent_classes, interfaces, method_ids, fan_in, fan_out, is_module)
       VALUES
         (@id, @name, @filePath, @language, @parentClasses, @interfaces, @methodIds, @fanIn, @fanOut, @isModule)
     `);
-    const insert = this.db.transaction((batch: ClassNode[]) => {
-      for (const c of batch) {
+    runTransaction(this.db, () => {
+      for (const c of classes) {
         stmt.run({
-          id:            c.id,
-          name:          c.name,
-          filePath:      c.filePath,
-          language:      c.language,
-          parentClasses: JSON.stringify(c.parentClasses),
-          interfaces:    JSON.stringify(c.interfaces),
-          methodIds:     JSON.stringify(c.methodIds),
-          fanIn:         c.fanIn,
-          fanOut:        c.fanOut,
-          isModule:      c.isModule ? 1 : 0,
+          '@id':            c.id,
+          '@name':          c.name,
+          '@filePath':      c.filePath,
+          '@language':      c.language,
+          '@parentClasses': JSON.stringify(c.parentClasses),
+          '@interfaces':    JSON.stringify(c.interfaces),
+          '@methodIds':     JSON.stringify(c.methodIds),
+          '@fanIn':         c.fanIn,
+          '@fanOut':        c.fanOut,
+          '@isModule':      c.isModule ? 1 : 0,
         });
       }
     });
-    insert(classes);
   }
 
   // ── Content-hash cache ────────────────────────────────────────────────────────
@@ -392,9 +415,9 @@ export class EdgeStore {
     this.db.exec('DELETE FROM edges; DELETE FROM inheritance_edges; DELETE FROM nodes; DELETE FROM classes; DELETE FROM nodes_fts; DELETE FROM file_hashes;');
   }
 
-  /** Run fn inside a single SQLite transaction. Nested calls use savepoints. */
+  /** Run fn inside a single SQLite transaction. */
   transaction(fn: () => void): void {
-    this.db.transaction(fn)();
+    runTransaction(this.db, fn);
   }
 
   close(): void {

--- a/src/core/services/mcp-handlers/analysis.test.ts
+++ b/src/core/services/mcp-handlers/analysis.test.ts
@@ -22,6 +22,11 @@ import {
   ARTIFACT_DEPENDENCY_GRAPH,
   ARTIFACT_MAPPING,
   ARTIFACT_ROUTE_INVENTORY,
+  ARTIFACT_MIDDLEWARE_INVENTORY,
+  ARTIFACT_SCHEMA_INVENTORY,
+  ARTIFACT_UI_INVENTORY,
+  ARTIFACT_ENV_INVENTORY,
+  ARTIFACT_EXTERNAL_PACKAGES,
 } from '../../../constants.js';
 
 // ============================================================================
@@ -638,5 +643,375 @@ describe('handleGetRouteInventory', () => {
     // Malformed JSON → JSON.parse throws → falls through to live extraction → cached: false
     expect(result.cached).toBe(false);
     expect(result).toHaveProperty('total');
+  });
+});
+
+// ============================================================================
+// handleGetMiddlewareInventory
+// ============================================================================
+
+describe('handleGetMiddlewareInventory', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns cached: true when middleware-inventory.json exists', async () => {
+    const payload = [{ name: 'authMiddleware', file: 'src/middleware/auth.ts' }];
+    await writeAnalysisFile(tmpDir, ARTIFACT_MIDDLEWARE_INVENTORY, payload);
+    const { handleGetMiddlewareInventory } = await import('./analysis.js');
+    const result = await handleGetMiddlewareInventory(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(true);
+    expect(result.total).toBe(1);
+    expect(Array.isArray(result.entries)).toBe(true);
+  });
+
+  it('falls back to live extraction (cached: false) when artifact absent', async () => {
+    const { handleGetMiddlewareInventory } = await import('./analysis.js');
+    const result = await handleGetMiddlewareInventory(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(false);
+    expect(result).toHaveProperty('total');
+    expect(result).toHaveProperty('entries');
+  });
+});
+
+// ============================================================================
+// handleGetSchemaInventory
+// ============================================================================
+
+describe('handleGetSchemaInventory', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns cached: true when schema-inventory.json exists', async () => {
+    const payload = [{ name: 'User', type: 'interface', file: 'src/types.ts' }];
+    await writeAnalysisFile(tmpDir, ARTIFACT_SCHEMA_INVENTORY, payload);
+    const { handleGetSchemaInventory } = await import('./analysis.js');
+    const result = await handleGetSchemaInventory(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(true);
+    expect(result.total).toBe(1);
+    expect(Array.isArray(result.schemas)).toBe(true);
+  });
+
+  it('falls back to live extraction when artifact absent', async () => {
+    const { handleGetSchemaInventory } = await import('./analysis.js');
+    const result = await handleGetSchemaInventory(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(false);
+    expect(result).toHaveProperty('schemas');
+  });
+});
+
+// ============================================================================
+// handleGetUIComponents
+// ============================================================================
+
+describe('handleGetUIComponents', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns cached: true when ui-inventory.json exists', async () => {
+    const payload = [{ name: 'Button', file: 'src/components/Button.tsx' }];
+    await writeAnalysisFile(tmpDir, ARTIFACT_UI_INVENTORY, payload);
+    const { handleGetUIComponents } = await import('./analysis.js');
+    const result = await handleGetUIComponents(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(true);
+    expect(result.total).toBe(1);
+    expect(Array.isArray(result.components)).toBe(true);
+  });
+
+  it('falls back to live extraction when artifact absent', async () => {
+    const { handleGetUIComponents } = await import('./analysis.js');
+    const result = await handleGetUIComponents(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(false);
+    expect(result).toHaveProperty('components');
+  });
+});
+
+// ============================================================================
+// handleGetEnvVars
+// ============================================================================
+
+describe('handleGetEnvVars', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns cached: true when env-inventory.json exists', async () => {
+    const payload = [{ name: 'DATABASE_URL', file: 'src/config.ts' }];
+    await writeAnalysisFile(tmpDir, ARTIFACT_ENV_INVENTORY, payload);
+    const { handleGetEnvVars } = await import('./analysis.js');
+    const result = await handleGetEnvVars(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(true);
+    expect(result.total).toBe(1);
+    expect(Array.isArray(result.envVars)).toBe(true);
+  });
+
+  it('falls back to live extraction when artifact absent', async () => {
+    const { handleGetEnvVars } = await import('./analysis.js');
+    const result = await handleGetEnvVars(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(false);
+    expect(result).toHaveProperty('envVars');
+  });
+});
+
+// ============================================================================
+// handleGetExternalPackages
+// ============================================================================
+
+describe('handleGetExternalPackages', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns cached: true when external-packages.json exists', async () => {
+    const payload = { total: 2, packages: [{ name: 'express', version: '^4.18.0' }] };
+    await writeAnalysisFile(tmpDir, ARTIFACT_EXTERNAL_PACKAGES, payload);
+    const { handleGetExternalPackages } = await import('./analysis.js');
+    const result = await handleGetExternalPackages(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(true);
+    expect(result.total).toBe(2);
+  });
+
+  it('falls back to live extraction when artifact absent', async () => {
+    const { handleGetExternalPackages } = await import('./analysis.js');
+    const result = await handleGetExternalPackages(tmpDir) as Record<string, unknown>;
+    expect(result.cached).toBe(false);
+  });
+});
+
+// ============================================================================
+// handleGetMinimalContext
+// ============================================================================
+
+function makeCallGraph(overrides: Partial<{
+  nodes: unknown[]; edges: unknown[];
+}> = {}) {
+  return {
+    nodes: [],
+    edges: [],
+    entryPoints: [],
+    hubFunctions: [],
+    layerViolations: [],
+    inheritanceEdges: [],
+    classes: [],
+    stats: { totalNodes: 0, totalEdges: 0, avgFanIn: 0, avgFanOut: 0 },
+    ...overrides,
+  };
+}
+
+describe('handleGetMinimalContext', () => {
+  let tmpDir: string;
+  let readCachedContext: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+    readCachedContext = vi.mocked(utils.readCachedContext);
+  });
+
+  it('returns error when no call graph available', async () => {
+    readCachedContext.mockResolvedValue(null);
+    const { handleGetMinimalContext } = await import('./analysis.js');
+    const result = await handleGetMinimalContext(tmpDir, 'myFn') as { error: string };
+    expect(result.error).toMatch(/No call graph/);
+  });
+
+  it('returns error when function not found in call graph', async () => {
+    readCachedContext.mockResolvedValue({ callGraph: makeCallGraph() });
+    const { handleGetMinimalContext } = await import('./analysis.js');
+    const result = await handleGetMinimalContext(tmpDir, 'nonExistentFn') as { error: string };
+    expect(result.error).toMatch(/"nonExistentFn" not found/);
+  });
+
+  it('returns function metadata with callers and callees', async () => {
+    const node = {
+      id: 'src/a.ts::doWork', name: 'doWork', filePath: `${tmpDir}/src/a.ts`,
+      signature: 'doWork(x: number): void', language: 'typescript',
+      fanIn: 2, fanOut: 1, startLine: 1, endLine: 5,
+      isExternal: false, isTest: false,
+    };
+    const callerNode = {
+      id: 'src/b.ts::caller', name: 'caller', filePath: `${tmpDir}/src/b.ts`,
+      signature: 'caller()', language: 'typescript',
+      fanIn: 0, fanOut: 1, startLine: 1, endLine: 3,
+      isExternal: false, isTest: false,
+    };
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [node, callerNode],
+        edges: [
+          { callerId: 'src/b.ts::caller', calleeId: 'src/a.ts::doWork', calleeName: 'doWork', confidence: 'exact', kind: 'calls' },
+        ],
+      }),
+    });
+    const { handleGetMinimalContext } = await import('./analysis.js');
+    const result = await handleGetMinimalContext(tmpDir, 'doWork') as Record<string, unknown>;
+    expect((result.function as Record<string, unknown>).name).toBe('doWork');
+    expect(Array.isArray(result.callers)).toBe(true);
+    expect((result.callers as unknown[]).length).toBeGreaterThanOrEqual(0);
+    expect(Array.isArray(result.callees)).toBe(true);
+    expect(Array.isArray(result.testedBy)).toBe(true);
+  });
+
+  it('includes testedBy edges when present', async () => {
+    const node = {
+      id: 'src/a.ts::compute', name: 'compute', filePath: `${tmpDir}/src/a.ts`,
+      signature: 'compute()', language: 'typescript',
+      fanIn: 0, fanOut: 0, startLine: 1, endLine: 3,
+      isExternal: false, isTest: false,
+    };
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [node],
+        edges: [
+          { callerId: 'src/a.ts::compute', calleeId: 'src/a.test.ts::testCompute', calleeName: 'compute.test.ts', confidence: 'import', kind: 'tested_by' },
+        ],
+      }),
+    });
+    const { handleGetMinimalContext } = await import('./analysis.js');
+    const result = await handleGetMinimalContext(tmpDir, 'compute') as { testedBy: Array<{ confidence: string }> };
+    expect(result.testedBy).toHaveLength(1);
+    expect(result.testedBy[0].confidence).toBe('imported');
+  });
+});
+
+// ============================================================================
+// handleGetCluster
+// ============================================================================
+
+describe('handleGetCluster', () => {
+  let tmpDir: string;
+  let readCachedContext: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+    readCachedContext = vi.mocked(utils.readCachedContext);
+  });
+
+  it('returns error when no call graph', async () => {
+    readCachedContext.mockResolvedValue(null);
+    const { handleGetCluster } = await import('./analysis.js');
+    const result = await handleGetCluster(tmpDir, 'foo') as { error: string };
+    expect(result.error).toMatch(/No call graph/);
+  });
+
+  it('returns error when function not found', async () => {
+    readCachedContext.mockResolvedValue({ callGraph: makeCallGraph() });
+    const { handleGetCluster } = await import('./analysis.js');
+    const result = await handleGetCluster(tmpDir, 'missing') as { error: string };
+    expect(result.error).toMatch(/"missing" not found/);
+  });
+
+  it('returns error when function has no community data', async () => {
+    const node = {
+      id: 'src/a.ts::fn', name: 'fn', filePath: `${tmpDir}/src/a.ts`,
+      fanIn: 0, fanOut: 0, isExternal: false, isTest: false,
+      // no communityId
+    };
+    readCachedContext.mockResolvedValue({ callGraph: makeCallGraph({ nodes: [node] }) });
+    const { handleGetCluster } = await import('./analysis.js');
+    const result = await handleGetCluster(tmpDir, 'fn') as { error: string };
+    expect(result.error).toMatch(/No community data/);
+  });
+
+  it('returns cluster members and stats for function with communityId', async () => {
+    const mkNode = (name: string) => ({
+      id: `src/a.ts::${name}`, name, filePath: `${tmpDir}/src/a.ts`,
+      fanIn: 1, fanOut: 1, isExternal: false, isTest: false,
+      communityId: 42, communityLabel: 'auth-cluster',
+    });
+    const nodes = [mkNode('login'), mkNode('logout'), mkNode('refresh')];
+    readCachedContext.mockResolvedValue({ callGraph: makeCallGraph({ nodes, edges: [] }) });
+    const { handleGetCluster } = await import('./analysis.js');
+    const result = await handleGetCluster(tmpDir, 'login') as Record<string, unknown>;
+    expect(result.communityId).toBe(42);
+    expect(result.communityLabel).toBe('auth-cluster');
+    expect((result.stats as Record<string, number>).members).toBe(3);
+    expect(Array.isArray(result.functions)).toBe(true);
+  });
+});
+
+// ============================================================================
+// handleDetectChanges
+// ============================================================================
+
+describe('handleDetectChanges', () => {
+  let tmpDir: string;
+  let readCachedContext: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+    readCachedContext = vi.mocked(utils.readCachedContext);
+  });
+
+  it('returns error when no call graph', async () => {
+    readCachedContext.mockResolvedValue(null);
+    const { handleDetectChanges } = await import('./analysis.js');
+    const result = await handleDetectChanges(tmpDir) as { error: string };
+    expect(result.error).toMatch(/No call graph/);
+  });
+
+  it('returns git error when directory is not a git repository', async () => {
+    readCachedContext.mockResolvedValue({ callGraph: makeCallGraph() });
+    const { handleDetectChanges } = await import('./analysis.js');
+    // tmpDir is not a git repo — git diff will fail
+    const result = await handleDetectChanges(tmpDir) as { error: string };
+    expect(result.error).toMatch(/git diff failed/);
+  });
+});
+
+// ============================================================================
+// handleAuditSpecCoverage
+// ============================================================================
+
+describe('handleAuditSpecCoverage', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpDir = await createTmpDir();
+    const utils = await import('./utils.js');
+    vi.mocked(utils.validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns error when audit fails (no analysis)', async () => {
+    const { handleAuditSpecCoverage } = await import('./analysis.js');
+    const result = await handleAuditSpecCoverage(tmpDir) as { error: string };
+    // No analysis cache → specGenAudit throws
+    expect(result.error).toMatch(/Audit failed/);
   });
 });

--- a/src/core/services/mcp-handlers/decisions.test.ts
+++ b/src/core/services/mcp-handlers/decisions.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for MCP decision handlers:
+ *   handleRecordDecision, handleListDecisions,
+ *   handleApproveDecision, handleRejectDecision, handleSyncDecisions
+ *
+ * Strategy: mock validateDirectory to return tmpDir so real store file I/O
+ * runs against the temp directory. Mock spawn (background consolidation),
+ * syncApprovedDecisions, buildSpecMap, and readSpecGenConfig.
+ */
+
+// ── Module mocks (hoisted) ────────────────────────────────────────────────────
+
+import { vi } from 'vitest';
+
+vi.mock('./utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./utils.js')>();
+  return {
+    ...actual,
+    validateDirectory: vi.fn(async (dir: string) => dir),
+  };
+});
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
+}));
+
+vi.mock('../config-manager.js', () => ({
+  readSpecGenConfig: vi.fn(async () => null),
+}));
+
+vi.mock('../../../core/drift/spec-mapper.js', () => ({
+  buildSpecMap: vi.fn(async () => ({})),
+  matchFileToDomains: vi.fn(() => []),
+}));
+
+vi.mock('../../decisions/syncer.js', () => ({
+  syncApprovedDecisions: vi.fn(async (store: unknown) => ({
+    store,
+    result: { synced: [], errors: [], modifiedSpecs: [] },
+  })),
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { DecisionStore, PendingDecision } from '../../../types/index.js';
+import {
+  SPEC_GEN_DIR,
+  SPEC_GEN_DECISIONS_SUBDIR,
+  DECISIONS_PENDING_FILE,
+} from '../../../constants.js';
+import {
+  handleRecordDecision,
+  handleListDecisions,
+  handleApproveDecision,
+  handleRejectDecision,
+  handleSyncDecisions,
+} from './decisions.js';
+import { validateDirectory } from './utils.js';
+import { readSpecGenConfig } from '../config-manager.js';
+import { syncApprovedDecisions } from '../../decisions/syncer.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeDecision(overrides: Partial<PendingDecision> = {}): PendingDecision {
+  return {
+    id: 'abc12345',
+    status: 'draft',
+    title: 'Use SQLite for edges',
+    rationale: 'JSON too large at scale',
+    consequences: 'Requires migration',
+    proposedRequirement: null,
+    affectedDomains: [],
+    affectedFiles: [],
+    sessionId: 'test-session',
+    recordedAt: '2026-01-01T00:00:00.000Z',
+    confidence: 'medium',
+    syncedToSpecs: [],
+    ...overrides,
+  };
+}
+
+function makeStore(overrides: Partial<DecisionStore> = {}): DecisionStore {
+  return {
+    version: '1',
+    sessionId: 'test-session',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    decisions: [],
+    ...overrides,
+  };
+}
+
+async function writeStore(rootPath: string, store: DecisionStore): Promise<void> {
+  const dir = join(rootPath, SPEC_GEN_DIR, SPEC_GEN_DECISIONS_SUBDIR);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, DECISIONS_PENDING_FILE), JSON.stringify(store, null, 2) + '\n', 'utf-8');
+}
+
+async function readStore(rootPath: string): Promise<DecisionStore> {
+  const path = join(rootPath, SPEC_GEN_DIR, SPEC_GEN_DECISIONS_SUBDIR, DECISIONS_PENDING_FILE);
+  return JSON.parse(await readFile(path, 'utf-8')) as DecisionStore;
+}
+
+// ── handleRecordDecision ──────────────────────────────────────────────────────
+
+describe('handleRecordDecision', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'spec-gen-decisions-test-'));
+    vi.mocked(validateDirectory).mockResolvedValue(tmpDir);
+    vi.clearAllMocks();
+    vi.mocked(validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns error when title is empty', async () => {
+    const result = await handleRecordDecision(tmpDir, '', 'some rationale') as { error: string };
+    expect(result.error).toMatch(/title is required/);
+  });
+
+  it('returns error when title is whitespace only', async () => {
+    const result = await handleRecordDecision(tmpDir, '   ', 'some rationale') as { error: string };
+    expect(result.error).toMatch(/title is required/);
+  });
+
+  it('returns error when rationale is empty', async () => {
+    const result = await handleRecordDecision(tmpDir, 'My decision', '') as { error: string };
+    expect(result.error).toMatch(/rationale is required/);
+  });
+
+  it('records a draft decision and returns an id', async () => {
+    const result = await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big') as { id: string; message: string };
+    expect(result.id).toHaveLength(8);
+    expect(result.message).toContain('Use SQLite');
+  });
+
+  it('persists the decision with draft status to disk', async () => {
+    await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big');
+    const store = await readStore(tmpDir);
+    expect(store.decisions).toHaveLength(1);
+    expect(store.decisions[0].title).toBe('Use SQLite');
+    expect(store.decisions[0].status).toBe('draft');
+    expect(store.decisions[0].rationale).toBe('JSON too big');
+  });
+
+  it('stores consequences and affectedFiles when provided', async () => {
+    await handleRecordDecision(
+      tmpDir, 'Use SQLite', 'JSON too big',
+      'needs migration', ['src/store.ts'],
+    );
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].consequences).toBe('needs migration');
+    expect(store.decisions[0].affectedFiles).toEqual(['src/store.ts']);
+  });
+
+  it('stores supersedes id when provided', async () => {
+    await handleRecordDecision(
+      tmpDir, 'Use SQLite', 'JSON too big',
+      undefined, undefined, 'deadbeef',
+    );
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].supersedes).toBe('deadbeef');
+  });
+});
+
+// ── handleListDecisions ───────────────────────────────────────────────────────
+
+describe('handleListDecisions', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'spec-gen-decisions-test-'));
+    vi.mocked(validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns empty list when no store exists', async () => {
+    const result = await handleListDecisions(tmpDir) as { total: number; decisions: unknown[] };
+    expect(result.total).toBe(0);
+    expect(result.decisions).toEqual([]);
+  });
+
+  it('returns all decisions when no status filter', async () => {
+    const store = makeStore({
+      decisions: [
+        makeDecision({ id: 'aaa11111', status: 'draft', title: 'Decision A' }),
+        makeDecision({ id: 'bbb22222', status: 'approved', title: 'Decision B' }),
+      ],
+    });
+    await writeStore(tmpDir, store);
+    const result = await handleListDecisions(tmpDir) as { total: number; decisions: Array<{ id: string }> };
+    expect(result.total).toBe(2);
+    expect(result.decisions.map((d) => d.id)).toEqual(['aaa11111', 'bbb22222']);
+  });
+
+  it('filters decisions by status', async () => {
+    const store = makeStore({
+      decisions: [
+        makeDecision({ id: 'aaa11111', status: 'draft', title: 'Draft' }),
+        makeDecision({ id: 'bbb22222', status: 'approved', title: 'Approved' }),
+      ],
+    });
+    await writeStore(tmpDir, store);
+    const result = await handleListDecisions(tmpDir, 'approved') as { total: number; decisions: Array<{ id: string; status: string }> };
+    expect(result.total).toBe(1);
+    expect(result.decisions[0].id).toBe('bbb22222');
+    expect(result.decisions[0].status).toBe('approved');
+  });
+
+  it('returns mapped fields including proposedRequirement and syncedToSpecs', async () => {
+    const store = makeStore({
+      decisions: [makeDecision({ proposedRequirement: 'REQ-001', syncedToSpecs: ['services'] })],
+    });
+    await writeStore(tmpDir, store);
+    const result = await handleListDecisions(tmpDir) as { decisions: Array<Record<string, unknown>> };
+    const d = result.decisions[0];
+    expect(d.proposedRequirement).toBe('REQ-001');
+    expect(d.syncedToSpecs).toEqual(['services']);
+  });
+});
+
+// ── handleApproveDecision ─────────────────────────────────────────────────────
+
+describe('handleApproveDecision', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'spec-gen-decisions-test-'));
+    vi.mocked(validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns error when decision id is not found', async () => {
+    await writeStore(tmpDir, makeStore());
+    const result = await handleApproveDecision(tmpDir, 'notfound') as { error: string };
+    expect(result.error).toMatch(/notfound/);
+  });
+
+  it('approves a draft decision and returns id + status + title', async () => {
+    const decision = makeDecision({ id: 'abc12345', status: 'draft', title: 'Use SQLite' });
+    await writeStore(tmpDir, makeStore({ decisions: [decision] }));
+
+    const result = await handleApproveDecision(tmpDir, 'abc12345') as { id: string; status: string; title: string };
+    expect(result.id).toBe('abc12345');
+    expect(result.status).toBe('approved');
+    expect(result.title).toBe('Use SQLite');
+  });
+
+  it('persists the approved status to disk', async () => {
+    const decision = makeDecision({ id: 'abc12345', status: 'draft' });
+    await writeStore(tmpDir, makeStore({ decisions: [decision] }));
+
+    await handleApproveDecision(tmpDir, 'abc12345', 'LGTM');
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].status).toBe('approved');
+    expect(store.decisions[0].reviewNote).toBe('LGTM');
+  });
+});
+
+// ── handleRejectDecision ──────────────────────────────────────────────────────
+
+describe('handleRejectDecision', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'spec-gen-decisions-test-'));
+    vi.mocked(validateDirectory).mockResolvedValue(tmpDir);
+  });
+
+  it('returns error when decision id is not found', async () => {
+    await writeStore(tmpDir, makeStore());
+    const result = await handleRejectDecision(tmpDir, 'notfound') as { error: string };
+    expect(result.error).toMatch(/notfound/);
+  });
+
+  it('rejects a decision and returns id + status + title', async () => {
+    const decision = makeDecision({ id: 'abc12345', status: 'draft', title: 'Use JSON' });
+    await writeStore(tmpDir, makeStore({ decisions: [decision] }));
+
+    const result = await handleRejectDecision(tmpDir, 'abc12345', 'Too slow') as { id: string; status: string; title: string };
+    expect(result.id).toBe('abc12345');
+    expect(result.status).toBe('rejected');
+    expect(result.title).toBe('Use JSON');
+  });
+
+  it('persists the rejected status and note to disk', async () => {
+    const decision = makeDecision({ id: 'abc12345', status: 'draft' });
+    await writeStore(tmpDir, makeStore({ decisions: [decision] }));
+
+    await handleRejectDecision(tmpDir, 'abc12345', 'Bad idea');
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].status).toBe('rejected');
+    expect(store.decisions[0].reviewNote).toBe('Bad idea');
+  });
+});
+
+// ── handleSyncDecisions ───────────────────────────────────────────────────────
+
+describe('handleSyncDecisions', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'spec-gen-decisions-test-'));
+    vi.mocked(validateDirectory).mockResolvedValue(tmpDir);
+    vi.mocked(readSpecGenConfig).mockResolvedValue(null);
+  });
+
+  it('returns error when no spec-gen config exists', async () => {
+    const result = await handleSyncDecisions(tmpDir) as { error: string };
+    expect(result.error).toMatch(/No spec-gen configuration/);
+  });
+
+  it('calls syncApprovedDecisions with rootPath and dryRun flag', async () => {
+    vi.mocked(readSpecGenConfig).mockResolvedValue({ openspecPath: 'openspec' } as never);
+    await writeStore(tmpDir, makeStore());
+
+    await handleSyncDecisions(tmpDir, true);
+    expect(syncApprovedDecisions).toHaveBeenCalledWith(
+      expect.objectContaining({ decisions: [] }),
+      expect.objectContaining({ rootPath: tmpDir, dryRun: true }),
+    );
+  });
+
+  it('returns synced/errors/modifiedSpecs and dryRun from syncer result', async () => {
+    vi.mocked(readSpecGenConfig).mockResolvedValue({ openspecPath: 'openspec' } as never);
+    vi.mocked(syncApprovedDecisions).mockResolvedValue({
+      store: makeStore(),
+      result: {
+        synced: [{ id: 'abc12345', title: 'Use SQLite', syncedToSpecs: ['services'] } as PendingDecision],
+        errors: [],
+        modifiedSpecs: ['openspec/specs/services/spec.md'],
+      },
+    });
+    await writeStore(tmpDir, makeStore());
+
+    const result = await handleSyncDecisions(tmpDir, false) as {
+      synced: Array<{ id: string; title: string; specs: string[] }>;
+      errors: unknown[];
+      modifiedSpecs: string[];
+      dryRun: boolean;
+    };
+    expect(result.dryRun).toBe(false);
+    expect(result.synced).toHaveLength(1);
+    expect(result.synced[0].id).toBe('abc12345');
+    expect(result.modifiedSpecs).toEqual(['openspec/specs/services/spec.md']);
+  });
+
+  it('promotes a specific decision to approved before syncing when id provided', async () => {
+    vi.mocked(readSpecGenConfig).mockResolvedValue({ openspecPath: 'openspec' } as never);
+    const decision = makeDecision({ id: 'abc12345', status: 'draft' });
+    await writeStore(tmpDir, makeStore({ decisions: [decision] }));
+
+    await handleSyncDecisions(tmpDir, false, 'abc12345');
+    expect(syncApprovedDecisions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decisions: expect.arrayContaining([
+          expect.objectContaining({ id: 'abc12345', status: 'approved' }),
+        ]),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('returns error when specific id not found', async () => {
+    vi.mocked(readSpecGenConfig).mockResolvedValue({ openspecPath: 'openspec' } as never);
+    await writeStore(tmpDir, makeStore());
+
+    const result = await handleSyncDecisions(tmpDir, false, 'notfound') as { error: string };
+    expect(result.error).toMatch(/notfound/);
+  });
+});

--- a/src/core/services/mcp-handlers/decisions.test.ts
+++ b/src/core/services/mcp-handlers/decisions.test.ts
@@ -170,6 +170,58 @@ describe('handleRecordDecision', () => {
     const store = await readStore(tmpDir);
     expect(store.decisions).toHaveLength(1);
   });
+
+  it('stores default scope component when no promotion triggers fire', async () => {
+    await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big');
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].scope).toBe('component');
+  });
+
+  it('respects explicit scope passed by caller', async () => {
+    await handleRecordDecision(tmpDir, 'Global auth strategy', 'Use JWT everywhere',
+      undefined, undefined, undefined, 'system');
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].scope).toBe('system');
+  });
+
+  it('structural trigger: files spanning 2+ top-level dirs → cross-domain', async () => {
+    // src/api/ and src/core/ are distinct top-level dirs (2-segment key: src/api vs src/core)
+    await handleRecordDecision(tmpDir, 'Shared cache layer',
+      'Cache used by both API and core services',
+      undefined, ['src/api/cache.ts', 'src/core/cache.ts']);
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].scope).toBe('cross-domain');
+  });
+
+  it('structural trigger does not fire for files in same top-level dir', async () => {
+    await handleRecordDecision(tmpDir, 'Extract helper',
+      'Refactor utility function',
+      undefined, ['src/utils/a.ts', 'src/utils/b.ts']);
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].scope).toBe('component');
+  });
+
+  it('semantic trigger suppressed when rationale contains refactor keyword', async () => {
+    const { matchFileToDomains } = await import('../../../core/drift/spec-mapper.js');
+    vi.mocked(matchFileToDomains).mockReturnValue(['api', 'core']);
+    await handleRecordDecision(tmpDir, 'Extract shared helper',
+      'Refactor duplicate code into a shared utility',
+      undefined, ['src/api/auth.ts']);
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].scope).toBe('component');
+    vi.mocked(matchFileToDomains).mockReturnValue([]);
+  });
+
+  it('semantic trigger: multi-domain + contract keyword + not refactor → cross-domain', async () => {
+    const { matchFileToDomains } = await import('../../../core/drift/spec-mapper.js');
+    vi.mocked(matchFileToDomains).mockReturnValue(['api', 'services']);
+    await handleRecordDecision(tmpDir, 'Shared auth contract',
+      'Define authentication interface across API and service layer',
+      undefined, ['src/auth/middleware.ts']);
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].scope).toBe('cross-domain');
+    vi.mocked(matchFileToDomains).mockReturnValue([]);
+  });
 });
 
 // ── handleListDecisions ───────────────────────────────────────────────────────
@@ -261,6 +313,16 @@ describe('handleApproveDecision', () => {
     const store = await readStore(tmpDir);
     expect(store.decisions[0].status).toBe('approved');
     expect(store.decisions[0].reviewNote).toBe('LGTM');
+  });
+
+  it('blocks re-approving an already synced decision', async () => {
+    const decision = makeDecision({ id: 'abc12345', status: 'synced' });
+    await writeStore(tmpDir, makeStore({ decisions: [decision] }));
+
+    const result = await handleApproveDecision(tmpDir, 'abc12345') as { error: string };
+    expect(result.error).toMatch(/already synced/);
+    const store = await readStore(tmpDir);
+    expect(store.decisions[0].status).toBe('synced');
   });
 });
 

--- a/src/core/services/mcp-handlers/decisions.test.ts
+++ b/src/core/services/mcp-handlers/decisions.test.ts
@@ -111,7 +111,6 @@ describe('handleRecordDecision', () => {
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(join(tmpdir(), 'spec-gen-decisions-test-'));
-    vi.mocked(validateDirectory).mockResolvedValue(tmpDir);
     vi.clearAllMocks();
     vi.mocked(validateDirectory).mockResolvedValue(tmpDir);
   });
@@ -163,6 +162,13 @@ describe('handleRecordDecision', () => {
     );
     const store = await readStore(tmpDir);
     expect(store.decisions[0].supersedes).toBe('deadbeef');
+  });
+
+  it('does not duplicate when same title recorded twice (makeDecisionId is deterministic)', async () => {
+    await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big');
+    await handleRecordDecision(tmpDir, 'Use SQLite', 'JSON too big');
+    const store = await readStore(tmpDir);
+    expect(store.decisions).toHaveLength(1);
   });
 });
 

--- a/src/core/services/mcp-handlers/decisions.ts
+++ b/src/core/services/mcp-handlers/decisions.ts
@@ -22,7 +22,7 @@ import { buildSpecMap, matchFileToDomains } from '../../../core/drift/spec-mappe
 import { readSpecGenConfig } from '../config-manager.js';
 import { join } from 'node:path';
 import { OPENSPEC_DIR } from '../../../constants.js';
-import type { PendingDecision } from '../../../types/index.js';
+import type { PendingDecision, DecisionScope } from '../../../types/index.js';
 
 function spawnConsolidateBackground(rootPath: string): void {
   // Resolve binary: prefer local build over global install (same order as pre-commit hook)
@@ -59,6 +59,7 @@ export async function handleRecordDecision(
   consequences?: string,
   affectedFiles?: string[],
   supersedes?: string,
+  scope?: DecisionScope,
 ): Promise<unknown> {
   try {
     if (!title?.trim()) return { error: 'title is required and must not be empty.' };
@@ -90,9 +91,34 @@ export async function handleRecordDecision(
 
     const id = makeDecisionId(store.sessionId, primaryDomain, title.trim());
 
+    // Resolve scope: explicit caller value wins; otherwise auto-promote via deterministic signals.
+    // Two independent triggers, either is sufficient:
+    //   1. Structural: files span 2+ distinct top-level source dirs (file-topology, no LLM)
+    //   2. Semantic: multiple domains inferred AND rationale contains contract/API keywords
+    // Rationale-only matching is intentionally avoided — too fuzzy to be reliable under replay.
+    let resolvedScope: DecisionScope = scope ?? 'component';
+    if (!scope) {
+      const topLevelDirs = new Set(
+        (affectedFiles ?? []).map((f) => f.split('/').slice(0, 2).join('/')),
+      );
+      const hasStructuralCrossDomain = topLevelDirs.size >= 2;
+
+      const lowerRationale = (rationale ?? '').toLowerCase();
+      const isRefactorOrUtil =
+        /\b(refactor|rename|extract|util|helper|constant|config|logging|test)\b/.test(lowerRationale);
+      const hasContractKeyword =
+        /\b(api|schema|contract|interface|protocol|auth|database|event|migration)\b/.test(lowerRationale);
+      const hasSemanticCrossDomain = inferredDomains.length >= 2 && !isRefactorOrUtil && hasContractKeyword;
+
+      if (hasStructuralCrossDomain || hasSemanticCrossDomain) {
+        resolvedScope = 'cross-domain';
+      }
+    }
+
     const decision: PendingDecision = {
       id,
       status: 'draft',
+      scope: resolvedScope,
       title: title.trim(),
       rationale: rationale.trim(),
       consequences: consequences ?? '',
@@ -174,6 +200,7 @@ export async function handleApproveDecision(
 
     const decision = store.decisions.find((d) => d.id === id);
     if (!decision) return { error: `Decision ${id} not found.` };
+    if (decision.status === 'synced') return { error: `Decision ${id} is already synced to spec files — re-approval not allowed.` };
 
     const updated = patchDecision(store, id, {
       status: 'approved',

--- a/src/core/services/mcp-handlers/graph.ts
+++ b/src/core/services/mcp-handlers/graph.ts
@@ -127,8 +127,10 @@ export function bfsFromDB(
   const visited = new Map<string, number>();
   for (const id of seeds) visited.set(id, 0);
 
-  // Level-by-level BFS: one batch query per depth level instead of one query per node.
-  // O(maxDepth) SQL queries vs O(visited_nodes) in the naive approach.
+  // Level-by-level BFS: one batch query per depth level, O(maxDepth) SQL queries.
+  // Recursive CTE was tested but regressed backward BFS on high fan-in hubs (19ms→30ms):
+  // SQLite UNION deduplicates on (id,depth) pairs, so (X,1) and (X,2) are both kept,
+  // causing path explosion. Iterative frontier never re-visits a node.
   let frontier = seeds.filter(id => !id.startsWith('external::'));
 
   for (let depth = 0; depth < maxDepth && frontier.length > 0; depth++) {

--- a/src/core/services/mcp-handlers/orient.test.ts
+++ b/src/core/services/mcp-handlers/orient.test.ts
@@ -61,6 +61,7 @@ vi.mock('../../decisions/store.js', () => ({
     updatedAt: '2026-01-01T00:00:00.000Z',
     decisions: [],
   })),
+  INACTIVE_STATUSES: new Set(['rejected', 'synced', 'phantom']),
 }));
 
 // ── Imports (after mocks) ─────────────────────────────────────────────────────

--- a/src/core/services/mcp-handlers/orient.test.ts
+++ b/src/core/services/mcp-handlers/orient.test.ts
@@ -54,6 +54,15 @@ vi.mock('../../analyzer/spec-vector-index.js', () => ({
   },
 }));
 
+vi.mock('../../decisions/store.js', () => ({
+  loadDecisionStore: vi.fn(async () => ({
+    version: '1',
+    sessionId: 'test-session',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    decisions: [],
+  })),
+}));
+
 // ── Imports (after mocks) ─────────────────────────────────────────────────────
 
 import { handleOrient } from './orient.js';
@@ -62,6 +71,7 @@ import { EmbeddingService } from '../../analyzer/embedding-service.js';
 import { SpecVectorIndex } from '../../analyzer/spec-vector-index.js';
 import { loadMappingIndex, specsForFile, functionsForDomain, readCachedContext } from './utils.js';
 import { readSpecGenConfig } from '../config-manager.js';
+import { loadDecisionStore } from '../../decisions/store.js';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -102,6 +112,12 @@ describe('handleOrient', () => {
     vi.mocked(readSpecGenConfig).mockResolvedValue(null);
     vi.mocked(EmbeddingService.fromEnv).mockImplementation(() => { throw new Error('no env'); });
     vi.mocked(EmbeddingService.fromConfig).mockReturnValue(null);
+    vi.mocked(loadDecisionStore).mockResolvedValue({
+      version: '1',
+      sessionId: 'test-session',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      decisions: [],
+    });
   });
 
   it('returns error when no code index exists', async () => {
@@ -272,5 +288,144 @@ describe('handleOrient', () => {
     expect(result.matchingSpecs).toBeDefined();
     const specs = result.matchingSpecs as Array<{ domain: string }>;
     expect(specs[0].domain).toBe('auth');
+  });
+
+  it('filters out external synthetic nodes from relevantFunctions', async () => {
+    vi.mocked(VectorIndex.exists).mockReturnValue(true);
+    vi.mocked(VectorIndex.search).mockResolvedValue([
+      makeSearchResult({ name: 'realFn', filePath: 'src/real.ts' }),
+      { score: 0.5, record: { ...makeSearchResult().record, id: 'external::fetch', name: 'fetch', filePath: 'external' } },
+      { score: 0.4, record: { ...makeSearchResult().record, id: 'external::https.request', name: 'https.request', filePath: 'src/real.ts' } },
+    ]);
+
+    const result = await handleOrient('/tmp/proj', 'fetch task') as Record<string, unknown>;
+    const fns = result.relevantFunctions as Array<{ name: string; filePath: string }>;
+
+    expect(fns.some(f => f.filePath === 'external')).toBe(false);
+    expect(fns.some(f => f.name === 'fetch')).toBe(false);
+    // The node with id starting with 'external::' is also filtered even if filePath differs
+    expect(fns.some(f => f.name === 'https.request')).toBe(false);
+  });
+
+  it('includes pendingDecisions when active decisions exist', async () => {
+    vi.mocked(VectorIndex.exists).mockReturnValue(true);
+    vi.mocked(VectorIndex.search).mockResolvedValue([makeSearchResult()]);
+    vi.mocked(loadDecisionStore).mockResolvedValue({
+      version: '1',
+      sessionId: 'test-session',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      decisions: [
+        {
+          id: 'abc12345',
+          status: 'approved',
+          title: 'Use SQLite',
+          rationale: 'JSON too big',
+          consequences: '',
+          proposedRequirement: null,
+          affectedDomains: ['services'],
+          affectedFiles: [],
+          sessionId: 'test-session',
+          recordedAt: '2026-01-01T00:00:00.000Z',
+          confidence: 'medium',
+          syncedToSpecs: [],
+        },
+        {
+          id: 'def67890',
+          status: 'synced', // excluded — synced decisions are not active
+          title: 'Already synced',
+          rationale: 'Done',
+          consequences: '',
+          proposedRequirement: null,
+          affectedDomains: [],
+          affectedFiles: [],
+          sessionId: 'test-session',
+          recordedAt: '2026-01-01T00:00:00.000Z',
+          confidence: 'medium',
+          syncedToSpecs: ['services'],
+        },
+      ],
+    });
+
+    const result = await handleOrient('/tmp/proj', 'task') as Record<string, unknown>;
+
+    expect(result.pendingDecisions).toBeDefined();
+    const decisions = result.pendingDecisions as Array<{ id: string; status: string }>;
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].id).toBe('abc12345');
+    expect(decisions[0].status).toBe('approved');
+  });
+
+  it('omits pendingDecisions when all decisions are synced or rejected', async () => {
+    vi.mocked(VectorIndex.exists).mockReturnValue(true);
+    vi.mocked(VectorIndex.search).mockResolvedValue([makeSearchResult()]);
+    vi.mocked(loadDecisionStore).mockResolvedValue({
+      version: '1',
+      sessionId: 'test-session',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      decisions: [
+        {
+          id: 'aaa11111',
+          status: 'synced',
+          title: 'Done',
+          rationale: 'r',
+          consequences: '',
+          proposedRequirement: null,
+          affectedDomains: [],
+          affectedFiles: [],
+          sessionId: 's',
+          recordedAt: '2026-01-01T00:00:00.000Z',
+          confidence: 'low',
+          syncedToSpecs: [],
+        },
+        {
+          id: 'bbb22222',
+          status: 'rejected',
+          title: 'Bad',
+          rationale: 'r',
+          consequences: '',
+          proposedRequirement: null,
+          affectedDomains: [],
+          affectedFiles: [],
+          sessionId: 's',
+          recordedAt: '2026-01-01T00:00:00.000Z',
+          confidence: 'low',
+          syncedToSpecs: [],
+        },
+      ],
+    });
+
+    const result = await handleOrient('/tmp/proj', 'task') as Record<string, unknown>;
+
+    expect(result.pendingDecisions).toBeUndefined();
+  });
+
+  it('omits external callee neighbours from call paths', async () => {
+    vi.mocked(VectorIndex.exists).mockReturnValue(true);
+    const searchResult = makeSearchResult({ id: 'src/foo.ts::doFoo', name: 'doFoo', filePath: 'src/foo.ts' });
+    vi.mocked(VectorIndex.search).mockResolvedValue([searchResult]);
+    vi.mocked(readCachedContext).mockResolvedValue({
+      callGraph: { nodes: [], edges: [], classes: [], inheritanceEdges: [], hubFunctions: [], entryPoints: [], layerViolations: [], stats: { totalNodes: 0, totalEdges: 0, avgFanIn: 0, avgFanOut: 0 } },
+      edgeStore: {
+        getCallers: () => [],
+        getCallees: () => [
+          { callerId: 'src/foo.ts::doFoo', calleeId: 'external::fetch', calleeName: 'fetch', confidence: 'name_only' },
+          { callerId: 'src/foo.ts::doFoo', calleeId: 'src/bar.ts::doBar', calleeName: 'doBar', confidence: 'exact' },
+        ],
+        getNode: (id: string) => {
+          if (id === 'external::fetch') return { id, name: 'fetch', filePath: 'external', fanIn: 0, fanOut: 0, isAsync: false, language: 'TypeScript', startIndex: 0, endIndex: 0, isExternal: true };
+          if (id === 'src/bar.ts::doBar') return { id, name: 'doBar', filePath: 'src/bar.ts', fanIn: 0, fanOut: 0, isAsync: false, language: 'TypeScript', startIndex: 0, endIndex: 50 };
+          return null;
+        },
+      },
+    } as never);
+
+    const result = await handleOrient('/tmp/proj', 'task') as Record<string, unknown>;
+    const callPaths = result.callPaths as Array<{ function: string; callees: Array<{ name: string }> }>;
+    const fooPaths = callPaths.find(p => p.function === 'doFoo');
+
+    expect(fooPaths).toBeDefined();
+    // External node (fetch) must be filtered out; internal doBar kept
+    expect(fooPaths!.callees.some(c => c.name === 'fetch')).toBe(false);
+    expect(fooPaths!.callees.some(c => c.name === 'doBar')).toBe(true);
   });
 });

--- a/src/core/services/mcp-handlers/orient.ts
+++ b/src/core/services/mcp-handlers/orient.ts
@@ -349,6 +349,8 @@ export async function handleOrient(
   }
 
   // ── Pending decisions (best-effort) ──────────────────────────────────────
+  // Active (non-synced) decisions relevant to this task's domains or files.
+  // Synced decisions appear via the vector index (domain "decisions") in matchingSpecs.
   interface DecisionSummary {
     id: string;
     title: string;
@@ -357,11 +359,19 @@ export async function handleOrient(
   }
   let pendingDecisions: DecisionSummary[] | undefined;
   try {
-    const { loadDecisionStore } = await import('../../decisions/store.js');
+    const { loadDecisionStore, INACTIVE_STATUSES } = await import('../../decisions/store.js');
     const store = await loadDecisionStore(absDir);
-    const active = store.decisions.filter(
-      (d) => d.status !== 'synced' && d.status !== 'rejected',
-    );
+    const relevantDomainSet = new Set(specDomains.map((s) => s.domain));
+    const relevantFileSet = new Set(relevantFiles);
+    const active = store.decisions.filter((d) => {
+      if (INACTIVE_STATUSES.has(d.status)) return false;
+      // Surface if it touches a domain or file the orient task identified
+      if (d.affectedDomains.some((dom) => relevantDomainSet.has(dom))) return true;
+      if (d.affectedFiles.some((f) => relevantFileSet.has(f))) return true;
+      // Always surface approved decisions — agent must sync before committing
+      if (d.status === 'approved') return true;
+      return false;
+    });
     if (active.length > 0) {
       pendingDecisions = active.map((d) => ({
         id: d.id,

--- a/src/core/services/mcp-handlers/orient.ts
+++ b/src/core/services/mcp-handlers/orient.ts
@@ -384,6 +384,23 @@ export async function handleOrient(
     // non-fatal — decisions feature may not be initialised
   }
 
+  // ── Suggested tools (portable discovery for non-Claude Code clients) ─────
+  // Derived from what orient already knows — no extra I/O.
+  const _suggested: string[] = ['record_decision'];
+  if (relevantFunctions.some(f => f.isHub)) _suggested.push('analyze_impact');
+  if (insertionPoints.length > 0) _suggested.push('get_subgraph');
+  if (specDomains.length > 0) _suggested.push('get_spec');
+  const _taskLow = task.toLowerCase();
+  if (/\b(debug|trace|flow|path|reach|call.?chain)\b/.test(_taskLow)) _suggested.push('trace_execution_path');
+  if (/\b(schema|database|db|model|table|entity|migration)\b/.test(_taskLow)) _suggested.push('get_schema_inventory');
+  if (/\b(route|endpoint|api|http|rest|request|handler)\b/.test(_taskLow)) _suggested.push('get_route_inventory');
+  if (/\b(test|coverage|spec.?driven)\b/.test(_taskLow)) _suggested.push('get_test_coverage');
+  if (/\b(duplicate|clone|similar|refactor)\b/.test(_taskLow)) _suggested.push('get_duplicate_report');
+  if (/\b(cluster|community|coupled|group)\b/.test(_taskLow)) _suggested.push('get_cluster');
+  _suggested.push('check_spec_drift');
+  const _seen = new Set<string>();
+  const suggestedTools = _suggested.filter(t => (_seen.has(t) ? false : (_seen.add(t), true)));
+
   // ── Next steps ────────────────────────────────────────────────────────────
   const nextSteps: string[] = [];
   nextSteps.push(
@@ -417,6 +434,7 @@ export async function handleOrient(
     insertionPoints,
     ...(matchingSpecs !== undefined ? { matchingSpecs } : {}),
     ...(pendingDecisions !== undefined ? { pendingDecisions } : {}),
+    suggestedTools,
     nextSteps,
   };
 }

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -44,16 +44,20 @@ export interface McpWatcherOptions {
 
 const SOURCE_EXTENSIONS = /\.(ts|tsx|js|jsx|py|go|rs|rb|java|kt|php|cs|cpp|cc|cxx|h|hpp|c|swift)$/;
 
-const DEFAULT_IGNORED = [
-  '**/node_modules/**',
-  '**/.spec-gen/**',
-  '**/dist/**',
-  '**/.git/**',
-  '**/*.test.ts',
-  '**/*.test.js',
-  '**/*.spec.ts',
-  '**/*.spec.js',
-];
+// String-segment checks evaluated before kqueue/inotify FDs are opened — avoids
+// EMFILE on macOS when chokidar opens FDs for all directories before applying globs.
+const IGNORED_SEGMENTS = ['/node_modules/', '/.spec-gen/', '/dist/', '/.git/'];
+const IGNORED_SUFFIXES = ['.test.ts', '.test.js', '.spec.ts', '.spec.js'];
+
+function isIgnoredPath(filePath: string): boolean {
+  for (const seg of IGNORED_SEGMENTS) {
+    if (filePath.includes(seg)) return true;
+  }
+  for (const suf of IGNORED_SUFFIXES) {
+    if (filePath.endsWith(suf)) return true;
+  }
+  return false;
+}
 
 // ── McpWatcher ────────────────────────────────────────────────────────────────
 
@@ -61,7 +65,7 @@ export class McpWatcher {
   private readonly rootPath: string;
   private readonly outputPath: string;
   private readonly debounceMs: number;
-  private readonly ignore: string[];
+  private readonly extraIgnore: string[];
 
   private fsWatcher?: FSWatcher;
   private timers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -71,18 +75,22 @@ export class McpWatcher {
     this.rootPath   = options.rootPath;
     this.outputPath = options.outputPath
       ?? join(options.rootPath, SPEC_GEN_DIR, SPEC_GEN_ANALYSIS_SUBDIR);
-    this.debounceMs = options.debounceMs ?? 400;
-    this.ignore     = [...DEFAULT_IGNORED, ...(options.ignore ?? [])];
+    this.debounceMs  = options.debounceMs ?? 400;
+    this.extraIgnore = options.ignore ?? [];
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────────────
 
   async start(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
+      const extraIgnore = this.extraIgnore;
       this.fsWatcher = chokidar.watch(this.rootPath, {
-        ignored: this.ignore,
+        ignored: (filePath: string) =>
+          isIgnoredPath(filePath) ||
+          extraIgnore.some((p) => filePath.includes(p)),
         persistent: true,
         ignoreInitial: true,
+        followSymlinks: false,
         awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 50 },
       });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -388,6 +388,12 @@ export interface AuditReport {
 // DECISIONS
 // ============================================================================
 
+export type DecisionScope =
+  | 'local'        // single file, no cross-cutting concern
+  | 'component'    // single component/service/module boundary
+  | 'cross-domain' // touches multiple spec domains or service contracts
+  | 'system';      // global constraint (auth, data model, infra, API protocol)
+
 export type DecisionStatus =
   | 'draft'         // recorded by agent during dev session
   | 'consolidated'  // LLM has merged/resolved drafts
@@ -421,6 +427,9 @@ export interface PendingDecision {
   recordedAt: string;
   consolidatedAt?: string;
   verifiedAt?: string;
+
+  // Scope — gates ADR creation: only cross-domain and system produce ADRs
+  scope?: DecisionScope;
 
   // Verification output
   confidence: 'high' | 'medium' | 'low';


### PR DESCRIPTION
## Summary

- **Gate hardening**: phantom bypass fix, `approved_not_synced` gate reason, `--no-verify` sentinel detection via post-commit hook
- **Consolidation reliability**: use IDs as traceability anchor to prevent duplicate decisions from LLM title variation; stable `replaceDecisions` fixes silent consolidation drop bug; merged decisions inherit earliest superseded `recordedAt`
- **Decision scope tiers**: `DecisionScope = 'local' | 'component' | 'cross-domain' | 'system'` — only `cross-domain` and `system` generate ADR files, preventing ADR spam from trivial implementation choices
- **Scope classification**:
  - Consolidation LLM prompt includes scope criteria with explicit negative rules
  - Extractor capped to `local`/`component` — cross-domain upgrade requires full multi-domain visibility and therefore only occurs during consolidation
  - Auto-promotion in `record_decision` uses two independent deterministic triggers: structural (files span 2+ distinct top-level dirs) OR semantic (multi-domain + contract keyword, not refactor)
- **Gate violation taxonomy centralized**: `GATE_REASONS` constant in `constants.ts` — all 4 reason codes shared by gate handler, docs, and tests
- **Store/ADR sync invariant**: purge only after all per-decision syncs complete; partial failure leaves decision at `approved` (safe to retry)
- **Store lifecycle**: `purgeInactiveDecisions()` — `--sync` always calls syncer so purge runs even with zero approved decisions (fixes early-exit skip)
- **RAG indexing**: ADR files indexed under domain `"decisions"` — `search_specs` and `orient` return relevant ADRs semantically
- **Orient context**: pending decisions surfaced by task domain/file relevance
- **EMFILE fix on macOS**: chokidar v5 + kqueue opened 28k+ file descriptors before evaluating glob patterns. Switched `ignored` from glob array to a string-segment function evaluated before FDs are opened — eliminates EMFILE on projects with large `node_modules`
- **Replace `better-sqlite3` with `node:sqlite` built-in**: eliminates native addon compilation and GitHub prebuilt download at install time. Required for enterprise environments behind Nexus or other isolated registries. `node:sqlite` is built into Node.js 22.5+ — zero extra dependencies. Requires Node.js ≥ 22.5.0 (bumped from 20)
- **CI bumped to Node 24 LTS**: `node:sqlite` experimental warning is absent on Node 24+. Node 22 still works but prints the warning to stderr (suppress with `NODE_NO_WARNINGS=1`)
- **MCP tool annotations**: `readOnlyHint`/`destructiveHint`/`idempotentHint` added to all 45 tools — improves Claude Code Tool Search ranking so deferred tools surface faster on relevant queries
- **MCP `--minimal` profile**: `spec-gen mcp --minimal` exposes only 5 core tools (`orient`, `search_code`, `record_decision`, `detect_changes`, `check_spec_drift`). Pair with `alwaysLoad: true` in Claude Code `.mcp.json` for always-visible core tools; use the full server with `alwaysLoad: false` (default) for the remaining 40 deferred and searchable via Tool Search. Documented in `docs/agent-setup.md`
- **`orient()` `suggestedTools` field**: orient now returns a ranked list of relevant spec-gen tools derived from what it already knows (hub presence, spec domains, task keywords) — no extra I/O. Provides portable tool discovery for Cline/Cursor/OpenCode where Claude Code's Tool Search is unavailable
- **+27 tests** this session on scope gate, auto-promotion triggers, consolidator scope mapping, synced re-approval guard (+98 total vs base)

## Decision scope tiers

```
local        — single file, no cross-cutting concern (refactors, extractions, renames)
component    — single component/service/module, no cross-boundary contract impact
cross-domain — touches multiple spec domains AND changes behavioral contracts  ← ADR written
system       — global architectural constraint (auth, infra, data model, API) ← ADR written
```

Scope promotion uses deterministic triggers that prevent LLM-only escalation paths — structural trigger (files span 2+ distinct top-level source dirs mapped to different inferred domains) OR semantic (multi-domain + contract keyword + not refactor). Extractor always outputs `local`/`component`; upgrade to `cross-domain`/`system` only at consolidation.

Old `pending.json` without `scope` → treated as `component` (no ADR). CLI `--list` shows scope badge: gray=local, blue=component, yellow=cross-domain, red=system.

## node:sqlite migration notes

- Named params: `{ name: v }` → `{ '@name': v }`
- `db.pragma()` → `db.exec('PRAGMA ...')`
- `db.transaction(fn)()` → `runTransaction(db, fn)` helper using `SAVEPOINT` for nested transaction support
- `.all()` / `.get()` return `Record<string, SQLOutputValue>` — cast via `as unknown as T`
- **Experimental warning**: present on Node 22, absent on Node 24+. Not suppressed programmatically — `process.emit`/`process.emitWarning` monkeypatching is fragile and can mask legitimate warnings. Use `NODE_NO_WARNINGS=1` on Node 22 if needed.

## Two-server MCP config (token-efficient Claude Code setup)

```json
{
  "mcpServers": {
    "spec-gen-core": {
      "type": "stdio",
      "command": "spec-gen",
      "args": ["mcp", "--minimal"],
      "alwaysLoad": true
    },
    "spec-gen": {
      "type": "stdio",
      "command": "spec-gen",
      "args": ["mcp"],
      "alwaysLoad": false
    }
  }
}
```

Core 5 always in context (~500 tokens). Full 45 deferred, searchable via Tool Search.

## Test plan

- [x] `npm test` — 2663 tests pass
- [x] `record_decision` with local helper change → no ADR after sync (automated test)
- [x] `record_decision` with cross-domain auth change → ADR created after sync (automated test)
- [x] `record_decision` with 2 inferred domains + contract keyword → auto-promoted to `cross-domain` (automated test)
- [x] `record_decision` with files in 2 different top-level dirs → auto-promoted to `cross-domain` (automated test)
- [x] `spec-gen decisions --list` → scope badge visible (gray/blue/yellow/red manually verified)
- [x] Old `pending.json` without `scope` field → loads cleanly, defaults to `component` (manually verified)
- [x] `git commit` with approved-not-synced decisions → gate blocks with `approved_not_synced` reason (manually verified)
- [x] `git commit --no-verify` → post-commit hook logs bypass warning (manually verified)
- [x] `spec-gen analyze` on project with large `node_modules` → no EMFILE error on macOS (manually verified)
- [x] `npm install` in isolated network (no GitHub access) → installs cleanly, no native compilation (node:sqlite built-in)
- [x] Node 24 — no `node:sqlite` experimental warning (manually verified)
- [x] Node 22 — experimental warning present but suppressed with `NODE_NO_WARNINGS=1` (manually verified)
- [x] `spec-gen mcp --minimal` → only 5 tools listed (manually verified via CLI help)
- [x] `orient("add payment method")` → `suggestedTools` includes `get_subgraph`, `get_spec`, `check_spec_drift` (manually verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)