### PR TITLE
feat(mcp): epistemic lease — session-level architectural confidence decay

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ AI agents are powerful but amnesiac. On every new task:
 - They forget architectural decisions made two sessions ago
 - They have no link between specs and code — drift is invisible
 - File-by-file navigation often burns **15,000–50,000 tokens** per orientation pass, before a single line of useful code is written
+- In long sessions, they drift from authoritative retrieval toward internally cached reasoning — producing subtly wrong architectural assumptions that compound silently until a refactor breaks
 
 openlore closes this loop. Run a full analysis once, then keep the graph incrementally updated as the codebase evolves. Even greenfield projects become cognitively "brownfield" after only a few agent sessions — architectural context fragments, decisions disappear, and agents repeatedly reconstruct the same understanding from scratch.
 
@@ -49,6 +50,7 @@ You can use layer 1 alone to give agents structural context. Add layer 2 for sem
 | Token-efficient orient() | ❌ | ❌ | ✓ ~1–3k vs 15–50k tokens |
 | Living spec generation | ❌ | ❌ | ✓ |
 | Persistent cross-session architectural memory | ❌ | Partial | ✓ |
+| Long-session confidence decay (Epistemic Lease) | ❌ | ❌ | ✓ |
 
 Traditional coding agents reconstruct architecture from repeated file reads every session. openlore persists it as a queryable graph.
 
@@ -166,6 +168,23 @@ Compares git changes against spec mappings in milliseconds. Detects: Gap (code c
 `orient()` is the main entry point — one call replaces 10+ file reads. `detect_changes` risk-scores changed functions using call graph centrality × change type multiplier. See [docs/mcp-tools.md](docs/mcp-tools.md).
 
 `orient()` runs in **~430µs p50** against a 15k-node codebase (TypeScript compiler, ~79k edges). Full benchmark results: [scripts/BENCHMARKS.md](scripts/BENCHMARKS.md).
+
+**Epistemic Lease** (no API key)
+
+As a session grows longer, agents naturally shift from authoritative graph retrieval toward internally cached reasoning. This is useful for fluency but dangerous for architectural correctness — cross-module assumptions go stale, dependency hallucinations accumulate, and delegation prompts embed incorrect repository understanding that cannot easily be corrected downstream.
+
+The Epistemic Lease models this decay explicitly. Every MCP tool response carries a freshness signal when the agent's architectural context has degraded or expired. Decay is triggered by any of: time elapsed since `orient()`, git hash divergence from the orient baseline, weighted cognitive load accumulation (heavier tools count more), or cross-module file access breadth.
+
+The signal escalates through three levels to resist [warning blindness](https://en.wikipedia.org/wiki/Alarm_fatigue):
+
+| Level | Trigger | Signal style |
+|---|---|---|
+| Degraded | load ≥ 30, age ≥ 15min, or >3 modules | 3-line advisory appended |
+| Stale [1] | load ≥ 60 or age ≥ 30min or git change | Procedural block prepended: what NOT to do |
+| Stale [Elevated] | load ≥ 85 or age ≥ 45min | Risk-framing: names downstream consequences |
+| Stale [Critical] | load ≥ 110 or age ≥ 60min | Imperative: `STOP. Call orient().` — minimal, hardest to skim |
+
+When fresh, injection is zero-overhead. Calling `orient()` resets the tracker. Unlike governance systems, the lease never blocks — it modulates the agent's confidence in its own cached reasoning rather than constraining its actions.
 
 **Decisions** (API key for consolidation)
 

--- a/README.md
+++ b/README.md
@@ -179,16 +179,39 @@ The signal escalates through three levels to resist [warning blindness](https://
 
 | Level | Trigger | Signal style |
 |---|---|---|
-| Degraded | load ≥ 30, age ≥ 15min, or >3 modules | Advisory signal appended |
-| Stale | load ≥ 60 or age ≥ 30min or git change | Procedural block prepended: what NOT to do |
+| Degraded | load ≥ 30, age ≥ 15min, or cross-module density ≥ 0.15 | Advisory signal appended |
+| Stale | load ≥ 60, age ≥ 30min, git hash divergence, or density ≥ 0.30 | Procedural block prepended: what NOT to do |
 | Stale [Elevated] | load ≥ 85 or age ≥ 45min | Risk-framing: names downstream consequences |
 | Stale [Critical] | load ≥ 110 or age ≥ 60min | Imperative: `STOP. Call orient().` — minimal, hardest to skim |
+
+Cross-module density is computed as a sliding-window trajectory model: `switches_in_last_15_calls / 15`. The fixed denominator prevents false positives during session warmup. Each module switch adds +5 cognitive debt; a high-density window adds +15; a burst (density ≥ 0.60) adds +20. A 5s dampening window prevents back-and-forth from double-counting.
 
 When fresh, injection is zero-overhead. Calling `orient()` resets the tracker. Unlike governance systems, the lease never blocks — it modulates the agent's confidence in its own cached reasoning rather than constraining its actions.
 
 **Decisions** (API key for consolidation)
 
 Agents call `record_decision` before writing code. Consolidation runs immediately in the background. At commit time, a pre-commit hook gates the commit until all verified decisions are reviewed and written back as requirements in `spec.md` files. Decisions are classified by scope (`local / component / cross-domain / system`); only `cross-domain` and `system` decisions produce ADR files, keeping the decision log signal-dense.
+
+**Telemetry** (opt-in, no API key)
+
+Cognitive telemetry for empirical measurement of EpistemicLease behavior. Gated by `OPENLORE_TELEMETRY=1` — disabled by default. Writes append-only JSONL to `.openlore/telemetry/` per domain. Agent identity is captured from the MCP `initialize` handshake, enabling per-agent behavioral comparison.
+
+```
+.openlore/telemetry/
+  mcp.jsonl              # every tool call: latency, errors, agent name
+  orient.jsonl           # orient quality: function/file/insertion_point counts
+  cache.jsonl            # readCachedContext hit/miss
+  epistemic-lease.jsonl  # state transitions: degraded, stale, depth escalation
+```
+
+Analyze with `openlore telemetry`:
+
+```
+openlore telemetry [directory]   # summary: latency, cache hit rate, obstinacy index
+openlore telemetry --live        # stream events in real time as they occur
+```
+
+Key metrics: **obstinacy index** (tool calls after stale before orient — measures whether agents act on warnings), **recovery efficiency** (stale→orient latency), **trajectory dynamics** (avg cross-module density, burst frequency). These turn EpistemicLease from a tuning-by-intuition system into an empirically measurable one.
 
 ---
 
@@ -239,6 +262,7 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 | Agentic workflows (BMAD, Vibe, GSD, spec-kit) | [docs/agentic-workflows.md](docs/agentic-workflows.md) |
 | Troubleshooting | [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) |
 | Philosophy | [docs/PHILOSOPHY.md](docs/PHILOSOPHY.md) |
+| Telemetry & cognitive metrics | [docs/telemetry.md](docs/telemetry.md) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ The signal escalates through three levels to resist [warning blindness](https://
 
 | Level | Trigger | Signal style |
 |---|---|---|
-| Degraded | load ≥ 30, age ≥ 15min, or >3 modules | 3-line advisory appended |
-| Stale [1] | load ≥ 60 or age ≥ 30min or git change | Procedural block prepended: what NOT to do |
+| Degraded | load ≥ 30, age ≥ 15min, or >3 modules | Advisory signal appended |
+| Stale | load ≥ 60 or age ≥ 30min or git change | Procedural block prepended: what NOT to do |
 | Stale [Elevated] | load ≥ 85 or age ≥ 45min | Risk-framing: names downstream consequences |
 | Stale [Critical] | load ≥ 110 or age ≥ 60min | Imperative: `STOP. Call orient().` — minimal, hardest to skim |
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Compares git changes against spec mappings in milliseconds. Detects: Gap (code c
 
 **Epistemic Lease** (no API key)
 
+> **Core principle**: EpistemicLease models architectural drift as a behavioral navigation phenomenon rather than a semantic understanding problem. Context decay is driven by where the agent goes (cross-module trajectory), not what it knows.
+
 As a session grows longer, agents naturally shift from authoritative graph retrieval toward internally cached reasoning. This is useful for fluency but dangerous for architectural correctness — cross-module assumptions go stale, dependency hallucinations accumulate, and delegation prompts embed incorrect repository understanding that cannot easily be corrected downstream.
 
 The Epistemic Lease models this decay explicitly. Every MCP tool response carries a freshness signal when the agent's architectural context has degraded or expired. Decay is triggered by any of: time elapsed since `orient()`, git hash divergence from the orient baseline, weighted cognitive load accumulation (heavier tools count more), or cross-module file access breadth.
@@ -185,6 +187,8 @@ The signal escalates through three levels to resist [warning blindness](https://
 | Stale [Critical] | load ≥ 110 or age ≥ 60min | Imperative: `STOP. Call orient().` — minimal, hardest to skim |
 
 Cross-module density is computed as a sliding-window trajectory model: `switches_in_last_15_calls / 15`. The fixed denominator prevents false positives during session warmup. Each module switch adds +5 cognitive debt; a high-density window adds +15; a burst (density ≥ 0.60) adds +20. A 5s dampening window prevents back-and-forth from double-counting.
+
+An oscillation coefficient (`repeated_bigram_transitions / total_transitions`) separately distinguishes confusion loops (A→B→A→B scores 1.0) from genuine exploration (A→B→C→D scores 0.0). When already stale, a heavy architectural tool (weight ≥ 8) or density burst (≥ 0.60) triggers immediate escalation to Stale [Critical].
 
 When fresh, injection is zero-overhead. Calling `orient()` resets the tracker. Unlike governance systems, the lease never blocks — it modulates the agent's confidence in its own cached reasoning rather than constraining its actions.
 

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -44,6 +44,7 @@ import {
 } from '../../constants.js';
 import type { PendingDecision } from '../../types/index.js';
 import { runTuiApproval } from '../tui-approval.js';
+import { emit } from '../../core/services/telemetry.js';
 
 // ============================================================================
 // AGENT INSTRUCTION FILES
@@ -507,6 +508,7 @@ Examples:
         reviewNote: options.note ?? options.reason,
       });
       await saveDecisionStore(rootPath, updated);
+      emit(rootPath, 'decisions', { event: 'decision_approved', id, title: decision.title, transport: 'cli' });
       logger.success(`Decision ${id} approved.`);
       if (!options.json) displayDecision({ ...decision, status: 'approved' }, true);
 
@@ -548,6 +550,7 @@ Examples:
         reviewNote: options.note ?? options.reason,
       });
       await saveDecisionStore(rootPath, updated);
+      emit(rootPath, 'decisions', { event: 'decision_rejected', id, title: decision.title, transport: 'cli' });
       logger.success(`Decision ${id} rejected.`);
 
       if (!options.json && decision.affectedFiles.length > 0) {
@@ -684,6 +687,8 @@ Examples:
               status: decision,
               reviewedAt: new Date().toISOString(),
             });
+            const d = updatedStore.decisions.find((x) => x.id === id);
+            emit(rootPath, 'decisions', { event: `decision_${decision}`, id, title: d?.title, transport: 'cli-tui' });
           }
         }
         await saveDecisionStore(rootPath, gateStore);
@@ -934,6 +939,7 @@ Examples:
         specMap,
         dryRun: options.dryRun,
       });
+      emit(rootPath, 'decisions', { event: 'decisions_synced', count: result.synced.length, dry_run: options.dryRun, transport: 'cli' });
 
       if (options.json) {
         process.stdout.write(JSON.stringify(result, null, 2) + '\n');

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -26,6 +26,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { sanitizeMcpError, validateDirectory } from '../../core/services/mcp-handlers/utils.js';
+import { createTracker, updateTracker, injectFreshness } from '../../core/services/mcp-handlers/epistemic-lease.js';
 import { DEFAULT_DRIFT_MAX_FILES } from '../../constants.js';
 import {
   handleGetCallGraph,
@@ -1295,6 +1296,9 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
     tools: activeTools.map(t => ({ ...t, annotations: TOOL_ANNOTATIONS[t.name] })),
   }));
 
+  // Per-session epistemic lease tracker — initialized on first tool call that carries a directory.
+  let tracker: ReturnType<typeof createTracker> | undefined;
+
   // --watch-auto: start the watcher on the first tool call that carries a directory
   let autoWatcher: import('../../core/services/mcp-watcher.js').McpWatcher | undefined;
 
@@ -1319,6 +1323,15 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
     }
 
     try {
+      const dir = (args as Record<string, unknown>).directory;
+      const directory = typeof dir === 'string' ? dir : '';
+      const filePath = (args as Record<string, unknown>).filePath;
+
+      // Lazy-init tracker on first call with a directory
+      if (!tracker && directory) tracker = createTracker(directory);
+      // Update epistemic state before dispatch (orient resets tracker)
+      if (tracker && directory) updateTracker(tracker, name, directory, typeof filePath === 'string' ? filePath : undefined);
+
       let result: unknown;
 
       if (name === 'orient') {
@@ -1490,8 +1503,9 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
         };
       }
 
-      const text =
+      let text =
         typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+      if (tracker) text = injectFreshness(text, tracker);
 
       return {
         content: [{ type: 'text', text }],

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -17,6 +17,10 @@
  *   }
  */
 
+import { createRequire } from 'node:module';
+const _require = createRequire(import.meta.url);
+const _pkgVersion = (_require('../../../package.json') as { version: string }).version;
+
 import { Command } from 'commander';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -28,6 +32,7 @@ import {
 
 import { sanitizeMcpError, validateDirectory } from '../../core/services/mcp-handlers/utils.js';
 import { createTracker, updateTracker, getFreshnessSignal } from '../../core/services/mcp-handlers/epistemic-lease.js';
+import type { EpistemicTracker } from '../../core/services/mcp-handlers/epistemic-lease.js';
 import { emit } from '../../core/services/telemetry.js';
 import { DEFAULT_DRIFT_MAX_FILES } from '../../constants.js';
 import {
@@ -1298,8 +1303,9 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
     tools: activeTools.map(t => ({ ...t, annotations: TOOL_ANNOTATIONS[t.name] })),
   }));
 
-  // Per-session epistemic lease tracker — initialized on first tool call that carries a directory.
-  let tracker: ReturnType<typeof createTracker> | undefined;
+  // Per-session epistemic lease tracker — re-initialized when directory changes.
+  let tracker: EpistemicTracker | undefined;
+  let trackerDir = '';
 
   // --watch-auto: start the watcher on the first tool call that carries a directory
   let autoWatcher: import('../../core/services/mcp-watcher.js').McpWatcher | undefined;
@@ -1313,7 +1319,7 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
     return {
       protocolVersion: request.params.protocolVersion,
       capabilities: { tools: {} },
-      serverInfo: { name: 'openlore', version: '1.0.0' },
+      serverInfo: { name: 'openlore', version: _pkgVersion },
     };
   });
 
@@ -1344,15 +1350,18 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
     try {
       const filePath = (args as Record<string, unknown>).filePath;
 
-      // Lazy-init tracker on first call with a directory
-      if (!tracker && directory) tracker = createTracker(directory);
-      // Update epistemic state before dispatch (orient resets tracker)
+      // Init (or re-init when project directory changes between calls)
+      if (directory && (!tracker || directory !== trackerDir)) {
+        tracker = createTracker(directory);
+        trackerDir = directory;
+      }
+      // Update epistemic state before dispatch (orient resets tracker internally)
       if (tracker && directory) updateTracker(tracker, name, directory, typeof filePath === 'string' ? filePath : undefined);
 
       let result: unknown;
 
       if (name === 'orient') {
-        const { directory, task, limit = 5 } = args as { directory: string; task: string; limit?: number };
+        const { task, limit = 5 } = args as { task: string; limit?: number };
         result = await handleOrient(directory, task, limit);
         if (result && typeof result === 'object') {
           const r = result as Record<string, unknown>;

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -26,7 +26,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 
 import { sanitizeMcpError, validateDirectory } from '../../core/services/mcp-handlers/utils.js';
-import { createTracker, updateTracker, injectFreshness } from '../../core/services/mcp-handlers/epistemic-lease.js';
+import { createTracker, updateTracker, getFreshnessSignal } from '../../core/services/mcp-handlers/epistemic-lease.js';
 import { DEFAULT_DRIFT_MAX_FILES } from '../../constants.js';
 import {
   handleGetCallGraph,
@@ -1503,13 +1503,19 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
         };
       }
 
-      let text =
+      const text =
         typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-      if (tracker) text = injectFreshness(text, tracker);
+      const signal = tracker ? getFreshnessSignal(tracker) : null;
 
-      return {
-        content: [{ type: 'text', text }],
-      };
+      // Freshness signal is a separate content item — never concatenated into
+      // the result body — so structured outputs (JSON, patches) are not corrupted.
+      const content: Array<{ type: 'text'; text: string }> = signal
+        ? signal.prepend
+          ? [{ type: 'text', text: signal.text }, { type: 'text', text }]
+          : [{ type: 'text', text }, { type: 'text', text: signal.text }]
+        : [{ type: 'text', text }];
+
+      return { content };
     } catch (err) {
       return {
         content: [{ type: 'text', text: `Tool error: ${sanitizeMcpError(err)}` }],

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -27,6 +27,7 @@ import {
 
 import { sanitizeMcpError, validateDirectory } from '../../core/services/mcp-handlers/utils.js';
 import { createTracker, updateTracker, getFreshnessSignal } from '../../core/services/mcp-handlers/epistemic-lease.js';
+import { emit } from '../../core/services/telemetry.js';
 import { DEFAULT_DRIFT_MAX_FILES } from '../../constants.js';
 import {
   handleGetCallGraph,
@@ -1322,9 +1323,11 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
       }
     }
 
+    const _dir = (args as Record<string, unknown>).directory;
+    const directory = typeof _dir === 'string' ? _dir : '';
+    const _t0 = Date.now();
+
     try {
-      const dir = (args as Record<string, unknown>).directory;
-      const directory = typeof dir === 'string' ? dir : '';
       const filePath = (args as Record<string, unknown>).filePath;
 
       // Lazy-init tracker on first call with a directory
@@ -1337,6 +1340,16 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
       if (name === 'orient') {
         const { directory, task, limit = 5 } = args as { directory: string; task: string; limit?: number };
         result = await handleOrient(directory, task, limit);
+        if (result && typeof result === 'object') {
+          const r = result as Record<string, unknown>;
+          emit(directory, 'orient', {
+            event: 'orient_call',
+            functions: Array.isArray(r['relevantFunctions']) ? r['relevantFunctions'].length : 0,
+            files: Array.isArray(r['relevantFiles']) ? r['relevantFiles'].length : 0,
+            spec_domains: Array.isArray(r['specDomains']) ? r['specDomains'].length : 0,
+            insertion_points: Array.isArray(r['insertionPoints']) ? r['insertionPoints'].length : 0,
+          });
+        }
       } else if (name === 'analyze_codebase') {
         const { directory, force = false } = args as { directory: string; force?: boolean };
         result = await handleAnalyzeCodebase(directory, force);
@@ -1503,6 +1516,8 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
         };
       }
 
+      emit(directory, 'mcp', { event: 'tool_call', tool: name, ms: Date.now() - _t0 });
+
       const text =
         typeof result === 'string' ? result : JSON.stringify(result, null, 2);
       const signal = tracker ? getFreshnessSignal(tracker) : null;
@@ -1517,6 +1532,7 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
 
       return { content };
     } catch (err) {
+      emit(directory, 'mcp', { event: 'tool_error', tool: name, ms: Date.now() - _t0, error: sanitizeMcpError(err) });
       return {
         content: [{ type: 'text', text: `Tool error: ${sanitizeMcpError(err)}` }],
         isError: true,

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -22,6 +22,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   CallToolRequestSchema,
+  InitializeRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 
@@ -1303,6 +1304,19 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
   // --watch-auto: start the watcher on the first tool call that carries a directory
   let autoWatcher: import('../../core/services/mcp-watcher.js').McpWatcher | undefined;
 
+  // Agent identity captured from initialize handshake
+  let agentName = 'unknown';
+  let agentVersion = 'unknown';
+  server.setRequestHandler(InitializeRequestSchema, async (request) => {
+    agentName = request.params.clientInfo?.name ?? 'unknown';
+    agentVersion = request.params.clientInfo?.version ?? 'unknown';
+    return {
+      protocolVersion: request.params.protocolVersion,
+      capabilities: { tools: {} },
+      serverInfo: { name: 'openlore', version: '1.0.0' },
+    };
+  });
+
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
 
@@ -1344,6 +1358,7 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
           const r = result as Record<string, unknown>;
           emit(directory, 'orient', {
             event: 'orient_call',
+            agent: agentName,
             functions: Array.isArray(r['relevantFunctions']) ? r['relevantFunctions'].length : 0,
             files: Array.isArray(r['relevantFiles']) ? r['relevantFiles'].length : 0,
             spec_domains: Array.isArray(r['specDomains']) ? r['specDomains'].length : 0,
@@ -1516,7 +1531,7 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
         };
       }
 
-      emit(directory, 'mcp', { event: 'tool_call', tool: name, ms: Date.now() - _t0 });
+      emit(directory, 'mcp', { event: 'tool_call', tool: name, ms: Date.now() - _t0, agent: agentName, agent_version: agentVersion });
 
       const text =
         typeof result === 'string' ? result : JSON.stringify(result, null, 2);
@@ -1532,7 +1547,7 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
 
       return { content };
     } catch (err) {
-      emit(directory, 'mcp', { event: 'tool_error', tool: name, ms: Date.now() - _t0, error: sanitizeMcpError(err) });
+      emit(directory, 'mcp', { event: 'tool_error', tool: name, ms: Date.now() - _t0, agent: agentName, error: sanitizeMcpError(err) });
       return {
         content: [{ type: 'text', text: `Tool error: ${sanitizeMcpError(err)}` }],
         isError: true,

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -311,15 +311,13 @@ function renderLive(dir: string) {
   // Initial tail
   Promise.all(files.map(tail));
 
-  for (const f of files) {
-    const watchDir = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR);
-    if (existsSync(watchDir)) {
-      watch(watchDir, { persistent: true }, async (_event, filename) => {
-        if (!filename) return;
-        const full = join(watchDir, filename);
-        if (files.includes(full)) await tail(full);
-      });
-    }
+  const watchDir = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR);
+  if (existsSync(watchDir)) {
+    watch(watchDir, { persistent: true }, async (_event, filename) => {
+      if (!filename) return;
+      const full = join(watchDir, filename);
+      if (files.includes(full)) await tail(full);
+    });
   }
 }
 

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -1,0 +1,363 @@
+/**
+ * openlore telemetry — cognitive telemetry analysis for EpistemicLease.
+ *
+ * Reads append-only JSONL streams from .openlore/telemetry/ and computes
+ * higher-level behavioral metrics describing long-session agent cognition.
+ *
+ * Streams line-by-line via readline (O(1) memory — arbitrarily large sessions).
+ */
+
+import { Command } from 'commander';
+import { createReadStream, existsSync, watch } from 'node:fs';
+import { createInterface } from 'node:readline';
+import { join } from 'node:path';
+import { OPENLORE_DIR } from '../../constants.js';
+
+const TELEMETRY_SUBDIR = 'telemetry';
+
+// ============================================================================
+// JSONL reader — O(1) streaming
+// ============================================================================
+
+async function readJsonl<T>(filePath: string): Promise<T[]> {
+  if (!existsSync(filePath)) return [];
+  const rows: T[] = [];
+  const rl = createInterface({ input: createReadStream(filePath, 'utf-8'), crlfDelay: Infinity });
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try { rows.push(JSON.parse(trimmed) as T); } catch { /* skip malformed */ }
+  }
+  return rows;
+}
+
+interface McpEvent {
+  ts: string; event: 'tool_call' | 'tool_error'; tool: string;
+  ms: number; agent?: string; agent_version?: string; error?: string;
+}
+interface OrientEvent {
+  ts: string; event: 'orient_call';
+  agent?: string; functions: number; files: number;
+  spec_domains: number; insertion_points: number;
+}
+interface CacheEvent {
+  ts: string; event: 'cache_read'; hit: boolean;
+}
+interface LeaseEvent {
+  ts: string;
+  event: 'degraded' | 'stale' | 'depth_escalate' | 'orient_reset';
+  trigger?: string; depth?: number; from_depth?: number; to_depth?: number;
+  from_state?: string; tool?: string; cognitive_load?: number;
+  density?: number; age_min?: number; prior_load?: number; prior_depth?: number;
+}
+
+// ============================================================================
+// METRIC COMPUTATIONS
+// ============================================================================
+
+function computeToolStats(mcp: McpEvent[]) {
+  const calls = mcp.filter(e => e.event === 'tool_call');
+  const errors = mcp.filter(e => e.event === 'tool_error');
+  const byTool = new Map<string, number[]>();
+  for (const e of calls) {
+    const arr = byTool.get(e.tool) ?? [];
+    arr.push(e.ms);
+    byTool.set(e.tool, arr);
+  }
+  const stats = [...byTool.entries()].map(([tool, latencies]) => {
+    const avg = Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length);
+    const max = Math.max(...latencies);
+    return { tool, count: latencies.length, avg_ms: avg, max_ms: max };
+  }).sort((a, b) => b.count - a.count);
+  return { stats, total_calls: calls.length, total_errors: errors.length };
+}
+
+function computeCacheStats(cache: CacheEvent[]) {
+  const hits = cache.filter(e => e.hit).length;
+  const total = cache.length;
+  return { hits, misses: total - hits, total, hit_rate: total ? Math.round(hits / total * 100) : 0 };
+}
+
+function computeOrientQuality(orient: OrientEvent[]) {
+  if (!orient.length) return null;
+  const avg = (arr: number[]) => arr.length ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
+  return {
+    calls: orient.length,
+    avg_functions: avg(orient.map(e => e.functions)),
+    avg_files: avg(orient.map(e => e.files)),
+    avg_insertion_points: avg(orient.map(e => e.insertion_points)),
+    agents: [...new Set(orient.map(e => e.agent ?? 'unknown'))],
+  };
+}
+
+/**
+ * Obstinacy: tool calls (non-orient) after each stale event before next orient/reset.
+ * High value = agent ignores stale warnings.
+ */
+function computeObstinacy(mcp: McpEvent[], lease: LeaseEvent[]) {
+  // Merge and sort by ts
+  type Tagged = { ts: string; kind: 'stale' | 'orient' | 'tool'; depth?: number; tool?: string };
+  const events: Tagged[] = [];
+
+  for (const e of lease) {
+    if (e.event === 'stale') events.push({ ts: e.ts, kind: 'stale', depth: e.depth });
+    if (e.event === 'orient_reset') events.push({ ts: e.ts, kind: 'orient' });
+  }
+  for (const e of mcp) {
+    if (e.event === 'tool_call') events.push({ ts: e.ts, kind: e.tool === 'orient' ? 'orient' : 'tool', tool: e.tool });
+  }
+  events.sort((a, b) => a.ts.localeCompare(b.ts));
+
+  const segments: { depth: number; calls_before_orient: number }[] = [];
+  let inStale = false;
+  let staleDepth = 0;
+  let callCount = 0;
+
+  for (const ev of events) {
+    if (ev.kind === 'stale') {
+      if (!inStale) { inStale = true; staleDepth = ev.depth ?? 1; callCount = 0; }
+      else if ((ev.depth ?? 1) > staleDepth) { staleDepth = ev.depth ?? 1; }
+    } else if (ev.kind === 'orient') {
+      if (inStale) { segments.push({ depth: staleDepth, calls_before_orient: callCount }); }
+      inStale = false; callCount = 0;
+    } else if (ev.kind === 'tool' && inStale) {
+      callCount++;
+    }
+  }
+  if (inStale) segments.push({ depth: staleDepth, calls_before_orient: callCount });
+
+  const avg = (arr: number[]) => arr.length ? (arr.reduce((a, b) => a + b, 0) / arr.length).toFixed(1) : '—';
+  const d2 = segments.filter(s => s.depth >= 2).map(s => s.calls_before_orient);
+  const d3 = segments.filter(s => s.depth >= 3).map(s => s.calls_before_orient);
+  return {
+    total_stale_episodes: segments.length,
+    avg_calls_before_orient: avg(segments.map(s => s.calls_before_orient)),
+    depth2_avg: avg(d2),
+    depth3_avg: avg(d3),
+    episodes: segments,
+  };
+}
+
+/**
+ * Recovery efficiency: time from stale to orient call (ms).
+ */
+function computeRecovery(mcp: McpEvent[], lease: LeaseEvent[]) {
+  const staleTs = lease.filter(e => e.event === 'stale').map(e => e.ts).sort();
+  const orientTs = mcp.filter(e => e.event === 'tool_call' && e.tool === 'orient').map(e => e.ts).sort();
+
+  const latencies: number[] = [];
+  for (const st of staleTs) {
+    const next = orientTs.find(o => o > st);
+    if (next) latencies.push(new Date(next).getTime() - new Date(st).getTime());
+  }
+  const avg = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : null;
+  const staleRecurrences = lease.filter(e => e.event === 'stale').length;
+  const orients = orientTs.length;
+  return {
+    stale_events: staleRecurrences,
+    orient_calls: orients,
+    avg_recovery_ms: avg,
+    recurrence_rate: orients ? `${(staleRecurrences / orients).toFixed(2)} stale/orient` : '—',
+  };
+}
+
+/**
+ * Trajectory entropy: low entropy oscillation (auth→billing→auth→billing) vs
+ * exploratory (auth→billing→infra→cache). Uses bigram repetition ratio.
+ */
+function computeTrajectoryEntropy(lease: LeaseEvent[]) {
+  const densities = lease
+    .filter(e => e.event === 'degraded' || e.event === 'stale')
+    .map(e => e.density ?? 0)
+    .filter(d => d > 0);
+
+  const bursts = lease.filter(e => (e.event === 'degraded' || e.event === 'stale') && (e.density ?? 0) >= 0.6).length;
+  const avg = densities.length ? (densities.reduce((a, b) => a + b, 0) / densities.length).toFixed(3) : '—';
+  const max = densities.length ? Math.max(...densities).toFixed(3) : '—';
+
+  return {
+    avg_density: avg,
+    max_density: max,
+    burst_events: bursts,
+    density_samples: densities.length,
+  };
+}
+
+// ============================================================================
+// RENDERING
+// ============================================================================
+
+function hr() { console.log('─'.repeat(60)); }
+function section(title: string) { hr(); console.log(`  ${title}`); hr(); }
+
+function renderSummary(
+  mcp: McpEvent[], orient: OrientEvent[], cache: CacheEvent[], lease: LeaseEvent[]
+) {
+  const tools = computeToolStats(mcp);
+  const cacheStats = computeCacheStats(cache);
+  const quality = computeOrientQuality(orient);
+  const obstinacy = computeObstinacy(mcp, lease);
+  const recovery = computeRecovery(mcp, lease);
+  const trajectory = computeTrajectoryEntropy(lease);
+
+  const agents = [...new Set(mcp.map(e => e.agent).filter(Boolean))];
+  if (agents.length) {
+    section('AGENTS');
+    for (const a of agents) console.log(`  ${a}`);
+  }
+
+  section('TOOL LATENCY');
+  if (tools.stats.length) {
+    console.log(`  ${'tool'.padEnd(32)} ${'calls'.padStart(6)} ${'avg ms'.padStart(8)} ${'max ms'.padStart(8)}`);
+    for (const s of tools.stats.slice(0, 15)) {
+      console.log(`  ${s.tool.padEnd(32)} ${String(s.count).padStart(6)} ${String(s.avg_ms).padStart(8)} ${String(s.max_ms).padStart(8)}`);
+    }
+    console.log(`\n  total: ${tools.total_calls} calls, ${tools.total_errors} errors`);
+  } else {
+    console.log('  no mcp.jsonl data');
+  }
+
+  section('CACHE');
+  console.log(`  hit rate : ${cacheStats.hit_rate}%  (${cacheStats.hits} hits / ${cacheStats.total} reads)`);
+
+  section('ORIENT QUALITY');
+  if (quality) {
+    console.log(`  calls              : ${quality.calls}`);
+    console.log(`  avg functions      : ${quality.avg_functions}`);
+    console.log(`  avg files          : ${quality.avg_files}`);
+    console.log(`  avg insertion pts  : ${quality.avg_insertion_points}`);
+    if (quality.agents.length) console.log(`  agents             : ${quality.agents.join(', ')}`);
+  } else {
+    console.log('  no orient.jsonl data');
+  }
+
+  section('EPISTEMIC STATE');
+  const degraded = lease.filter(e => e.event === 'degraded').length;
+  const stale = lease.filter(e => e.event === 'stale').length;
+  const d2 = lease.filter(e => e.event === 'stale' && (e.depth ?? 0) >= 2).length;
+  const d3 = lease.filter(e => e.event === 'stale' && (e.depth ?? 0) >= 3).length;
+  const triggers = new Map<string, number>();
+  for (const e of lease) {
+    if (e.trigger) triggers.set(e.trigger, (triggers.get(e.trigger) ?? 0) + 1);
+  }
+  console.log(`  degraded events  : ${degraded}`);
+  console.log(`  stale events     : ${stale}  (depth≥2: ${d2}, depth≥3: ${d3})`);
+  if (triggers.size) {
+    console.log(`  triggers         : ${[...triggers.entries()].map(([k, v]) => `${k}×${v}`).join('  ')}`);
+  }
+
+  section('OBSTINACY INDEX');
+  console.log(`  stale episodes         : ${obstinacy.total_stale_episodes}`);
+  console.log(`  avg calls before orient: ${obstinacy.avg_calls_before_orient}`);
+  console.log(`  depth≥2 avg            : ${obstinacy.depth2_avg}`);
+  console.log(`  depth≥3 avg            : ${obstinacy.depth3_avg}`);
+
+  section('RECOVERY EFFICIENCY');
+  console.log(`  avg stale→orient latency : ${recovery.avg_recovery_ms != null ? `${recovery.avg_recovery_ms}ms` : '—'}`);
+  console.log(`  recurrence rate          : ${recovery.recurrence_rate}`);
+
+  section('TRAJECTORY DYNAMICS');
+  console.log(`  avg cross-module density : ${trajectory.avg_density}`);
+  console.log(`  max density              : ${trajectory.max_density}`);
+  console.log(`  burst events (≥0.6)      : ${trajectory.burst_events}`);
+
+  hr();
+}
+
+function renderLive(dir: string) {
+  const leaseFile = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR, 'epistemic-lease.jsonl');
+  const mcpFile = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR, 'mcp.jsonl');
+
+  // Track file positions to only read new lines
+  const offsets = new Map<string, number>([
+    [leaseFile, 0], [mcpFile, 0],
+  ]);
+
+  async function tail(filePath: string) {
+    if (!existsSync(filePath)) return;
+    const { createReadStream } = await import('node:fs');
+    const offset = offsets.get(filePath) ?? 0;
+    const stream = createReadStream(filePath, { start: offset, encoding: 'utf-8' });
+    let buf = '';
+    stream.on('data', chunk => { buf += chunk; });
+    stream.on('end', () => {
+      offsets.set(filePath, offset + Buffer.byteLength(buf, 'utf-8'));
+      for (const line of buf.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const ev = JSON.parse(trimmed) as Record<string, unknown>;
+          const ts = String(ev['ts'] ?? '').slice(11, 23);
+          if (filePath === leaseFile) {
+            const evt = ev['event'];
+            if (evt === 'stale') console.log(`${ts}  STALE depth=${ev['depth']} trigger=${ev['trigger']} load=${ev['cognitive_load']} density=${ev['density']}`);
+            else if (evt === 'degraded') console.log(`${ts}  DEGRADED trigger=${ev['trigger']} density=${ev['density']}`);
+            else if (evt === 'orient_reset') console.log(`${ts}  ORIENT_RESET from=${ev['from_state']} prior_load=${ev['prior_load']}`);
+            else if (evt === 'depth_escalate') console.log(`${ts}  DEPTH ${ev['from_depth']} → ${ev['to_depth']}`);
+          } else {
+            const tool = ev['tool'];
+            const agent = ev['agent'] ? ` [${ev['agent']}]` : '';
+            if (ev['event'] === 'tool_call') console.log(`${ts}  ${String(tool).padEnd(30)} ${ev['ms']}ms${agent}`);
+            else if (ev['event'] === 'tool_error') console.log(`${ts}  ERROR ${tool}${agent}`);
+          }
+        } catch { /* skip */ }
+      }
+    });
+  }
+
+  console.log(`Watching ${join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR)} — Ctrl+C to stop\n`);
+
+  const files = [leaseFile, mcpFile];
+  // Initial tail
+  Promise.all(files.map(tail));
+
+  for (const f of files) {
+    const watchDir = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR);
+    if (existsSync(watchDir)) {
+      watch(watchDir, { persistent: true }, async (_event, filename) => {
+        if (!filename) return;
+        const full = join(watchDir, filename);
+        if (files.includes(full)) await tail(full);
+      });
+    }
+  }
+}
+
+// ============================================================================
+// COMMAND
+// ============================================================================
+
+export const telemetryCommand = new Command('telemetry')
+  .description('Analyze EpistemicLease cognitive telemetry')
+  .argument('[directory]', 'Project directory', process.cwd())
+  .option('--live', 'Stream cognitive events in real time')
+  .addHelpText('after', `
+Examples:
+  $ openlore telemetry                    Summary stats for current directory
+  $ openlore telemetry /path/to/repo      Summary for specific project
+  $ openlore telemetry --live             Stream events live
+`)
+  .action(async function (directory: string, options: { live?: boolean }) {
+    const dir = directory ?? process.cwd();
+    const telDir = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR);
+
+    if (options.live) {
+      renderLive(dir);
+      return; // keep process alive — watcher keeps running
+    }
+
+    const [mcp, orient, cache, lease] = await Promise.all([
+      readJsonl<McpEvent>(join(telDir, 'mcp.jsonl')),
+      readJsonl<OrientEvent>(join(telDir, 'orient.jsonl')),
+      readJsonl<CacheEvent>(join(telDir, 'cache.jsonl')),
+      readJsonl<LeaseEvent>(join(telDir, 'epistemic-lease.jsonl')),
+    ]);
+
+    if (!mcp.length && !orient.length && !cache.length && !lease.length) {
+      console.log(`No telemetry found at ${telDir}`);
+      console.log('Enable with: export OPENLORE_TELEMETRY=1');
+      return;
+    }
+
+    renderSummary(mcp, orient, cache, lease);
+  });

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -48,7 +48,7 @@ interface LeaseEvent {
   event: 'degraded' | 'stale' | 'depth_escalate' | 'orient_reset';
   trigger?: string; depth?: number; from_depth?: number; to_depth?: number;
   from_state?: string; tool?: string; cognitive_load?: number;
-  density?: number; age_min?: number; prior_load?: number; prior_depth?: number;
+  density?: number; oscillation?: number; age_min?: number; prior_load?: number; prior_depth?: number;
 }
 
 // ============================================================================
@@ -139,7 +139,8 @@ function computeObstinacy(mcp: McpEvent[], lease: LeaseEvent[]) {
 }
 
 /**
- * Recovery efficiency: time from stale to orient call (ms).
+ * Recovery efficiency: time from stale to orient call (ms),
+ * and recovery half-life: time from orient_reset to first degraded/stale after it.
  */
 function computeRecovery(mcp: McpEvent[], lease: LeaseEvent[]) {
   const staleTs = lease.filter(e => e.event === 'stale').map(e => e.ts).sort();
@@ -151,12 +152,27 @@ function computeRecovery(mcp: McpEvent[], lease: LeaseEvent[]) {
     if (next) latencies.push(new Date(next).getTime() - new Date(st).getTime());
   }
   const avg = latencies.length ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length) : null;
+
+  // Recovery half-life: orient_reset → next degraded/stale (how long context stays fresh post-orient).
+  const resetTs = lease.filter(e => e.event === 'orient_reset').map(e => e.ts).sort();
+  const degradationTs = lease.filter(e => e.event === 'degraded' || e.event === 'stale').map(e => e.ts).sort();
+  const stableDurations: number[] = [];
+  for (const rt of resetTs) {
+    const next = degradationTs.find(d => d > rt);
+    if (next) stableDurations.push(new Date(next).getTime() - new Date(rt).getTime());
+  }
+  const avgStableMs = stableDurations.length
+    ? Math.round(stableDurations.reduce((a, b) => a + b, 0) / stableDurations.length)
+    : null;
+
   const staleRecurrences = lease.filter(e => e.event === 'stale').length;
   const orients = orientTs.length;
   return {
     stale_events: staleRecurrences,
     orient_calls: orients,
+    orient_resets: resetTs.length,
     avg_recovery_ms: avg,
+    avg_stable_after_orient_ms: avgStableMs,
     recurrence_rate: orients ? `${(staleRecurrences / orients).toFixed(2)} stale/orient` : '—',
   };
 }
@@ -254,6 +270,8 @@ function renderSummary(
 
   section('RECOVERY EFFICIENCY');
   console.log(`  avg stale→orient latency : ${recovery.avg_recovery_ms != null ? `${recovery.avg_recovery_ms}ms` : '—'}`);
+  console.log(`  recovery half-life       : ${recovery.avg_stable_after_orient_ms != null ? `${recovery.avg_stable_after_orient_ms}ms` : '—'}  (orient_reset → next degradation)`);
+  console.log(`  orient resets            : ${recovery.orient_resets}`);
   console.log(`  recurrence rate          : ${recovery.recurrence_rate}`);
 
   section('TRAJECTORY DYNAMICS');
@@ -290,10 +308,22 @@ function renderLive(dir: string) {
           const ts = String(ev['ts'] ?? '').slice(11, 23);
           if (filePath === leaseFile) {
             const evt = ev['event'];
-            if (evt === 'stale') console.log(`${ts}  STALE depth=${ev['depth']} trigger=${ev['trigger']} load=${ev['cognitive_load']} density=${ev['density']}`);
-            else if (evt === 'degraded') console.log(`${ts}  DEGRADED trigger=${ev['trigger']} density=${ev['density']}`);
-            else if (evt === 'orient_reset') console.log(`${ts}  ORIENT_RESET from=${ev['from_state']} prior_load=${ev['prior_load']}`);
-            else if (evt === 'depth_escalate') console.log(`${ts}  DEPTH ${ev['from_depth']} → ${ev['to_depth']}`);
+            if (evt === 'stale' || evt === 'degraded') {
+              const density = Number(ev['density'] ?? 0);
+              const oscillation = Number(ev['oscillation'] ?? 0);
+              const isSpike = density >= 0.60;
+              const isOscillating = oscillation >= 0.50;
+              const structuredType = isSpike ? 'TRAJECTORY_SPIKE' : 'STATE_TRANSITION';
+              const depthStr = evt === 'stale' ? ` depth=${ev['depth']}` : '';
+              let line = `${ts}  [${structuredType}] ${String(evt).toUpperCase()}${depthStr} trigger=${ev['trigger']} load=${ev['cognitive_load']} density=${density.toFixed(3)}`;
+              if (isOscillating) line += `  [OSCILLATION_DETECTED osc=${oscillation.toFixed(2)}]`;
+              console.log(line);
+            } else if (evt === 'orient_reset') {
+              console.log(`${ts}  [ORIENT_RECOVERY] from=${ev['from_state']} prior_load=${ev['prior_load']} prior_depth=${ev['prior_depth']}`);
+            } else if (evt === 'depth_escalate') {
+              const burstStr = ev['trigger'] === 'burst' ? ' (burst)' : '';
+              console.log(`${ts}  [STATE_TRANSITION] DEPTH ${ev['from_depth']} → ${ev['to_depth']}${burstStr} density=${Number(ev['density'] ?? 0).toFixed(3)}`);
+            }
           } else {
             const tool = ev['tool'];
             const agent = ev['agent'] ? ` [${ev['agent']}]` : '';

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -81,13 +81,23 @@ function computeCacheStats(cache: CacheEvent[]) {
 function computeOrientQuality(orient: OrientEvent[]) {
   if (!orient.length) return null;
   const avg = (arr: number[]) => arr.length ? Math.round(arr.reduce((a, b) => a + b, 0) / arr.length) : 0;
-  return {
-    calls: orient.length,
-    avg_functions: avg(orient.map(e => e.functions)),
-    avg_files: avg(orient.map(e => e.files)),
-    avg_insertion_points: avg(orient.map(e => e.insertion_points)),
-    agents: [...new Set(orient.map(e => e.agent ?? 'unknown'))],
-  };
+  const byAgent = new Map<string, OrientEvent[]>();
+  for (const e of orient) {
+    const agent = e.agent ?? 'unknown';
+    const arr = byAgent.get(agent) ?? [];
+    arr.push(e);
+    byAgent.set(agent, arr);
+  }
+  const perAgent = [...byAgent.entries()]
+    .map(([agent, events]) => ({
+      agent,
+      calls: events.length,
+      avg_functions: avg(events.map(e => e.functions)),
+      avg_files: avg(events.map(e => e.files)),
+      avg_insertion_points: avg(events.map(e => e.insertion_points)),
+    }))
+    .sort((a, b) => b.calls - a.calls);
+  return { total_calls: orient.length, per_agent: perAgent };
 }
 
 /**
@@ -217,12 +227,6 @@ function renderSummary(
   const recovery = computeRecovery(mcp, lease);
   const trajectory = computeTrajectoryEntropy(lease);
 
-  const agents = [...new Set(mcp.map(e => e.agent).filter(Boolean))];
-  if (agents.length) {
-    section('AGENTS');
-    for (const a of agents) console.log(`  ${a}`);
-  }
-
   section('TOOL LATENCY');
   if (tools.stats.length) {
     console.log(`  ${'tool'.padEnd(32)} ${'calls'.padStart(6)} ${'avg ms'.padStart(8)} ${'max ms'.padStart(8)}`);
@@ -239,11 +243,11 @@ function renderSummary(
 
   section('ORIENT QUALITY');
   if (quality) {
-    console.log(`  calls              : ${quality.calls}`);
-    console.log(`  avg functions      : ${quality.avg_functions}`);
-    console.log(`  avg files          : ${quality.avg_files}`);
-    console.log(`  avg insertion pts  : ${quality.avg_insertion_points}`);
-    if (quality.agents.length) console.log(`  agents             : ${quality.agents.join(', ')}`);
+    console.log(`  total calls : ${quality.total_calls}\n`);
+    console.log(`  ${'agent'.padEnd(28)} ${'calls'.padStart(6)} ${'avg fn'.padStart(8)} ${'avg files'.padStart(10)} ${'avg ins pts'.padStart(12)}`);
+    for (const r of quality.per_agent) {
+      console.log(`  ${r.agent.padEnd(28)} ${String(r.calls).padStart(6)} ${String(r.avg_functions).padStart(8)} ${String(r.avg_files).padStart(10)} ${String(r.avg_insertion_points).padStart(12)}`);
+    }
   } else {
     console.log('  no orient.jsonl data');
   }

--- a/src/cli/commands/telemetry.ts
+++ b/src/cli/commands/telemetry.ts
@@ -106,6 +106,7 @@ function computeObstinacy(mcp: McpEvent[], lease: LeaseEvent[]) {
   for (const e of mcp) {
     if (e.event === 'tool_call') events.push({ ts: e.ts, kind: e.tool === 'orient' ? 'orient' : 'tool', tool: e.tool });
   }
+  // ISO 8601 strings from toISOString() are lexicographically sortable
   events.sort((a, b) => a.ts.localeCompare(b.ts));
 
   const segments: { depth: number; calls_before_orient: number }[] = [];
@@ -286,13 +287,17 @@ function renderLive(dir: string) {
   const leaseFile = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR, 'epistemic-lease.jsonl');
   const mcpFile = join(dir, OPENLORE_DIR, TELEMETRY_SUBDIR, 'mcp.jsonl');
 
-  // Track file positions to only read new lines
+  // Track file positions to only read new lines; in-flight guard prevents
+  // overlapping reads when watch() fires twice before the first stream ends.
   const offsets = new Map<string, number>([
     [leaseFile, 0], [mcpFile, 0],
   ]);
+  const inFlight = new Set<string>();
 
   async function tail(filePath: string) {
     if (!existsSync(filePath)) return;
+    if (inFlight.has(filePath)) return;
+    inFlight.add(filePath);
     const { createReadStream } = await import('node:fs');
     const offset = offsets.get(filePath) ?? 0;
     const stream = createReadStream(filePath, { start: offset, encoding: 'utf-8' });
@@ -300,6 +305,7 @@ function renderLive(dir: string) {
     stream.on('data', chunk => { buf += chunk; });
     stream.on('end', () => {
       offsets.set(filePath, offset + Buffer.byteLength(buf, 'utf-8'));
+      inFlight.delete(filePath);
       for (const line of buf.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import { auditCommand } from './commands/audit.js';
 import { testCommand } from './commands/test.js';
 import { digestCommand } from './commands/digest.js';
 import { decisionsCommand } from './commands/decisions.js';
+import { telemetryCommand } from './commands/telemetry.js';
 import { configureLogger } from '../utils/logger.js';
 
 // Read version from package.json at runtime so it never drifts from the published version
@@ -133,5 +134,6 @@ program.addCommand(auditCommand);
 program.addCommand(testCommand);
 program.addCommand(digestCommand);
 program.addCommand(decisionsCommand);
+program.addCommand(telemetryCommand);
 
 program.parse();

--- a/src/core/services/mcp-handlers/decisions.ts
+++ b/src/core/services/mcp-handlers/decisions.ts
@@ -10,6 +10,7 @@
 
 import { spawn } from 'node:child_process';
 import { validateDirectory, sanitizeMcpError } from './utils.js';
+import { emit } from '../telemetry.js';
 import {
   loadDecisionStore,
   saveDecisionStore,
@@ -208,6 +209,7 @@ export async function handleApproveDecision(
       reviewNote: note,
     });
     await saveDecisionStore(rootPath, updated);
+    emit(rootPath, 'decisions', { event: 'decision_approved', id, title: decision.title });
 
     return { id, status: 'approved', title: decision.title };
   } catch (err) {
@@ -237,6 +239,7 @@ export async function handleRejectDecision(
       reviewNote: note,
     });
     await saveDecisionStore(rootPath, updated);
+    emit(rootPath, 'decisions', { event: 'decision_rejected', id, title: decision.title });
 
     return { id, status: 'rejected', title: decision.title };
   } catch (err) {
@@ -276,6 +279,8 @@ export async function handleSyncDecisions(
       specMap,
       dryRun,
     });
+
+    emit(rootPath, 'decisions', { event: 'decisions_synced', count: result.synced.length, dry_run: dryRun });
 
     return {
       synced: result.synced.map((d) => ({ id: d.id, title: d.title, specs: d.syncedToSpecs })),

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -221,6 +221,16 @@ describe('updateTracker — git hash invalidation', () => {
     expect(t.freshnessState).toBe('fresh');
   });
 
+  it('git-divergence stale transition starts at depth 1 (load and age below d2 thresholds)', () => {
+    const t = freshTracker();
+    t.graphVersionAtOrient = 'old-hash';
+    vi.advanceTimersByTime(31_000);
+    mockSpawnSync.mockReturnValueOnce({ stdout: 'new-hash\n', status: 0 } as ReturnType<typeof spawnSync>);
+    updateTracker(t, 'search_code', '/fake/repo');
+    expect(t.freshnessState).toBe('stale');
+    expect(t.staleDepth).toBe(1);
+  });
+
   it('skips git comparison when either hash is empty', () => {
     const t = freshTracker();
     t.graphVersionAtOrient = '';
@@ -328,9 +338,10 @@ describe('injectFreshness', () => {
     expect(out.indexOf('EPISTEMIC LEASE: STALE')).toBeLessThan(out.indexOf('tool result'));
   });
 
-  it('stale block contains capability-invalidation language', () => {
+  it('stale block contains capability-invalidation language (depth 1)', () => {
     const t = freshTracker();
     t.freshnessState = 'stale';
+    t.staleDepth = 1;
     const out = injectFreshness('', t);
     expect(out).toContain('Cached architectural reasoning reliability: LOW');
     expect(out).toContain('Cross-module dependency assumptions: UNRELIABLE');

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createTracker, updateTracker, injectFreshness } from './epistemic-lease.js';
+import { createTracker, updateTracker, injectFreshness, getSourceRoots } from './epistemic-lease.js';
 import type { EpistemicTracker, StaleDepth } from './epistemic-lease.js';
 
 // ============================================================================
@@ -12,6 +12,15 @@ import type { EpistemicTracker, StaleDepth } from './epistemic-lease.js';
 
 vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(() => ({ stdout: 'deadbeef1234\n', status: 0 })),
+}));
+
+vi.mock('node:fs', () => ({
+  readdirSync: vi.fn(() => [
+    { name: 'src', isDirectory: () => true },
+    { name: 'node_modules', isDirectory: () => true },
+    { name: 'dist', isDirectory: () => true },
+    { name: 'package.json', isDirectory: () => false },
+  ]),
 }));
 
 import { spawnSync } from 'node:child_process';
@@ -24,6 +33,32 @@ const mockSpawnSync = vi.mocked(spawnSync);
 function freshTracker(): EpistemicTracker {
   return createTracker('/fake/repo');
 }
+
+// ============================================================================
+// getSourceRoots
+// ============================================================================
+
+describe('getSourceRoots', () => {
+  it('returns directories that are not ignored and not hidden', () => {
+    // readdirSync mock returns src, node_modules, dist, package.json
+    const roots = getSourceRoots('/fake/repo');
+    expect(roots).toContain('src');
+    expect(roots).not.toContain('node_modules');
+    expect(roots).not.toContain('dist');
+    expect(roots).not.toContain('package.json');
+  });
+
+  it('returns empty array on non-existent directory', async () => {
+    const { readdirSync } = await import('node:fs');
+    vi.mocked(readdirSync).mockImplementationOnce(() => { throw new Error('ENOENT'); });
+    expect(getSourceRoots('/does/not/exist')).toEqual([]);
+  });
+
+  it('tracker carries sourceRoots from project scan', () => {
+    const t = createTracker('/fake/repo');
+    expect(t.sourceRoots).toContain('src');
+  });
+});
 
 // ============================================================================
 // createTracker

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -277,21 +277,23 @@ describe('updateTracker — module drift', () => {
     expect(t.modulesVisited.has('auth')).toBe(true);
   });
 
-  it('tracks distinct modules', () => {
+  it('tracks distinct modules (capped by stale short-circuit)', () => {
     const t = freshTracker();
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/jwt.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/stripe.ts');
-    updateTracker(t, 'get_function_body', '/fake/repo', 'src/analytics/events.ts');
-    expect(t.modulesVisited.size).toBe(3);
+    // density = 1/2 = 0.50 >= 0.30 → stale after billing
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/analytics/events.ts'); // short-circuit
+    expect(t.modulesVisited.size).toBe(2); // analytics not tracked — stale before that call
   });
 
-  it('degrades at > 3 distinct modules', () => {
+  it('goes stale via high cross-module density (4 sequential distinct modules)', () => {
     const t = freshTracker();
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/jwt.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/stripe.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/analytics/events.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/infra/db.ts');
-    expect(t.freshnessState).toBe('degraded');
+    // 3 switches / 4 entries = 0.75 density >= 0.30 stale threshold
+    expect(t.freshnessState).toBe('stale');
   });
 
   it('ignores filePath without src/ prefix — no module pollution', () => {
@@ -520,5 +522,98 @@ describe('stale depth escalation', () => {
     const d3 = injectFreshness('', t);
 
     expect(d3.length).toBeLessThan(d1.length);
+  });
+});
+
+// ============================================================================
+// V3.1 cross-module trajectory model
+// ============================================================================
+
+describe('updateTracker — V3.1 cross-module trajectory', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('degrades when density reaches 0.15 threshold', () => {
+    const t = freshTracker();
+    // 8 calls same module, then switch to billing, then back to auth
+    // Window: 10 entries, 2 non-null switches => density 2/10 = 0.20 >= 0.15
+    for (let i = 0; i < 8; i++) updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/x.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/y.ts');
+    expect(t.freshnessState).toBe('degraded');
+  });
+
+  it('module switch adds 5 to cognitiveLoad', () => {
+    const t = freshTracker();
+    // Pre-pad window with 13 nulls so first switch stays at density 1/15 ≈ 0.07 — no bonus fires
+    for (let i = 0; i < 13; i++) updateTracker(t, 'search_code', '/fake/repo');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts'); // no switch (lastModule null)
+    const loadBeforeSwitch = t.cognitiveLoad; // 13*1 + 2 = 15
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/x.ts');
+    // window=[null×13,auth,billing], switch=1, density=1/15≈0.067 — no bonus, no stale
+    expect(t.cognitiveLoad).toBe(loadBeforeSwitch + 2 + 5);
+  });
+
+  it('switch dampening prevents double-counting rapid back-and-forth', () => {
+    const t = freshTracker();
+    // Pre-pad so density stays low throughout
+    for (let i = 0; i < 12; i++) updateTracker(t, 'search_code', '/fake/repo');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts'); // no switch
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/x.ts'); // switch +5, density=1/14≈0.07
+    const loadAfterSwitch = t.cognitiveLoad; // 12 + 2 + 2 + 5 = 21
+    // Return immediately — within dampening window, no +5
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts'); // density=2/15≈0.13, no stale
+    expect(t.cognitiveLoad).toBe(loadAfterSwitch + 2); // only tool weight
+  });
+
+  it('switch dampening lifts after 5s', () => {
+    const t = freshTracker();
+    for (let i = 0; i < 12; i++) updateTracker(t, 'search_code', '/fake/repo');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts'); // no switch
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/x.ts'); // switch +5
+    vi.advanceTimersByTime(5001);
+    const loadBefore = t.cognitiveLoad; // 12 + 2 + 2 + 5 = 21
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts'); // switch fires again
+    // density=2/15≈0.13, no stale, no bonus
+    expect(t.cognitiveLoad).toBe(loadBefore + 2 + 5);
+  });
+
+  it('burst spike (+20) applied when density >= 0.60', () => {
+    const t = freshTracker();
+    // Seed window directly with high-alternating pattern to control density
+    // [a,b,a,b,a,b,a,b,a] = 8 switches / 9 entries = 0.89 >= 0.60
+    t.moduleAccessWindow = ['auth','billing','auth','billing','auth','billing','auth','billing','auth'] as (string | null)[];
+    t.lastModule = 'auth';
+    // One non-file call: density check fires, burst spike (+20) applied, then stale
+    updateTracker(t, 'search_code', '/fake/repo'); // weight=1, no new switch, density≈0.78 >= 0.60
+    expect(t.cognitiveLoad).toBe(1 + 20); // tool weight + burst spike
+  });
+
+  it('orient resets lastModule and moduleAccessWindow', () => {
+    const t = freshTracker();
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts');
+    updateTracker(t, 'orient', '/fake/repo');
+    expect(t.lastModule).toBeNull();
+    expect(t.moduleAccessWindow).toHaveLength(0);
+  });
+
+  it('non-file calls dilute density below threshold', () => {
+    const t = freshTracker();
+    // Pre-pad 13 nulls, then 1 switch — density = 1/15 ≈ 0.067 < 0.15 → fresh
+    for (let i = 0; i < 13; i++) updateTracker(t, 'search_code', '/fake/repo');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/x.ts');
+    // window=[null×13,auth,billing], density=1/15≈0.067 < 0.15
+    expect(t.freshnessState).toBe('fresh');
+  });
+
+  it('window slides — old entries fall off after 15 calls', () => {
+    const t = freshTracker();
+    // Fill window with auth calls (no switches)
+    for (let i = 0; i < 15; i++) updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts');
+    expect(t.moduleAccessWindow).toHaveLength(15);
+    // One more call — oldest entry drops off
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/y.ts');
+    expect(t.moduleAccessWindow).toHaveLength(15);
   });
 });

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for the epistemic lease — session-level architectural confidence decay.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTracker, updateTracker, injectFreshness } from './epistemic-lease.js';
+import type { EpistemicTracker } from './epistemic-lease.js';
+
+// ============================================================================
+// Mock git hash — default returns stable hash
+// ============================================================================
+
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(() => ({ stdout: 'deadbeef1234\n', status: 0 })),
+}));
+
+import { spawnSync } from 'node:child_process';
+const mockSpawnSync = vi.mocked(spawnSync);
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function freshTracker(): EpistemicTracker {
+  return createTracker('/fake/repo');
+}
+
+// ============================================================================
+// createTracker
+// ============================================================================
+
+describe('createTracker', () => {
+  it('starts fresh with zero load', () => {
+    const t = freshTracker();
+    expect(t.freshnessState).toBe('fresh');
+    expect(t.cognitiveLoad).toBe(0);
+    expect(t.modulesVisited.size).toBe(0);
+  });
+
+  it('captures git hash at creation', () => {
+    mockSpawnSync.mockReturnValueOnce({ stdout: 'abc123\n', status: 0 } as ReturnType<typeof spawnSync>);
+    const t = createTracker('/fake/repo');
+    expect(t.graphVersionAtOrient).toBe('abc123');
+  });
+
+  it('handles git unavailable gracefully', () => {
+    mockSpawnSync.mockReturnValueOnce({ stdout: null, status: 128 } as unknown as ReturnType<typeof spawnSync>);
+    const t = createTracker('/fake/repo');
+    expect(t.graphVersionAtOrient).toBe('');
+    expect(t.freshnessState).toBe('fresh');
+  });
+});
+
+// ============================================================================
+// updateTracker — orient resets
+// ============================================================================
+
+describe('updateTracker — orient reset', () => {
+  it('resets load, modules, and state to fresh', () => {
+    const t = freshTracker();
+    // Manually degrade
+    t.cognitiveLoad = 50;
+    t.freshnessState = 'degraded';
+    t.modulesVisited.add('auth');
+
+    updateTracker(t, 'orient', '/fake/repo');
+
+    expect(t.freshnessState).toBe('fresh');
+    expect(t.cognitiveLoad).toBe(0);
+    expect(t.modulesVisited.size).toBe(0);
+  });
+
+  it('updates git hash on orient reset', () => {
+    const t = freshTracker();
+    t.graphVersionAtOrient = 'old-hash';
+    mockSpawnSync.mockReturnValueOnce({ stdout: 'new-hash\n', status: 0 } as ReturnType<typeof spawnSync>);
+
+    updateTracker(t, 'orient', '/fake/repo');
+
+    expect(t.graphVersionAtOrient).toBe('new-hash');
+  });
+
+  it('injectFreshness returns text unchanged after orient', () => {
+    const t = freshTracker();
+    t.freshnessState = 'degraded';
+    updateTracker(t, 'orient', '/fake/repo');
+    expect(injectFreshness('result text', t)).toBe('result text');
+  });
+});
+
+// ============================================================================
+// updateTracker — cognitive load accumulation
+// ============================================================================
+
+describe('updateTracker — cognitive load', () => {
+  it('accumulates load by tool weight', () => {
+    const t = freshTracker();
+    updateTracker(t, 'search_code', '/fake/repo');         // weight 1
+    updateTracker(t, 'get_subgraph', '/fake/repo');        // weight 5
+    updateTracker(t, 'trace_execution_path', '/fake/repo'); // weight 8
+    expect(t.cognitiveLoad).toBe(14);
+  });
+
+  it('assigns weight 1 to unknown tools', () => {
+    const t = freshTracker();
+    updateTracker(t, 'unknown_future_tool', '/fake/repo');
+    expect(t.cognitiveLoad).toBe(1);
+  });
+
+  it('does not accumulate load for orient', () => {
+    const t = freshTracker();
+    updateTracker(t, 'orient', '/fake/repo');
+    expect(t.cognitiveLoad).toBe(0);
+  });
+});
+
+// ============================================================================
+// updateTracker — state transitions (load-based)
+// ============================================================================
+
+describe('updateTracker — load-based decay', () => {
+  it('transitions fresh → degraded at load >= 30', () => {
+    const t = freshTracker();
+    // trace_execution_path = 8, call 4 times = 32
+    for (let i = 0; i < 4; i++) updateTracker(t, 'trace_execution_path', '/fake/repo');
+    expect(t.freshnessState).toBe('degraded');
+  });
+
+  it('transitions directly to stale at load >= 60', () => {
+    const t = freshTracker();
+    // trace_execution_path = 8, call 8 times = 64
+    for (let i = 0; i < 8; i++) updateTracker(t, 'trace_execution_path', '/fake/repo');
+    expect(t.freshnessState).toBe('stale');
+  });
+
+  it('state never reverses: stale stays stale after orient-weight-0 tool', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    updateTracker(t, 'search_code', '/fake/repo');
+    expect(t.freshnessState).toBe('stale');
+  });
+
+  it('degraded never drops back to fresh', () => {
+    const t = freshTracker();
+    t.freshnessState = 'degraded';
+    // Low-weight calls shouldn't reverse state
+    updateTracker(t, 'list_spec_domains', '/fake/repo');
+    expect(t.freshnessState).toBe('degraded');
+  });
+});
+
+// ============================================================================
+// updateTracker — time-based decay
+// ============================================================================
+
+describe('updateTracker — time-based decay', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('degrades after 15 minutes', () => {
+    const t = freshTracker();
+    vi.advanceTimersByTime(15 * 60 * 1000 + 1);
+    // Trigger check with a lightweight call (won't hit load threshold alone)
+    updateTracker(t, 'list_spec_domains', '/fake/repo');
+    expect(t.freshnessState).toBe('degraded');
+  });
+
+  it('goes stale after 30 minutes', () => {
+    const t = freshTracker();
+    vi.advanceTimersByTime(30 * 60 * 1000 + 1);
+    updateTracker(t, 'list_spec_domains', '/fake/repo');
+    expect(t.freshnessState).toBe('stale');
+  });
+
+  it('stays fresh within 15 minutes with low load', () => {
+    const t = freshTracker();
+    vi.advanceTimersByTime(14 * 60 * 1000);
+    updateTracker(t, 'search_code', '/fake/repo');
+    expect(t.freshnessState).toBe('fresh');
+  });
+});
+
+// ============================================================================
+// updateTracker — git hash invalidation
+// ============================================================================
+
+describe('updateTracker — git hash invalidation', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('goes stale immediately when git hash changes', () => {
+    const t = freshTracker();
+    t.graphVersionAtOrient = 'old-hash';
+    // Advance past git check interval so the check fires
+    vi.advanceTimersByTime(31_000);
+    mockSpawnSync.mockReturnValueOnce({ stdout: 'new-hash\n', status: 0 } as ReturnType<typeof spawnSync>);
+
+    updateTracker(t, 'search_code', '/fake/repo');
+    expect(t.freshnessState).toBe('stale');
+  });
+
+  it('stays fresh when git hash unchanged', () => {
+    const t = freshTracker();
+    t.graphVersionAtOrient = 'same-hash';
+    vi.advanceTimersByTime(31_000);
+    mockSpawnSync.mockReturnValueOnce({ stdout: 'same-hash\n', status: 0 } as ReturnType<typeof spawnSync>);
+
+    updateTracker(t, 'search_code', '/fake/repo');
+    expect(t.freshnessState).toBe('fresh');
+  });
+
+  it('skips git check within interval window', () => {
+    const t = freshTracker();
+    t.graphVersionAtOrient = 'old-hash';
+    // Only 5 seconds in — within 30s interval, git check skipped
+    vi.advanceTimersByTime(5_000);
+    mockSpawnSync.mockReturnValueOnce({ stdout: 'new-hash\n', status: 0 } as ReturnType<typeof spawnSync>);
+
+    updateTracker(t, 'search_code', '/fake/repo');
+    // Hash changed but check was skipped — not stale yet
+    expect(t.freshnessState).toBe('fresh');
+  });
+
+  it('skips git comparison when either hash is empty', () => {
+    const t = freshTracker();
+    t.graphVersionAtOrient = '';
+    vi.advanceTimersByTime(31_000);
+    mockSpawnSync.mockReturnValueOnce({ stdout: 'new-hash\n', status: 0 } as ReturnType<typeof spawnSync>);
+
+    updateTracker(t, 'search_code', '/fake/repo');
+    expect(t.freshnessState).toBe('fresh');
+  });
+});
+
+// ============================================================================
+// updateTracker — module drift
+// ============================================================================
+
+describe('updateTracker — module drift', () => {
+  it('tracks module from src/ path', () => {
+    const t = freshTracker();
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/middleware.ts');
+    expect(t.modulesVisited.has('auth')).toBe(true);
+  });
+
+  it('tracks distinct modules', () => {
+    const t = freshTracker();
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/jwt.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/stripe.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/analytics/events.ts');
+    expect(t.modulesVisited.size).toBe(3);
+  });
+
+  it('degrades at > 3 distinct modules', () => {
+    const t = freshTracker();
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/jwt.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/stripe.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/analytics/events.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/infra/db.ts');
+    expect(t.freshnessState).toBe('degraded');
+  });
+
+  it('ignores filePath without src/ prefix — no module pollution', () => {
+    const t = freshTracker();
+    // Absolute path with no src/ segment
+    updateTracker(t, 'get_function_body', '/fake/repo', '/Users/foo/bar.ts');
+    expect(t.modulesVisited.size).toBe(0);
+  });
+
+  it('deduplicates same module across calls', () => {
+    const t = freshTracker();
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/jwt.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/session.ts');
+    expect(t.modulesVisited.size).toBe(1);
+  });
+
+  it('does not accumulate when filePath absent', () => {
+    const t = freshTracker();
+    updateTracker(t, 'get_subgraph', '/fake/repo');
+    expect(t.modulesVisited.size).toBe(0);
+  });
+});
+
+// ============================================================================
+// updateTracker — stale short-circuit (no load accumulation)
+// ============================================================================
+
+describe('updateTracker — stale short-circuit', () => {
+  it('does not accumulate load when already stale', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.cognitiveLoad = 10;
+    updateTracker(t, 'trace_execution_path', '/fake/repo');
+    expect(t.cognitiveLoad).toBe(10); // unchanged
+  });
+
+  it('does not add modules when already stale', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/jwt.ts');
+    expect(t.modulesVisited.size).toBe(0);
+  });
+});
+
+// ============================================================================
+// injectFreshness
+// ============================================================================
+
+describe('injectFreshness', () => {
+  it('returns text unchanged when fresh', () => {
+    const t = freshTracker();
+    expect(injectFreshness('tool result', t)).toBe('tool result');
+  });
+
+  it('appends degraded signal — does not prepend', () => {
+    const t = freshTracker();
+    t.freshnessState = 'degraded';
+    const out = injectFreshness('tool result', t);
+    expect(out.startsWith('tool result')).toBe(true);
+    expect(out).toContain('EPISTEMIC LEASE: DEGRADED');
+    expect(out).toContain('orient()');
+  });
+
+  it('prepends stale block — agent sees it first', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    const out = injectFreshness('tool result', t);
+    expect(out.indexOf('EPISTEMIC LEASE: STALE')).toBeLessThan(out.indexOf('tool result'));
+  });
+
+  it('stale block contains capability-invalidation language', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    const out = injectFreshness('', t);
+    expect(out).toContain('Cached architectural reasoning reliability: LOW');
+    expect(out).toContain('Cross-module dependency assumptions: UNRELIABLE');
+    expect(out).toContain('Internal repository model: NOT AUTHORITATIVE');
+  });
+
+  it('degraded signal contains orient call-to-action', () => {
+    const t = freshTracker();
+    t.freshnessState = 'degraded';
+    const out = injectFreshness('', t);
+    expect(out).toContain('orient()');
+    expect(out).toContain('DEGRADED');
+  });
+
+  it('stale block shows age in minutes', () => {
+    vi.useFakeTimers();
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    vi.advanceTimersByTime(25 * 60 * 1000);
+    const out = injectFreshness('', t);
+    expect(out).toContain('25min');
+    vi.useRealTimers();
+  });
+
+  it('degraded signal shows module count', () => {
+    const t = freshTracker();
+    t.freshnessState = 'degraded';
+    t.modulesVisited.add('auth');
+    t.modulesVisited.add('billing');
+    const out = injectFreshness('', t);
+    expect(out).toContain('modules visited: 2');
+  });
+
+  it('stale block shows cognitive load score', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.cognitiveLoad = 42;
+    const out = injectFreshness('', t);
+    expect(out).toContain('42');
+  });
+});

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTracker, updateTracker, injectFreshness, getSourceRoots } from './epistemic-lease.js';
-import type { EpistemicTracker, StaleDepth } from './epistemic-lease.js';
+import type { EpistemicTracker } from './epistemic-lease.js';
 
 // ============================================================================
 // Mock git hash — default returns stable hash

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTracker, updateTracker, injectFreshness } from './epistemic-lease.js';
-import type { EpistemicTracker } from './epistemic-lease.js';
+import type { EpistemicTracker, StaleDepth } from './epistemic-lease.js';
 
 // ============================================================================
 // Mock git hash — default returns stable hash
@@ -367,8 +367,123 @@ describe('injectFreshness', () => {
   it('stale block shows cognitive load score', () => {
     const t = freshTracker();
     t.freshnessState = 'stale';
+    t.staleDepth = 1;
     t.cognitiveLoad = 42;
     const out = injectFreshness('', t);
     expect(out).toContain('42');
+  });
+});
+
+// ============================================================================
+// Stale depth escalation
+// ============================================================================
+
+describe('stale depth escalation', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('starts at depth 1 when crossing stale threshold', () => {
+    const t = freshTracker();
+    // load = 64, below depth-2 threshold of 85
+    for (let i = 0; i < 8; i++) updateTracker(t, 'trace_execution_path', '/fake/repo');
+    expect(t.freshnessState).toBe('stale');
+    expect(t.staleDepth).toBe(1);
+  });
+
+  it('enters depth 2 when load >= 85 at stale transition', () => {
+    const t = freshTracker();
+    // Pre-seed just below depth-2 threshold, then one more call crosses it
+    t.cognitiveLoad = 84;
+    updateTracker(t, 'search_code', '/fake/repo'); // +1 → 85 >= 85, also >= stale threshold 60
+    expect(t.freshnessState).toBe('stale');
+    expect(t.staleDepth).toBe(2);
+  });
+
+  it('enters depth 3 when load >= 110 at stale transition', () => {
+    const t = freshTracker();
+    t.cognitiveLoad = 109;
+    updateTracker(t, 'search_code', '/fake/repo'); // +1 → 110
+    expect(t.freshnessState).toBe('stale');
+    expect(t.staleDepth).toBe(3);
+  });
+
+  it('escalates depth 1 → 2 via time when already stale', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.staleDepth = 1;
+    // Advance to 45+ minutes
+    vi.advanceTimersByTime(46 * 60 * 1000);
+    updateTracker(t, 'list_spec_domains', '/fake/repo');
+    expect(t.staleDepth).toBe(2);
+  });
+
+  it('escalates depth 2 → 3 via time when already stale', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.staleDepth = 2;
+    vi.advanceTimersByTime(61 * 60 * 1000);
+    updateTracker(t, 'list_spec_domains', '/fake/repo');
+    expect(t.staleDepth).toBe(3);
+  });
+
+  it('depth never decreases — stays at 3', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.staleDepth = 3;
+    vi.advanceTimersByTime(1000);
+    updateTracker(t, 'list_spec_domains', '/fake/repo');
+    expect(t.staleDepth).toBe(3);
+  });
+
+  it('depth resets to 0 on orient', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.staleDepth = 3;
+    updateTracker(t, 'orient', '/fake/repo');
+    expect(t.staleDepth).toBe(0);
+    expect(t.freshnessState).toBe('fresh');
+  });
+
+  it('depth 1 block contains procedural NOT-DO instructions', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.staleDepth = 1;
+    const out = injectFreshness('', t);
+    expect(out).toContain('Do NOT rely on previous dependency assumptions');
+    expect(out).toContain('STALE');
+    expect(out).not.toContain('[ELEVATED]');
+    expect(out).not.toContain('[CRITICAL]');
+  });
+
+  it('depth 2 block names downstream risks', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.staleDepth = 2;
+    const out = injectFreshness('', t);
+    expect(out).toContain('[ELEVATED]');
+    expect(out).toContain('HALLUCINATION RISK');
+  });
+
+  it('depth 3 block is imperative — STOP command present', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+    t.staleDepth = 3;
+    const out = injectFreshness('', t);
+    expect(out).toContain('[CRITICAL]');
+    expect(out).toContain('STOP');
+    expect(out).toContain('CRITICALLY LOW');
+  });
+
+  it('depth 3 block is shorter than depth 1 — harder to skim', () => {
+    const t = freshTracker();
+    t.freshnessState = 'stale';
+
+    t.staleDepth = 1;
+    const d1 = injectFreshness('', t);
+
+    t.staleDepth = 3;
+    const d3 = injectFreshness('', t);
+
+    expect(d3.length).toBeLessThan(d1.length);
   });
 });

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -277,22 +277,23 @@ describe('updateTracker — module drift', () => {
     expect(t.modulesVisited.has('auth')).toBe(true);
   });
 
-  it('tracks distinct modules (capped by stale short-circuit)', () => {
+  it('tracks distinct modules', () => {
     const t = freshTracker();
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/jwt.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/stripe.ts');
-    // density = 1/2 = 0.50 >= 0.30 → stale after billing
-    updateTracker(t, 'get_function_body', '/fake/repo', 'src/analytics/events.ts'); // short-circuit
-    expect(t.modulesVisited.size).toBe(2); // analytics not tracked — stale before that call
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/analytics/events.ts');
+    expect(t.modulesVisited.size).toBe(3);
   });
 
-  it('goes stale via high cross-module density (4 sequential distinct modules)', () => {
+  it('goes stale via high cross-module density (6 sequential distinct modules)', () => {
     const t = freshTracker();
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/jwt.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/stripe.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/analytics/events.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/infra/db.ts');
-    // 3 switches / 4 entries = 0.75 density >= 0.30 stale threshold
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/core/index.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/api/run.ts');
+    // 5 switches / 15 window size = 0.33 >= 0.30 stale threshold
     expect(t.freshnessState).toBe('stale');
   });
 
@@ -535,11 +536,12 @@ describe('updateTracker — V3.1 cross-module trajectory', () => {
 
   it('degrades when density reaches 0.15 threshold', () => {
     const t = freshTracker();
-    // 8 calls same module, then switch to billing, then back to auth
-    // Window: 10 entries, 2 non-null switches => density 2/10 = 0.20 >= 0.15
-    for (let i = 0; i < 8; i++) updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts');
+    // 9 nulls + 4 alternating file calls = 3 switches / 15 window = 0.20 >= 0.15
+    for (let i = 0; i < 9; i++) updateTracker(t, 'search_code', '/fake/repo');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/x.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/x.ts');
     updateTracker(t, 'get_function_body', '/fake/repo', 'src/auth/y.ts');
+    updateTracker(t, 'get_function_body', '/fake/repo', 'src/billing/y.ts');
     expect(t.freshnessState).toBe('degraded');
   });
 
@@ -580,12 +582,14 @@ describe('updateTracker — V3.1 cross-module trajectory', () => {
 
   it('burst spike (+20) applied when density >= 0.60', () => {
     const t = freshTracker();
-    // Seed window directly with high-alternating pattern to control density
-    // [a,b,a,b,a,b,a,b,a] = 8 switches / 9 entries = 0.89 >= 0.60
-    t.moduleAccessWindow = ['auth','billing','auth','billing','auth','billing','auth','billing','auth'] as (string | null)[];
+    // Full window of 15 alternating entries = 14 switches / 15 = 0.93 >= 0.60
+    t.moduleAccessWindow = [
+      'auth','billing','auth','billing','auth','billing','auth','billing',
+      'auth','billing','auth','billing','auth','billing','auth',
+    ] as (string | null)[];
     t.lastModule = 'auth';
-    // One non-file call: density check fires, burst spike (+20) applied, then stale
-    updateTracker(t, 'search_code', '/fake/repo'); // weight=1, no new switch, density≈0.78 >= 0.60
+    // One non-file call: density check fires with burst spike (+20), then stale
+    updateTracker(t, 'search_code', '/fake/repo'); // weight=1
     expect(t.cognitiveLoad).toBe(1 + 20); // tool weight + burst spike
   });
 

--- a/src/core/services/mcp-handlers/epistemic-lease.test.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.test.ts
@@ -14,14 +14,6 @@ vi.mock('node:child_process', () => ({
   spawnSync: vi.fn(() => ({ stdout: 'deadbeef1234\n', status: 0 })),
 }));
 
-vi.mock('node:fs', () => ({
-  readdirSync: vi.fn(() => [
-    { name: 'src', isDirectory: () => true },
-    { name: 'node_modules', isDirectory: () => true },
-    { name: 'dist', isDirectory: () => true },
-    { name: 'package.json', isDirectory: () => false },
-  ]),
-}));
 
 import { spawnSync } from 'node:child_process';
 const mockSpawnSync = vi.mocked(spawnSync);
@@ -31,7 +23,10 @@ const mockSpawnSync = vi.mocked(spawnSync);
 // ============================================================================
 
 function freshTracker(): EpistemicTracker {
-  return createTracker('/fake/repo');
+  const t = createTracker('/fake/repo');
+  // No db at /fake/repo so sourceRoots=[] — set explicitly for module-drift tests.
+  t.sourceRoots = ['src'];
+  return t;
 }
 
 // ============================================================================
@@ -39,24 +34,18 @@ function freshTracker(): EpistemicTracker {
 // ============================================================================
 
 describe('getSourceRoots', () => {
-  it('returns directories that are not ignored and not hidden', () => {
-    // readdirSync mock returns src, node_modules, dist, package.json
-    const roots = getSourceRoots('/fake/repo');
-    expect(roots).toContain('src');
-    expect(roots).not.toContain('node_modules');
-    expect(roots).not.toContain('dist');
-    expect(roots).not.toContain('package.json');
+  it('returns empty array when no analysis db exists', () => {
+    // /fake/repo has no .openlore/analysis/call-graph.db
+    expect(getSourceRoots('/fake/repo')).toEqual([]);
   });
 
-  it('returns empty array on non-existent directory', async () => {
-    const { readdirSync } = await import('node:fs');
-    vi.mocked(readdirSync).mockImplementationOnce(() => { throw new Error('ENOENT'); });
+  it('returns empty array for non-existent directory', () => {
     expect(getSourceRoots('/does/not/exist')).toEqual([]);
   });
 
-  it('tracker carries sourceRoots from project scan', () => {
+  it('tracker sourceRoots empty before analyze has run', () => {
     const t = createTracker('/fake/repo');
-    expect(t.sourceRoots).toContain('src');
+    expect(t.sourceRoots).toEqual([]);
   });
 });
 

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -24,6 +24,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
 
 // ============================================================================
 // TYPES
@@ -41,6 +42,8 @@ export interface EpistemicTracker {
   /** Escalating severity within stale state. 0 when not stale. */
   staleDepth: 0 | StaleDepth;
   lastGitCheckAt: number;
+  /** Top-level source directories derived from the actual project layout. */
+  sourceRoots: string[];
 }
 
 // ============================================================================
@@ -140,15 +143,39 @@ function getGitHash(directory: string): string {
 
 // ============================================================================
 // MODULE EXTRACTION
-// Extract top-level module segment from a file path: src/core/... → "core"
-// Paths without a src/ segment return null — no module pollution from absolute paths.
+// Extract top-level module segment from a file path, using the actual source
+// root directories scanned from the project at tracker creation time.
+//
+//   (project has packages/, src/)
+//   packages/auth/src/jwt.ts → "auth"
+//   src/core/services/mcp.ts → "core"
+//
+// Paths with no matching source root return null — prevents OS path segment
+// pollution from absolute paths like /Users/foo/bar.ts.
 // ============================================================================
 
-function moduleFromPath(filePath: string): string | null {
+const IGNORED_DIRS = new Set([
+  'node_modules', 'dist', 'build', 'out', 'target', 'coverage',
+  'vendor', '.cache', '__pycache__',
+]);
+
+export function getSourceRoots(directory: string): string[] {
+  try {
+    return readdirSync(directory, { withFileTypes: true })
+      .filter(e => e.isDirectory() && !e.name.startsWith('.') && !IGNORED_DIRS.has(e.name))
+      .map(e => e.name);
+  } catch {
+    return [];
+  }
+}
+
+function moduleFromPath(filePath: string, sourceRoots: string[]): string | null {
   const parts = filePath.split(/[/\\]/);
-  const srcIdx = parts.indexOf('src');
-  if (srcIdx >= 0 && srcIdx + 1 < parts.length) {
-    return parts[srcIdx + 1];
+  for (const root of sourceRoots) {
+    const idx = parts.indexOf(root);
+    if (idx >= 0 && idx + 1 < parts.length) {
+      return parts[idx + 1];
+    }
   }
   return null;
 }
@@ -177,6 +204,7 @@ export function createTracker(directory: string): EpistemicTracker {
     freshnessState: 'fresh',
     staleDepth: 0,
     lastGitCheckAt: Date.now(),
+    sourceRoots: getSourceRoots(directory),
   };
 }
 
@@ -188,6 +216,7 @@ function resetTracker(tracker: EpistemicTracker, directory: string): void {
   tracker.freshnessState = 'fresh';
   tracker.staleDepth = 0;
   tracker.lastGitCheckAt = Date.now();
+  // sourceRoots not reset — project layout doesn't change during a session
 }
 
 function transitionToStale(tracker: EpistemicTracker, load: number, ageMs: number): void {
@@ -224,7 +253,7 @@ export function updateTracker(
 
   // Track cross-module file access
   if (filePath) {
-    const mod = moduleFromPath(filePath);
+    const mod = moduleFromPath(filePath, tracker.sourceRoots);
     if (mod) tracker.modulesVisited.add(mod);
   }
 
@@ -316,16 +345,37 @@ function degradedSignal(ageMin: number, modules: number): string {
   );
 }
 
-export function injectFreshness(text: string, tracker: EpistemicTracker): string {
-  if (tracker.freshnessState === 'fresh') return text;
+/**
+ * Returns the freshness signal for the current tracker state, or null if fresh.
+ * prepend=true → signal should appear before the tool result (stale).
+ * prepend=false → signal should appear after the tool result (degraded).
+ *
+ * Callers that build MCP content arrays should add this as a separate TextContent
+ * item rather than string-concatenating into the result body.
+ */
+export function getFreshnessSignal(
+  tracker: EpistemicTracker,
+): { text: string; prepend: boolean } | null {
+  if (tracker.freshnessState === 'fresh') return null;
 
   const ageMin = Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000);
 
   if (tracker.freshnessState === 'stale') {
     // staleDepth is always ≥1 when freshnessState === 'stale' — invariant enforced by transitionToStale.
-    // The cast is safe; staleDepth=0 + state=stale is unreachable through the public API.
-    return staleBlock(ageMin, tracker.cognitiveLoad, tracker.staleDepth as StaleDepth) + text;
+    return {
+      text: staleBlock(ageMin, tracker.cognitiveLoad, tracker.staleDepth as StaleDepth),
+      prepend: true,
+    };
   }
 
-  return text + degradedSignal(ageMin, tracker.modulesVisited.size);
+  return {
+    text: degradedSignal(ageMin, tracker.modulesVisited.size),
+    prepend: false,
+  };
+}
+
+export function injectFreshness(text: string, tracker: EpistemicTracker): string {
+  const signal = getFreshnessSignal(tracker);
+  if (!signal) return text;
+  return signal.prepend ? signal.text + text : text + signal.text;
 }

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -209,7 +209,9 @@ export function updateTracker(
   const now = Date.now();
   const ageMs = now - tracker.lastOrientAt.getTime();
 
-  // Already stale — update depth only (time-based escalation, monotonic)
+  // Already stale — update depth only (time-based escalation, monotonic).
+  // Load stops accumulating here, so post-transition depth escalation is purely
+  // time-driven regardless of how many more heavy tools are called.
   if (tracker.freshnessState === 'stale') {
     const newDepth = computeStaleDepth(tracker.cognitiveLoad, ageMs);
     if (newDepth > tracker.staleDepth) tracker.staleDepth = newDepth as StaleDepth;
@@ -320,7 +322,9 @@ export function injectFreshness(text: string, tracker: EpistemicTracker): string
   const ageMin = Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000);
 
   if (tracker.freshnessState === 'stale') {
-    return staleBlock(ageMin, tracker.cognitiveLoad, (tracker.staleDepth || 1) as StaleDepth) + text;
+    // staleDepth is always ≥1 when freshnessState === 'stale' — invariant enforced by transitionToStale.
+    // The cast is safe; staleDepth=0 + state=stale is unreachable through the public API.
+    return staleBlock(ageMin, tracker.cognitiveLoad, tracker.staleDepth as StaleDepth) + text;
   }
 
   return text + degradedSignal(ageMin, tracker.modulesVisited.size);

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -61,6 +61,8 @@ export interface EpistemicTracker {
   lastDensityPenaltyAt: number;
   /** V3.1: epoch ms of last module switch (dampening). */
   lastSwitchAt: number;
+  /** V3.2: oscillation score — repeated bigram transitions / total transitions [0,1]. */
+  oscillation: number;
 }
 
 // ============================================================================
@@ -149,6 +151,10 @@ const BURST_DEBT_SPIKE              = 20;
 const DENSITY_BONUS_COOLDOWN_MS     = 60_000;
 const SWITCH_DAMPENING_MS           = 5_000;
 
+// V3.2 oscillation model — detects back-and-forth (A→B→A→B) vs exploration
+const BURST_DENSITY_THRESHOLD       = 0.60;  // density for post-stale burst escalation
+const BURST_TOOL_WEIGHT_THRESHOLD   = 8;     // tool weight for post-stale burst escalation
+
 // ============================================================================
 // GIT HASH
 // ============================================================================
@@ -230,6 +236,25 @@ function computeCrossModuleDensity(window: (string | null)[]): number {
 }
 
 // ============================================================================
+// OSCILLATION SCORE
+// Bigram repetition ratio: how often the module 2 calls ago reappears.
+// A→B→A→B→A scores 1.0 (pure confusion loop); A→B→C→D→E scores 0.0.
+// Fixed denominator = window entries ≥ 3 so early-session doesn't spike.
+// ============================================================================
+
+function computeOscillationScore(window: (string | null)[]): number {
+  const modules = window.filter((m): m is string => m !== null);
+  if (modules.length < 3) return 0;
+  let repeated = 0;
+  let total = 0;
+  for (let i = 2; i < modules.length; i++) {
+    total++;
+    if (modules[i] === modules[i - 2]) repeated++;
+  }
+  return total > 0 ? repeated / total : 0;
+}
+
+// ============================================================================
 // STALE DEPTH
 // Monotonic — depth can only increase, never decrease until orient() reset.
 // ============================================================================
@@ -258,6 +283,7 @@ export function createTracker(directory: string): EpistemicTracker {
     moduleAccessWindow: [],
     lastDensityPenaltyAt: 0,
     lastSwitchAt: 0,
+    oscillation: 0,
   };
 }
 
@@ -273,6 +299,7 @@ function resetTracker(tracker: EpistemicTracker, directory: string): void {
   tracker.moduleAccessWindow = [];
   tracker.lastDensityPenaltyAt = 0;
   tracker.lastSwitchAt = 0;
+  tracker.oscillation = 0;
   // sourceRoots not reset — project layout doesn't change during a session
 }
 
@@ -294,7 +321,8 @@ export function updateTracker(
         from_state: tracker.freshnessState,
         prior_load: tracker.cognitiveLoad,
         prior_depth: tracker.staleDepth,
-        tool: 'orient', module: null, cognitive_load: tracker.cognitiveLoad, density: 0, age_min: Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000),
+        tool: 'orient', module: null, cognitive_load: tracker.cognitiveLoad, density: 0,
+        oscillation: tracker.oscillation, age_min: Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000),
       });
     }
     resetTracker(tracker, directory);
@@ -303,17 +331,39 @@ export function updateTracker(
 
   const now = Date.now();
   const ageMs = now - tracker.lastOrientAt.getTime();
+  const weight = TOOL_WEIGHTS[toolName] ?? 1;
 
-  // Already stale — update depth only (time-based escalation, monotonic).
-  // Load stops accumulating here, so post-transition depth escalation is purely
-  // time-driven regardless of how many more heavy tools are called.
+  // Update trajectory window on EVERY call (including when stale) so burst
+  // detection and oscillation scoring reflect the actual navigation path.
+  const mod = filePath ? moduleFromPath(filePath, tracker.sourceRoots) : null;
+  tracker.moduleAccessWindow.push(mod);
+  if (tracker.moduleAccessWindow.length > CROSS_MODULE_WINDOW_SIZE) {
+    tracker.moduleAccessWindow.shift();
+  }
+
+  const density = computeCrossModuleDensity(tracker.moduleAccessWindow);
+  const oscillation = computeOscillationScore(tracker.moduleAccessWindow);
+  tracker.oscillation = oscillation;
+
+  // Already stale — time-based depth escalation only, plus V3.2 burst sensitivity.
+  // Load stops accumulating here; burst detection uses tool weight and density instead.
   if (tracker.freshnessState === 'stale') {
+    // Post-stale burst: heavy architectural tool or trajectory burst → immediate depth 3
+    if (tracker.staleDepth < 3 && (weight >= BURST_TOOL_WEIGHT_THRESHOLD || density >= BURST_DENSITY_THRESHOLD)) {
+      emit(directory, 'epistemic-lease', {
+        event: 'depth_escalate', from_depth: tracker.staleDepth, to_depth: 3,
+        tool: toolName, module: mod, cognitive_load: tracker.cognitiveLoad,
+        density, oscillation, age_min: Math.floor(ageMs / 60_000), trigger: 'burst',
+      });
+      tracker.staleDepth = 3;
+      return;
+    }
     const newDepth = computeStaleDepth(tracker.cognitiveLoad, ageMs);
     if (newDepth > tracker.staleDepth) {
       emit(directory, 'epistemic-lease', {
         event: 'depth_escalate', from_depth: tracker.staleDepth, to_depth: newDepth,
-        tool: toolName, module: null, cognitive_load: tracker.cognitiveLoad,
-        density: 0, age_min: Math.floor(ageMs / 60_000),
+        tool: toolName, module: mod, cognitive_load: tracker.cognitiveLoad,
+        density, oscillation, age_min: Math.floor(ageMs / 60_000),
       });
       tracker.staleDepth = newDepth as StaleDepth;
     }
@@ -321,17 +371,7 @@ export function updateTracker(
   }
 
   // Accumulate cognitive load from tool weight
-  const weight = TOOL_WEIGHTS[toolName] ?? 1;
   tracker.cognitiveLoad += weight;
-
-  // V3.1: trajectory-based cross-module drift tracking
-  const mod = filePath ? moduleFromPath(filePath, tracker.sourceRoots) : null;
-
-  // Sliding window — push on every call so density denominator = total calls
-  tracker.moduleAccessWindow.push(mod);
-  if (tracker.moduleAccessWindow.length > CROSS_MODULE_WINDOW_SIZE) {
-    tracker.moduleAccessWindow.shift();
-  }
 
   if (mod !== null) {
     tracker.modulesVisited.add(mod);
@@ -344,16 +384,15 @@ export function updateTracker(
     tracker.lastModule = mod;
   }
 
-  // Density-based debt bonus (with cooldown to prevent oscillation)
-  const density = computeCrossModuleDensity(tracker.moduleAccessWindow);
+  // Density-based debt bonus (with cooldown to prevent double-counting)
   if (density >= CROSS_MODULE_STALE_DENSITY && now - tracker.lastDensityPenaltyAt > DENSITY_BONUS_COOLDOWN_MS) {
-    const isBurst = density >= CROSS_MODULE_STALE_DENSITY * 2;
+    const isBurst = density >= BURST_DENSITY_THRESHOLD;
     tracker.cognitiveLoad += isBurst ? BURST_DEBT_SPIKE : HIGH_DENSITY_DEBT_BONUS;
     tracker.lastDensityPenaltyAt = now;
   }
 
   const ageMin = Math.floor(ageMs / 60_000);
-  const telCtx = { tool: toolName, module: mod, cognitive_load: tracker.cognitiveLoad, density, age_min: ageMin };
+  const telCtx = { tool: toolName, module: mod, cognitive_load: tracker.cognitiveLoad, density, oscillation, age_min: ageMin };
 
   // Rate-limited git hash check (~every 30s) — structural invalidation
   if (now - tracker.lastGitCheckAt > GIT_CHECK_INTERVAL_MS) {

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -26,7 +26,6 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { appendFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import {
@@ -34,6 +33,7 @@ import {
   OPENLORE_ANALYSIS_SUBDIR,
   ARTIFACT_CALL_GRAPH_DB,
 } from '../../../constants.js';
+import { emit } from '../telemetry.js';
 
 // ============================================================================
 // TYPES
@@ -148,34 +148,6 @@ const HIGH_DENSITY_DEBT_BONUS       = 15;
 const BURST_DEBT_SPIKE              = 20;
 const DENSITY_BONUS_COOLDOWN_MS     = 60_000;
 const SWITCH_DAMPENING_MS           = 5_000;
-
-// ============================================================================
-// TELEMETRY
-// Opt-in via OPENLORE_LEASE_TELEMETRY=1. Logs state-transition events only
-// (not every tool call) to .openlore/telemetry/epistemic-lease.jsonl.
-// ============================================================================
-
-type TelemetryEvent =
-  | { event: 'degraded';        trigger: 'load' | 'density' | 'time' }
-  | { event: 'stale';           trigger: 'load' | 'density' | 'time' | 'git'; depth: StaleDepth }
-  | { event: 'depth_escalate';  from_depth: number; to_depth: StaleDepth }
-  | { event: 'orient_reset';    from_state: FreshnessState; prior_load: number; prior_depth: number };
-
-function emitTelemetry(
-  directory: string,
-  ev: TelemetryEvent,
-  ctx: { tool: string; module: string | null; cognitive_load: number; density: number; age_min: number },
-): void {
-  if (!process.env['OPENLORE_LEASE_TELEMETRY']) return;
-  try {
-    const dir = join(directory, OPENLORE_DIR, 'telemetry');
-    mkdirSync(dir, { recursive: true });
-    const line = JSON.stringify({ ts: new Date().toISOString(), ...ev, ...ctx }) + '\n';
-    appendFileSync(join(dir, 'epistemic-lease.jsonl'), line, 'utf-8');
-  } catch {
-    // telemetry must never crash the hot path
-  }
-}
 
 // ============================================================================
 // GIT HASH
@@ -317,12 +289,13 @@ export function updateTracker(
 ): void {
   if (toolName === 'orient') {
     if (tracker.freshnessState !== 'fresh') {
-      emitTelemetry(directory, {
+      emit(directory, 'epistemic-lease', {
         event: 'orient_reset',
         from_state: tracker.freshnessState,
         prior_load: tracker.cognitiveLoad,
         prior_depth: tracker.staleDepth,
-      }, { tool: 'orient', module: null, cognitive_load: tracker.cognitiveLoad, density: 0, age_min: Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000) });
+        tool: 'orient', module: null, cognitive_load: tracker.cognitiveLoad, density: 0, age_min: Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000),
+      });
     }
     resetTracker(tracker, directory);
     return;
@@ -337,7 +310,8 @@ export function updateTracker(
   if (tracker.freshnessState === 'stale') {
     const newDepth = computeStaleDepth(tracker.cognitiveLoad, ageMs);
     if (newDepth > tracker.staleDepth) {
-      emitTelemetry(directory, { event: 'depth_escalate', from_depth: tracker.staleDepth, to_depth: newDepth }, {
+      emit(directory, 'epistemic-lease', {
+        event: 'depth_escalate', from_depth: tracker.staleDepth, to_depth: newDepth,
         tool: toolName, module: null, cognitive_load: tracker.cognitiveLoad,
         density: 0, age_min: Math.floor(ageMs / 60_000),
       });
@@ -387,7 +361,7 @@ export function updateTracker(
     const currentHash = getGitHash(directory);
     if (currentHash && tracker.graphVersionAtOrient && currentHash !== tracker.graphVersionAtOrient) {
       transitionToStale(tracker, tracker.cognitiveLoad, ageMs);
-      emitTelemetry(directory, { event: 'stale', trigger: 'git', depth: tracker.staleDepth as StaleDepth }, telCtx);
+      emit(directory, 'epistemic-lease', { event: 'stale', trigger: 'git', depth: tracker.staleDepth as StaleDepth, ...telCtx });
       return;
     }
   }
@@ -396,7 +370,7 @@ export function updateTracker(
   if (ageMs >= STALE_AGE_MS || tracker.cognitiveLoad >= STALE_LOAD_THRESHOLD || density >= CROSS_MODULE_STALE_DENSITY) {
     const trigger = density >= CROSS_MODULE_STALE_DENSITY ? 'density' : tracker.cognitiveLoad >= STALE_LOAD_THRESHOLD ? 'load' : 'time';
     transitionToStale(tracker, tracker.cognitiveLoad, ageMs);
-    emitTelemetry(directory, { event: 'stale', trigger, depth: tracker.staleDepth as StaleDepth }, telCtx);
+    emit(directory, 'epistemic-lease', { event: 'stale', trigger, depth: tracker.staleDepth as StaleDepth, ...telCtx });
   } else if (
     tracker.freshnessState === 'fresh' && (
       ageMs >= DEGRADE_AGE_MS ||
@@ -406,7 +380,7 @@ export function updateTracker(
   ) {
     const trigger = density >= CROSS_MODULE_DEGRADE_DENSITY ? 'density' : tracker.cognitiveLoad >= DEGRADE_LOAD_THRESHOLD ? 'load' : 'time';
     tracker.freshnessState = 'degraded';
-    emitTelemetry(directory, { event: 'degraded', trigger }, telCtx);
+    emit(directory, 'epistemic-lease', { event: 'degraded', trigger, ...telCtx });
   }
 }
 

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -10,7 +10,9 @@
  *   - Time: >15min → degraded, >30min → stale
  *   - Git hash divergence from orient baseline → immediate stale
  *   - Weighted cognitive load: >30 → degraded, >60 → stale
- *   - Cross-module file access diversity: >3 distinct top-level modules → degraded
+ *   - Cross-module trajectory density: ≥0.15 → degraded, ≥0.30 → stale
+ *     Density = module switches in last 15 calls / window size.
+ *     Each switch also adds +5 debt; high-density window +15; burst +20.
  *
  * Stale escalates through 3 depths to prevent warning blindness:
  *   - Depth 1 (load≥60, age≥30min): procedural — explains what NOT to do
@@ -50,6 +52,14 @@ export interface EpistemicTracker {
   lastGitCheckAt: number;
   /** Top-level source directories derived from the actual project layout. */
   sourceRoots: string[];
+  /** V3.1: last resolved module for switch detection. */
+  lastModule: string | null;
+  /** V3.1: sliding window of last N module accesses (null = no filePath on that call). */
+  moduleAccessWindow: (string | null)[];
+  /** V3.1: epoch ms of last density-bonus application (cooldown). */
+  lastDensityPenaltyAt: number;
+  /** V3.1: epoch ms of last module switch (dampening). */
+  lastSwitchAt: number;
 }
 
 // ============================================================================
@@ -126,8 +136,17 @@ const STALE_AGE_MS    = 30 * 60 * 1000;
 const STALE_D2_AGE_MS = 45 * 60 * 1000;
 const STALE_D3_AGE_MS = 60 * 60 * 1000;
 
-const DEGRADE_MODULE_THRESHOLD = 3;
 const GIT_CHECK_INTERVAL_MS    = 30_000;
+
+// V3.1 cross-module trajectory model
+const CROSS_MODULE_WINDOW_SIZE      = 15;
+const CROSS_MODULE_DEGRADE_DENSITY  = 0.15;
+const CROSS_MODULE_STALE_DENSITY    = 0.30;
+const MODULE_SWITCH_BASE_WEIGHT     = 5;
+const HIGH_DENSITY_DEBT_BONUS       = 15;
+const BURST_DEBT_SPIKE              = 20;
+const DENSITY_BONUS_COOLDOWN_MS     = 60_000;
+const SWITCH_DAMPENING_MS           = 5_000;
 
 // ============================================================================
 // GIT HASH
@@ -189,6 +208,25 @@ function moduleFromPath(filePath: string, sourceRoots: string[]): string | null 
 }
 
 // ============================================================================
+// CROSS-MODULE DENSITY
+// Counts module transitions in the sliding window, skipping null entries.
+// Denominator is total window length so non-file calls dilute density.
+// ============================================================================
+
+function computeCrossModuleDensity(window: (string | null)[]): number {
+  if (window.length < 2) return 0;
+  let switches = 0;
+  let prev: string | null = null;
+  for (const mod of window) {
+    if (mod !== null) {
+      if (prev !== null && mod !== prev) switches++;
+      prev = mod;
+    }
+  }
+  return switches / window.length;
+}
+
+// ============================================================================
 // STALE DEPTH
 // Monotonic — depth can only increase, never decrease until orient() reset.
 // ============================================================================
@@ -213,6 +251,10 @@ export function createTracker(directory: string): EpistemicTracker {
     staleDepth: 0,
     lastGitCheckAt: Date.now(),
     sourceRoots: getSourceRoots(directory),
+    lastModule: null,
+    moduleAccessWindow: [],
+    lastDensityPenaltyAt: 0,
+    lastSwitchAt: 0,
   };
 }
 
@@ -224,6 +266,10 @@ function resetTracker(tracker: EpistemicTracker, directory: string): void {
   tracker.freshnessState = 'fresh';
   tracker.staleDepth = 0;
   tracker.lastGitCheckAt = Date.now();
+  tracker.lastModule = null;
+  tracker.moduleAccessWindow = [];
+  tracker.lastDensityPenaltyAt = 0;
+  tracker.lastSwitchAt = 0;
   // sourceRoots not reset — project layout doesn't change during a session
 }
 
@@ -255,14 +301,36 @@ export function updateTracker(
     return;
   }
 
-  // Accumulate cognitive load
+  // Accumulate cognitive load from tool weight
   const weight = TOOL_WEIGHTS[toolName] ?? 1;
   tracker.cognitiveLoad += weight;
 
-  // Track cross-module file access
-  if (filePath) {
-    const mod = moduleFromPath(filePath, tracker.sourceRoots);
-    if (mod) tracker.modulesVisited.add(mod);
+  // V3.1: trajectory-based cross-module drift tracking
+  const mod = filePath ? moduleFromPath(filePath, tracker.sourceRoots) : null;
+
+  // Sliding window — push on every call so density denominator = total calls
+  tracker.moduleAccessWindow.push(mod);
+  if (tracker.moduleAccessWindow.length > CROSS_MODULE_WINDOW_SIZE) {
+    tracker.moduleAccessWindow.shift();
+  }
+
+  if (mod !== null) {
+    tracker.modulesVisited.add(mod);
+    const isSwitch = tracker.lastModule !== null && mod !== tracker.lastModule;
+    // Dampen rapid back-and-forth (same switch pair within SWITCH_DAMPENING_MS)
+    if (isSwitch && now - tracker.lastSwitchAt > SWITCH_DAMPENING_MS) {
+      tracker.cognitiveLoad += MODULE_SWITCH_BASE_WEIGHT;
+      tracker.lastSwitchAt = now;
+    }
+    tracker.lastModule = mod;
+  }
+
+  // Density-based debt bonus (with cooldown to prevent oscillation)
+  const density = computeCrossModuleDensity(tracker.moduleAccessWindow);
+  if (density >= CROSS_MODULE_STALE_DENSITY && now - tracker.lastDensityPenaltyAt > DENSITY_BONUS_COOLDOWN_MS) {
+    const isBurst = density >= CROSS_MODULE_STALE_DENSITY * 2;
+    tracker.cognitiveLoad += isBurst ? BURST_DEBT_SPIKE : HIGH_DENSITY_DEBT_BONUS;
+    tracker.lastDensityPenaltyAt = now;
   }
 
   // Rate-limited git hash check (~every 30s) — structural invalidation
@@ -275,14 +343,14 @@ export function updateTracker(
     }
   }
 
-  // Time and load based decay (never reverses: stale > degraded > fresh)
-  if (ageMs >= STALE_AGE_MS || tracker.cognitiveLoad >= STALE_LOAD_THRESHOLD) {
+  // State transitions: stale > degraded > fresh (never reverses)
+  if (ageMs >= STALE_AGE_MS || tracker.cognitiveLoad >= STALE_LOAD_THRESHOLD || density >= CROSS_MODULE_STALE_DENSITY) {
     transitionToStale(tracker, tracker.cognitiveLoad, ageMs);
   } else if (
     tracker.freshnessState === 'fresh' && (
       ageMs >= DEGRADE_AGE_MS ||
       tracker.cognitiveLoad >= DEGRADE_LOAD_THRESHOLD ||
-      tracker.modulesVisited.size > DEGRADE_MODULE_THRESHOLD
+      density >= CROSS_MODULE_DEGRADE_DENSITY
     )
   ) {
     tracker.freshnessState = 'degraded';

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -26,6 +26,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import { appendFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import {
@@ -147,6 +148,34 @@ const HIGH_DENSITY_DEBT_BONUS       = 15;
 const BURST_DEBT_SPIKE              = 20;
 const DENSITY_BONUS_COOLDOWN_MS     = 60_000;
 const SWITCH_DAMPENING_MS           = 5_000;
+
+// ============================================================================
+// TELEMETRY
+// Opt-in via OPENLORE_LEASE_TELEMETRY=1. Logs state-transition events only
+// (not every tool call) to .openlore/telemetry/epistemic-lease.jsonl.
+// ============================================================================
+
+type TelemetryEvent =
+  | { event: 'degraded';        trigger: 'load' | 'density' | 'time' }
+  | { event: 'stale';           trigger: 'load' | 'density' | 'time' | 'git'; depth: StaleDepth }
+  | { event: 'depth_escalate';  from_depth: number; to_depth: StaleDepth }
+  | { event: 'orient_reset';    from_state: FreshnessState; prior_load: number; prior_depth: number };
+
+function emitTelemetry(
+  directory: string,
+  ev: TelemetryEvent,
+  ctx: { tool: string; module: string | null; cognitive_load: number; density: number; age_min: number },
+): void {
+  if (!process.env['OPENLORE_LEASE_TELEMETRY']) return;
+  try {
+    const dir = join(directory, OPENLORE_DIR, 'telemetry');
+    mkdirSync(dir, { recursive: true });
+    const line = JSON.stringify({ ts: new Date().toISOString(), ...ev, ...ctx }) + '\n';
+    appendFileSync(join(dir, 'epistemic-lease.jsonl'), line, 'utf-8');
+  } catch {
+    // telemetry must never crash the hot path
+  }
+}
 
 // ============================================================================
 // GIT HASH
@@ -287,6 +316,14 @@ export function updateTracker(
   filePath?: string,
 ): void {
   if (toolName === 'orient') {
+    if (tracker.freshnessState !== 'fresh') {
+      emitTelemetry(directory, {
+        event: 'orient_reset',
+        from_state: tracker.freshnessState,
+        prior_load: tracker.cognitiveLoad,
+        prior_depth: tracker.staleDepth,
+      }, { tool: 'orient', module: null, cognitive_load: tracker.cognitiveLoad, density: 0, age_min: Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000) });
+    }
     resetTracker(tracker, directory);
     return;
   }
@@ -299,7 +336,13 @@ export function updateTracker(
   // time-driven regardless of how many more heavy tools are called.
   if (tracker.freshnessState === 'stale') {
     const newDepth = computeStaleDepth(tracker.cognitiveLoad, ageMs);
-    if (newDepth > tracker.staleDepth) tracker.staleDepth = newDepth as StaleDepth;
+    if (newDepth > tracker.staleDepth) {
+      emitTelemetry(directory, { event: 'depth_escalate', from_depth: tracker.staleDepth, to_depth: newDepth }, {
+        tool: toolName, module: null, cognitive_load: tracker.cognitiveLoad,
+        density: 0, age_min: Math.floor(ageMs / 60_000),
+      });
+      tracker.staleDepth = newDepth as StaleDepth;
+    }
     return;
   }
 
@@ -335,19 +378,25 @@ export function updateTracker(
     tracker.lastDensityPenaltyAt = now;
   }
 
+  const ageMin = Math.floor(ageMs / 60_000);
+  const telCtx = { tool: toolName, module: mod, cognitive_load: tracker.cognitiveLoad, density, age_min: ageMin };
+
   // Rate-limited git hash check (~every 30s) — structural invalidation
   if (now - tracker.lastGitCheckAt > GIT_CHECK_INTERVAL_MS) {
     tracker.lastGitCheckAt = now;
     const currentHash = getGitHash(directory);
     if (currentHash && tracker.graphVersionAtOrient && currentHash !== tracker.graphVersionAtOrient) {
       transitionToStale(tracker, tracker.cognitiveLoad, ageMs);
+      emitTelemetry(directory, { event: 'stale', trigger: 'git', depth: tracker.staleDepth as StaleDepth }, telCtx);
       return;
     }
   }
 
   // State transitions: stale > degraded > fresh (never reverses)
   if (ageMs >= STALE_AGE_MS || tracker.cognitiveLoad >= STALE_LOAD_THRESHOLD || density >= CROSS_MODULE_STALE_DENSITY) {
+    const trigger = density >= CROSS_MODULE_STALE_DENSITY ? 'density' : tracker.cognitiveLoad >= STALE_LOAD_THRESHOLD ? 'load' : 'time';
     transitionToStale(tracker, tracker.cognitiveLoad, ageMs);
+    emitTelemetry(directory, { event: 'stale', trigger, depth: tracker.staleDepth as StaleDepth }, telCtx);
   } else if (
     tracker.freshnessState === 'fresh' && (
       ageMs >= DEGRADE_AGE_MS ||
@@ -355,7 +404,9 @@ export function updateTracker(
       density >= CROSS_MODULE_DEGRADE_DENSITY
     )
   ) {
+    const trigger = density >= CROSS_MODULE_DEGRADE_DENSITY ? 'density' : tracker.cognitiveLoad >= DEGRADE_LOAD_THRESHOLD ? 'load' : 'time';
     tracker.freshnessState = 'degraded';
+    emitTelemetry(directory, { event: 'degraded', trigger }, telCtx);
   }
 }
 

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -223,7 +223,9 @@ function computeCrossModuleDensity(window: (string | null)[]): number {
       prev = mod;
     }
   }
-  return switches / window.length;
+  // Fixed denominator = window capacity so early-session (small window) doesn't
+  // produce inflated density — density only reaches threshold after real accumulation.
+  return switches / CROSS_MODULE_WINDOW_SIZE;
 }
 
 // ============================================================================

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -1,0 +1,260 @@
+/**
+ * Epistemic Lease — session-level architectural confidence decay for MCP agents.
+ *
+ * Models repository understanding as a temporary, degradable representation rather
+ * than permanent truth. Injects freshness signals into every MCP tool response so
+ * that agents drifting toward internally cached reasoning ("repo fiction") see
+ * confidence decay even when they have stopped calling orient/graph tools.
+ *
+ * Decay triggers (any one sufficient):
+ *   - Time: >15min → degraded, >30min → stale
+ *   - Git hash divergence from orient baseline → immediate stale
+ *   - Weighted cognitive load: >30 → degraded, >60 → stale
+ *   - Cross-module file access diversity: >3 distinct top-level modules → degraded
+ *
+ * Injection:
+ *   - fresh  → no injection (zero overhead)
+ *   - degraded → 2-line signal appended (low friction)
+ *   - stale  → explicit capability-invalidation block prepended (hard to miss)
+ */
+
+import { spawnSync } from 'node:child_process';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type FreshnessState = 'fresh' | 'degraded' | 'stale';
+
+export interface EpistemicTracker {
+  lastOrientAt: Date;
+  graphVersionAtOrient: string;
+  cognitiveLoad: number;
+  modulesVisited: Set<string>;
+  freshnessState: FreshnessState;
+  lastGitCheckAt: number;
+}
+
+// ============================================================================
+// TOOL COGNITIVE WEIGHTS
+// Three tiers: lightweight ops (1-2), structural ops (3-5), architectural ops (8).
+// ============================================================================
+
+const TOOL_WEIGHTS: Record<string, number> = {
+  // Resets tracker — not counted
+  orient: 0,
+  analyze_codebase: 0,
+
+  // Lightweight: search / read operations
+  search_code: 1,
+  search_specs: 1,
+  search_unified: 1,
+  list_spec_domains: 1,
+  list_decisions: 1,
+  record_decision: 1,
+  get_env_vars: 1,
+  get_external_packages: 1,
+
+  // Structural: function/file-level reads
+  get_spec: 2,
+  get_signatures: 2,
+  get_function_body: 2,
+  get_function_skeleton: 2,
+  get_mapping: 2,
+  get_test_coverage: 2,
+  get_route_inventory: 2,
+  get_schema_inventory: 2,
+  get_ui_components: 2,
+  get_middleware_inventory: 2,
+
+  // Structural-heavy: graph and architecture reads
+  get_architecture_overview: 3,
+  get_call_graph: 3,
+  get_file_dependencies: 3,
+  get_critical_hubs: 3,
+  get_god_functions: 3,
+  get_leaf_functions: 3,
+  get_refactor_report: 3,
+  get_duplicate_report: 3,
+  check_spec_drift: 3,
+  detect_changes: 3,
+  audit_spec_coverage: 3,
+  get_decisions: 3,
+  get_minimal_context: 3,
+
+  // Graph traversal / cross-module
+  get_subgraph: 5,
+  analyze_impact: 5,
+  get_cluster: 4,
+  generate_change_proposal: 5,
+  annotate_story: 5,
+  generate_tests: 4,
+  get_low_risk_refactor_candidates: 4,
+
+  // Deep architectural tracing
+  trace_execution_path: 8,
+};
+
+// ============================================================================
+// THRESHOLDS
+// ============================================================================
+
+const DEGRADE_LOAD_THRESHOLD = 30;
+const STALE_LOAD_THRESHOLD = 60;
+const DEGRADE_AGE_MS = 15 * 60 * 1000;
+const STALE_AGE_MS = 30 * 60 * 1000;
+const DEGRADE_MODULE_THRESHOLD = 3;
+const GIT_CHECK_INTERVAL_MS = 30_000;
+
+// ============================================================================
+// GIT HASH
+// ============================================================================
+
+function getGitHash(directory: string): string {
+  try {
+    const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+      cwd: directory,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
+    });
+    return result.stdout?.trim() ?? '';
+  } catch {
+    return '';
+  }
+}
+
+// ============================================================================
+// MODULE EXTRACTION
+// Extract top-level module segment from a file path: src/core/... → "core"
+// ============================================================================
+
+function moduleFromPath(filePath: string): string | null {
+  const parts = filePath.split(/[/\\]/);
+  const srcIdx = parts.indexOf('src');
+  if (srcIdx >= 0 && srcIdx + 1 < parts.length) {
+    return parts[srcIdx + 1];
+  }
+  return null;
+}
+
+// ============================================================================
+// TRACKER LIFECYCLE
+// ============================================================================
+
+export function createTracker(directory: string): EpistemicTracker {
+  return {
+    lastOrientAt: new Date(),
+    graphVersionAtOrient: getGitHash(directory),
+    cognitiveLoad: 0,
+    modulesVisited: new Set(),
+    freshnessState: 'fresh',
+    lastGitCheckAt: Date.now(),
+  };
+}
+
+function resetTracker(tracker: EpistemicTracker, directory: string): void {
+  tracker.lastOrientAt = new Date();
+  tracker.graphVersionAtOrient = getGitHash(directory);
+  tracker.cognitiveLoad = 0;
+  tracker.modulesVisited = new Set();
+  tracker.freshnessState = 'fresh';
+  tracker.lastGitCheckAt = Date.now();
+}
+
+export function updateTracker(
+  tracker: EpistemicTracker,
+  toolName: string,
+  directory: string,
+  filePath?: string,
+): void {
+  if (toolName === 'orient') {
+    resetTracker(tracker, directory);
+    return;
+  }
+
+  // Already stale — skip all accumulation and state evaluation
+  if (tracker.freshnessState === 'stale') return;
+
+  // Accumulate cognitive load
+  const weight = TOOL_WEIGHTS[toolName] ?? 1;
+  tracker.cognitiveLoad += weight;
+
+  // Track cross-module file access
+  if (filePath) {
+    const mod = moduleFromPath(filePath);
+    if (mod) tracker.modulesVisited.add(mod);
+  }
+
+  // Rate-limited git hash check (~every 30s) — structural invalidation
+  const now = Date.now();
+  if (now - tracker.lastGitCheckAt > GIT_CHECK_INTERVAL_MS) {
+    tracker.lastGitCheckAt = now;
+    const currentHash = getGitHash(directory);
+    if (currentHash && tracker.graphVersionAtOrient && currentHash !== tracker.graphVersionAtOrient) {
+      tracker.freshnessState = 'stale';
+      return;
+    }
+  }
+
+  // Time and load based decay (never reverses: stale > degraded > fresh)
+  const ageMs = now - tracker.lastOrientAt.getTime();
+
+  if (ageMs >= STALE_AGE_MS || tracker.cognitiveLoad >= STALE_LOAD_THRESHOLD) {
+    tracker.freshnessState = 'stale';
+  } else if (
+    tracker.freshnessState === 'fresh' && (
+      ageMs >= DEGRADE_AGE_MS ||
+      tracker.cognitiveLoad >= DEGRADE_LOAD_THRESHOLD ||
+      tracker.modulesVisited.size > DEGRADE_MODULE_THRESHOLD
+    )
+  ) {
+    tracker.freshnessState = 'degraded';
+  }
+}
+
+// ============================================================================
+// FRESHNESS SIGNALS
+// Stale: prepended — agent sees it before reading any result.
+// Degraded: appended — low friction, visible but not blocking.
+// ============================================================================
+
+function staleBlock(ageMin: number, load: number): string {
+  return (
+    `\n╔══════════════════════════════════════════════════════════╗\n` +
+    `║  EPISTEMIC LEASE: STALE                                  ║\n` +
+    `╚══════════════════════════════════════════════════════════╝\n` +
+    `Context age: ${ageMin}min | Cognitive load score: ${load}\n\n` +
+    `Cached architectural reasoning reliability: LOW\n` +
+    `Cross-module dependency assumptions: UNRELIABLE\n` +
+    `Internal repository model: NOT AUTHORITATIVE\n\n` +
+    `Before continuing:\n` +
+    `  - Do NOT rely on previous dependency assumptions\n` +
+    `  - Do NOT infer cross-module relationships from memory\n` +
+    `  - Do NOT compile delegation prompts from cached architectural model\n` +
+    `  - Do NOT continue architectural reasoning from internal state\n\n` +
+    `Call orient() to restore architectural authority.\n` +
+    `─────────────────────────────────────────────────────────────\n\n`
+  );
+}
+
+function degradedSignal(ageMin: number, modules: number): string {
+  return (
+    `\n─────────────────────────────────────────────────────────────\n` +
+    `[EPISTEMIC LEASE: DEGRADED | age: ${ageMin}min | modules visited: ${modules}]\n` +
+    `Cross-module dependency assumptions: reduced confidence.\n` +
+    `Call orient() before architectural decisions or delegation prompt compilation.\n`
+  );
+}
+
+export function injectFreshness(text: string, tracker: EpistemicTracker): string {
+  if (tracker.freshnessState === 'fresh') return text;
+
+  const ageMin = Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000);
+
+  if (tracker.freshnessState === 'stale') {
+    return staleBlock(ageMin, tracker.cognitiveLoad) + text;
+  }
+
+  return text + degradedSignal(ageMin, tracker.modulesVisited.size);
+}

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -24,7 +24,13 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import {
+  OPENLORE_DIR,
+  OPENLORE_ANALYSIS_SUBDIR,
+  ARTIFACT_CALL_GRAPH_DB,
+} from '../../../constants.js';
 
 // ============================================================================
 // TYPES
@@ -143,27 +149,29 @@ function getGitHash(directory: string): string {
 
 // ============================================================================
 // MODULE EXTRACTION
-// Extract top-level module segment from a file path, using the actual source
-// root directories scanned from the project at tracker creation time.
+// Extract top-level module segment from a file path, using the source root
+// directories derived from the call-graph db (files actually analyzed, already
+// filtered by config include/exclude patterns).
 //
-//   (project has packages/, src/)
-//   packages/auth/src/jwt.ts → "auth"
-//   src/core/services/mcp.ts → "core"
+//   src/core/services/mcp.ts → root "src" → module "core"
+//   packages/auth/src/jwt.ts → root "packages" → module "auth"
 //
-// Paths with no matching source root return null — prevents OS path segment
-// pollution from absolute paths like /Users/foo/bar.ts.
+// Returns [] when no analysis exists yet — module tracking stays silent rather
+// than tracking arbitrary filesystem dirs as if they were analyzed modules.
 // ============================================================================
-
-const IGNORED_DIRS = new Set([
-  'node_modules', 'dist', 'build', 'out', 'target', 'coverage',
-  'vendor', '.cache', '__pycache__',
-]);
 
 export function getSourceRoots(directory: string): string[] {
   try {
-    return readdirSync(directory, { withFileTypes: true })
-      .filter(e => e.isDirectory() && !e.name.startsWith('.') && !IGNORED_DIRS.has(e.name))
-      .map(e => e.name);
+    const dbPath = join(directory, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_CALL_GRAPH_DB);
+    const db = new DatabaseSync(dbPath);
+    const rows = db.prepare('SELECT DISTINCT file_path FROM nodes WHERE is_external = 0').all() as Array<{ file_path: string }>;
+    db.close();
+    const roots = new Set<string>();
+    for (const { file_path } of rows) {
+      const first = file_path.split(/[/\\]/)[0];
+      if (first) roots.add(first);
+    }
+    return [...roots];
   } catch {
     return [];
   }

--- a/src/core/services/mcp-handlers/epistemic-lease.ts
+++ b/src/core/services/mcp-handlers/epistemic-lease.ts
@@ -12,10 +12,15 @@
  *   - Weighted cognitive load: >30 → degraded, >60 → stale
  *   - Cross-module file access diversity: >3 distinct top-level modules → degraded
  *
+ * Stale escalates through 3 depths to prevent warning blindness:
+ *   - Depth 1 (load≥60, age≥30min): procedural — explains what NOT to do
+ *   - Depth 2 (load≥85, age≥45min): risk-framing — names downstream consequences
+ *   - Depth 3 (load≥110, age≥60min): imperative — minimal text, hardest to skim
+ *
  * Injection:
- *   - fresh  → no injection (zero overhead)
- *   - degraded → 2-line signal appended (low friction)
- *   - stale  → explicit capability-invalidation block prepended (hard to miss)
+ *   - fresh    → no injection (zero overhead)
+ *   - degraded → 3-line signal appended (low friction)
+ *   - stale    → depth-varying capability-invalidation block prepended
  */
 
 import { spawnSync } from 'node:child_process';
@@ -25,6 +30,7 @@ import { spawnSync } from 'node:child_process';
 // ============================================================================
 
 export type FreshnessState = 'fresh' | 'degraded' | 'stale';
+export type StaleDepth = 1 | 2 | 3;
 
 export interface EpistemicTracker {
   lastOrientAt: Date;
@@ -32,6 +38,8 @@ export interface EpistemicTracker {
   cognitiveLoad: number;
   modulesVisited: Set<string>;
   freshnessState: FreshnessState;
+  /** Escalating severity within stale state. 0 when not stale. */
+  staleDepth: 0 | StaleDepth;
   lastGitCheckAt: number;
 }
 
@@ -99,12 +107,18 @@ const TOOL_WEIGHTS: Record<string, number> = {
 // THRESHOLDS
 // ============================================================================
 
-const DEGRADE_LOAD_THRESHOLD = 30;
-const STALE_LOAD_THRESHOLD = 60;
-const DEGRADE_AGE_MS = 15 * 60 * 1000;
-const STALE_AGE_MS = 30 * 60 * 1000;
+const DEGRADE_LOAD_THRESHOLD  = 30;
+const STALE_LOAD_THRESHOLD    = 60;
+const STALE_D2_LOAD_THRESHOLD = 85;
+const STALE_D3_LOAD_THRESHOLD = 110;
+
+const DEGRADE_AGE_MS  = 15 * 60 * 1000;
+const STALE_AGE_MS    = 30 * 60 * 1000;
+const STALE_D2_AGE_MS = 45 * 60 * 1000;
+const STALE_D3_AGE_MS = 60 * 60 * 1000;
+
 const DEGRADE_MODULE_THRESHOLD = 3;
-const GIT_CHECK_INTERVAL_MS = 30_000;
+const GIT_CHECK_INTERVAL_MS    = 30_000;
 
 // ============================================================================
 // GIT HASH
@@ -127,6 +141,7 @@ function getGitHash(directory: string): string {
 // ============================================================================
 // MODULE EXTRACTION
 // Extract top-level module segment from a file path: src/core/... → "core"
+// Paths without a src/ segment return null — no module pollution from absolute paths.
 // ============================================================================
 
 function moduleFromPath(filePath: string): string | null {
@@ -136,6 +151,17 @@ function moduleFromPath(filePath: string): string | null {
     return parts[srcIdx + 1];
   }
   return null;
+}
+
+// ============================================================================
+// STALE DEPTH
+// Monotonic — depth can only increase, never decrease until orient() reset.
+// ============================================================================
+
+function computeStaleDepth(load: number, ageMs: number): StaleDepth {
+  if (load >= STALE_D3_LOAD_THRESHOLD || ageMs >= STALE_D3_AGE_MS) return 3;
+  if (load >= STALE_D2_LOAD_THRESHOLD || ageMs >= STALE_D2_AGE_MS) return 2;
+  return 1;
 }
 
 // ============================================================================
@@ -149,6 +175,7 @@ export function createTracker(directory: string): EpistemicTracker {
     cognitiveLoad: 0,
     modulesVisited: new Set(),
     freshnessState: 'fresh',
+    staleDepth: 0,
     lastGitCheckAt: Date.now(),
   };
 }
@@ -159,7 +186,13 @@ function resetTracker(tracker: EpistemicTracker, directory: string): void {
   tracker.cognitiveLoad = 0;
   tracker.modulesVisited = new Set();
   tracker.freshnessState = 'fresh';
+  tracker.staleDepth = 0;
   tracker.lastGitCheckAt = Date.now();
+}
+
+function transitionToStale(tracker: EpistemicTracker, load: number, ageMs: number): void {
+  tracker.freshnessState = 'stale';
+  tracker.staleDepth = computeStaleDepth(load, ageMs);
 }
 
 export function updateTracker(
@@ -173,8 +206,15 @@ export function updateTracker(
     return;
   }
 
-  // Already stale — skip all accumulation and state evaluation
-  if (tracker.freshnessState === 'stale') return;
+  const now = Date.now();
+  const ageMs = now - tracker.lastOrientAt.getTime();
+
+  // Already stale — update depth only (time-based escalation, monotonic)
+  if (tracker.freshnessState === 'stale') {
+    const newDepth = computeStaleDepth(tracker.cognitiveLoad, ageMs);
+    if (newDepth > tracker.staleDepth) tracker.staleDepth = newDepth as StaleDepth;
+    return;
+  }
 
   // Accumulate cognitive load
   const weight = TOOL_WEIGHTS[toolName] ?? 1;
@@ -187,21 +227,18 @@ export function updateTracker(
   }
 
   // Rate-limited git hash check (~every 30s) — structural invalidation
-  const now = Date.now();
   if (now - tracker.lastGitCheckAt > GIT_CHECK_INTERVAL_MS) {
     tracker.lastGitCheckAt = now;
     const currentHash = getGitHash(directory);
     if (currentHash && tracker.graphVersionAtOrient && currentHash !== tracker.graphVersionAtOrient) {
-      tracker.freshnessState = 'stale';
+      transitionToStale(tracker, tracker.cognitiveLoad, ageMs);
       return;
     }
   }
 
   // Time and load based decay (never reverses: stale > degraded > fresh)
-  const ageMs = now - tracker.lastOrientAt.getTime();
-
   if (ageMs >= STALE_AGE_MS || tracker.cognitiveLoad >= STALE_LOAD_THRESHOLD) {
-    tracker.freshnessState = 'stale';
+    transitionToStale(tracker, tracker.cognitiveLoad, ageMs);
   } else if (
     tracker.freshnessState === 'fresh' && (
       ageMs >= DEGRADE_AGE_MS ||
@@ -215,27 +252,57 @@ export function updateTracker(
 
 // ============================================================================
 // FRESHNESS SIGNALS
-// Stale: prepended — agent sees it before reading any result.
-// Degraded: appended — low friction, visible but not blocking.
+//
+// Stale depth variants use different rhetorical strategies to resist blindness:
+//   Depth 1 — procedural: enumerates what NOT to do, offers orient()
+//   Depth 2 — consequential: names downstream risks of ignoring the signal
+//   Depth 3 — imperative: minimal text, command form, hardest to skim past
+//
+// Degraded: appended (low friction, visible but not blocking).
+// Stale:    prepended (agent sees it before reading any result).
 // ============================================================================
 
-function staleBlock(ageMin: number, load: number): string {
-  return (
+function staleBlock(ageMin: number, load: number, depth: StaleDepth): string {
+  const header =
     `\n╔══════════════════════════════════════════════════════════╗\n` +
-    `║  EPISTEMIC LEASE: STALE                                  ║\n` +
+    (depth === 1
+      ? `║  EPISTEMIC LEASE: STALE                                  ║\n`
+      : depth === 2
+      ? `║  EPISTEMIC LEASE: STALE [ELEVATED]                       ║\n`
+      : `║  EPISTEMIC LEASE: STALE [CRITICAL]                       ║\n`) +
     `╚══════════════════════════════════════════════════════════╝\n` +
-    `Context age: ${ageMin}min | Cognitive load score: ${load}\n\n` +
-    `Cached architectural reasoning reliability: LOW\n` +
-    `Cross-module dependency assumptions: UNRELIABLE\n` +
-    `Internal repository model: NOT AUTHORITATIVE\n\n` +
-    `Before continuing:\n` +
-    `  - Do NOT rely on previous dependency assumptions\n` +
-    `  - Do NOT infer cross-module relationships from memory\n` +
-    `  - Do NOT compile delegation prompts from cached architectural model\n` +
-    `  - Do NOT continue architectural reasoning from internal state\n\n` +
-    `Call orient() to restore architectural authority.\n` +
-    `─────────────────────────────────────────────────────────────\n\n`
-  );
+    `Context age: ${ageMin}min | Cognitive load score: ${load}\n\n`;
+
+  const body =
+    depth === 1
+      ? (
+        `Cached architectural reasoning reliability: LOW\n` +
+        `Cross-module dependency assumptions: UNRELIABLE\n` +
+        `Internal repository model: NOT AUTHORITATIVE\n\n` +
+        `Before continuing:\n` +
+        `  - Do NOT rely on previous dependency assumptions\n` +
+        `  - Do NOT infer cross-module relationships from memory\n` +
+        `  - Do NOT compile delegation prompts from cached architectural model\n` +
+        `  - Do NOT continue architectural reasoning from internal state\n\n` +
+        `Call orient() to restore architectural authority.\n`
+      )
+      : depth === 2
+      ? (
+        `Dependency assumptions: NO LONGER AUTHORITATIVE\n` +
+        `Architectural inference from memory: HIGH HALLUCINATION RISK\n` +
+        `Delegation prompt compilation: UNSAFE — context unreliable\n\n` +
+        `Continuing without orient() risks embedding stale architectural\n` +
+        `assumptions into refactor plans, cross-module reasoning, and\n` +
+        `delegation context that cannot easily be corrected downstream.\n\n` +
+        `orient() required before architectural decisions.\n`
+      )
+      : (
+        `Cross-module reasoning reliability: CRITICALLY LOW\n` +
+        `Repository model: EXPIRED — do not use for architectural decisions\n\n` +
+        `STOP. Call orient() before any architectural reasoning.\n`
+      );
+
+  return header + body + `─────────────────────────────────────────────────────────────\n\n`;
 }
 
 function degradedSignal(ageMin: number, modules: number): string {
@@ -253,7 +320,7 @@ export function injectFreshness(text: string, tracker: EpistemicTracker): string
   const ageMin = Math.floor((Date.now() - tracker.lastOrientAt.getTime()) / 60_000);
 
   if (tracker.freshnessState === 'stale') {
-    return staleBlock(ageMin, tracker.cognitiveLoad) + text;
+    return staleBlock(ageMin, tracker.cognitiveLoad, (tracker.staleDepth || 1) as StaleDepth) + text;
   }
 
   return text + degradedSignal(ageMin, tracker.modulesVisited.size);

--- a/src/core/services/mcp-handlers/utils.ts
+++ b/src/core/services/mcp-handlers/utils.ts
@@ -12,6 +12,7 @@ import { ANALYSIS_STALE_THRESHOLD_MS, ARTIFACT_FINGERPRINT, ARTIFACT_LLM_CONTEXT
 /** LLMContext with optional SQLite edge store attached (present when call-graph.db exists). */
 export type CachedContext = LLMContext & { edgeStore?: EdgeStore };
 import { logger } from '../../../utils/logger.js';
+import { emit } from '../telemetry.js';
 
 /**
  * Resolve and validate a user-supplied directory path.
@@ -117,8 +118,10 @@ export async function readCachedContext(directory: string, timeout?: number): Pr
       if (EdgeStore.exists(analysisDir)) {
         ctx.edgeStore = EdgeStore.open(EdgeStore.dbPath(analysisDir));
       }
+      emit(directory, 'cache', { event: 'cache_read', hit: true });
       return ctx;
     } catch {
+      emit(directory, 'cache', { event: 'cache_read', hit: false });
       return null;
     }
   }

--- a/src/core/services/telemetry.ts
+++ b/src/core/services/telemetry.ts
@@ -1,0 +1,37 @@
+/**
+ * Opt-in telemetry writer for openlore.
+ *
+ * Gate: OPENLORE_TELEMETRY=1 (disabled by default).
+ * Writes append-only JSONL to .openlore/telemetry/<domain>.jsonl.
+ * Never throws — telemetry must not crash the hot path.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { OPENLORE_DIR } from '../../constants.js';
+
+const TELEMETRY_SUBDIR = 'telemetry';
+
+/**
+ * Emit a telemetry event to .openlore/telemetry/<domain>.jsonl.
+ *
+ * @param directory  - project root (must be absolute)
+ * @param domain     - log file name without extension (e.g. 'mcp', 'cache', 'epistemic-lease')
+ * @param payload    - arbitrary fields merged with the timestamp
+ */
+export function emit(
+  directory: string,
+  domain: string,
+  payload: Record<string, unknown>,
+): void {
+  if (!process.env['OPENLORE_TELEMETRY']) return;
+  if (!directory) return;
+  try {
+    const dir = join(directory, OPENLORE_DIR, TELEMETRY_SUBDIR);
+    mkdirSync(dir, { recursive: true });
+    const line = JSON.stringify({ ts: new Date().toISOString(), ...payload }) + '\n';
+    appendFileSync(join(dir, `${domain}.jsonl`), line, 'utf-8');
+  } catch {
+    // never crash the hot path
+  }
+}

--- a/src/core/services/telemetry.ts
+++ b/src/core/services/telemetry.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { OPENLORE_DIR } from '../../constants.js';
 
 const TELEMETRY_SUBDIR = 'telemetry';
+const _createdDirs = new Set<string>();
 
 /**
  * Emit a telemetry event to .openlore/telemetry/<domain>.jsonl.
@@ -28,7 +29,7 @@ export function emit(
   if (!directory) return;
   try {
     const dir = join(directory, OPENLORE_DIR, TELEMETRY_SUBDIR);
-    mkdirSync(dir, { recursive: true });
+    if (!_createdDirs.has(dir)) { mkdirSync(dir, { recursive: true }); _createdDirs.add(dir); }
     const line = JSON.stringify({ ts: new Date().toISOString(), ...payload }) + '\n';
     appendFileSync(join(dir, `${domain}.jsonl`), line, 'utf-8');
   } catch {


### PR DESCRIPTION
## Summary

Implements EpistemicLease — a session-level architectural confidence model for MCP agents.

**Core principle**: EpistemicLease models architectural drift as a behavioral navigation phenomenon rather than a semantic understanding problem. Context decay is driven by where the agent goes (cross-module trajectory), not what it knows.

### Decay model

**Cross-module trajectory density**: `module_switches_in_last_15_calls / 15`
- Fixed denominator prevents false positives during session warmup
- Each module switch adds +5 cognitive debt; high-density window adds +15; burst (≥0.60) adds +20
- 5s dampening window prevents rapid back-and-forth from double-counting

**Oscillation coefficient**: `repeated_bigram_transitions / total_transitions`
- Distinguishes confusion loops (A→B→A→B = 1.0) from healthy exploration (A→B→C = 0.0)
- Emitted on every telemetry event for behavioral analysis

**Post-stale burst sensitivity**: when already stale, a heavy architectural tool (weight ≥ 8) or trajectory burst (density ≥ 0.60) triggers immediate escalation to Stale [Critical], bypassing intermediate depth
- Trajectory window continues updating during stale state so burst detection reflects actual post-stale navigation

### Stale depth escalation (signal design)

| Level | Trigger | Signal style |
|---|---|---|
| Degraded | load ≥ 30, age ≥ 15min, or density ≥ 0.15 | Advisory signal appended |
| Stale [depth 1] | load ≥ 60, age ≥ 30min, git divergence, or density ≥ 0.30 | Procedural: what NOT to do |
| Stale [depth 2] | load ≥ 85 or age ≥ 45min | Risk-framing: downstream consequences |
| Stale [depth 3] | load ≥ 110 or age ≥ 60min, or burst while stale | Imperative: STOP. Call orient(). |

### Telemetry infrastructure

Opt-in (`OPENLORE_TELEMETRY=1`), append-only JSONL per domain: `mcp.jsonl`, `orient.jsonl`, `cache.jsonl`, `epistemic-lease.jsonl`. Agent identity captured from the MCP `initialize` handshake and tagged to all events, enabling per-agent behavioral comparison.

`openlore telemetry [dir]` — summary report: tool latency, cache hit rate, orient quality per agent, obstinacy index (tool calls after stale before orient), recovery efficiency with half-life, trajectory dynamics.

`openlore telemetry --live` — real-time event stream with structured types: `STATE_TRANSITION`, `TRAJECTORY_SPIKE`, `ORIENT_RECOVERY`, `OSCILLATION_DETECTED`.

<details>
<summary>Example: <code>openlore telemetry</code> output</summary>

```
────────────────────────────────────────────────────────────
  TOOL LATENCY
────────────────────────────────────────────────────────────
  tool                              calls   avg ms   max ms
  search_code                          47      312      891
  orient                               12      428     1204
  get_subgraph                          8      673     1432
  trace_execution_path                  3     1821     2340
  get_spec                              6      201      389

  total: 76 calls, 2 errors
────────────────────────────────────────────────────────────
  CACHE
────────────────────────────────────────────────────────────
  hit rate : 84%  (63 hits / 75 reads)
────────────────────────────────────────────────────────────
  ORIENT QUALITY
────────────────────────────────────────────────────────────
  total calls : 12

  agent                         calls   avg fn  avg files  avg ins pts
  claude-code                       8        7          5            4
  cursor                            3        5          3            3
  unknown                           1        6          4            3
────────────────────────────────────────────────────────────
  EPISTEMIC STATE
────────────────────────────────────────────────────────────
  degraded events  : 4
  stale events     : 2  (depth≥2: 1, depth≥3: 0)
  triggers         : load×3  density×2  time×1
────────────────────────────────────────────────────────────
  OBSTINACY INDEX
────────────────────────────────────────────────────────────
  stale episodes         : 2
  avg calls before orient: 4.5
  depth≥2 avg            : 7.0
  depth≥3 avg            : —
────────────────────────────────────────────────────────────
  RECOVERY EFFICIENCY
────────────────────────────────────────────────────────────
  avg stale→orient latency : 43000ms
  recovery half-life       : 8 min  (orient_reset → next degradation)
  orient resets            : 2
  recurrence rate          : 1.00 stale/orient
────────────────────────────────────────────────────────────
  TRAJECTORY DYNAMICS
────────────────────────────────────────────────────────────
  avg cross-module density : 0.187
  max density              : 0.467
  burst events (≥0.6)      : 0
────────────────────────────────────────────────────────────
```

</details>

<details>
<summary>Example: <code>openlore telemetry --live</code> output</summary>

```
Watching /project/.openlore/telemetry — Ctrl+C to stop

14:23:11.042  orient                         428ms [claude-code]
14:23:14.881  search_code                    312ms [claude-code]
14:23:19.203  get_subgraph                   673ms [claude-code]
14:23:31.441  [STATE_TRANSITION] DEGRADED trigger=load load=32 density=0.133
14:23:44.102  trace_execution_path          1821ms [claude-code]
14:23:44.103  [TRAJECTORY_SPIKE] STALE depth=1 trigger=density load=67 density=0.667  [OSCILLATION_DETECTED osc=0.57]
14:23:51.334  search_code                    298ms [claude-code]
14:23:58.771  get_spec                       201ms [claude-code]
14:24:03.009  [STATE_TRANSITION] DEPTH 1 → 3 (burst) density=0.667
14:25:12.883  orient                         441ms [claude-code]
14:25:12.884  [ORIENT_RECOVERY] from=stale prior_load=89 prior_depth=3
```

</details>

## Test plan
- [x] 2722 unit tests pass (`npm test`)
- [x] TypeScript build clean (`npm run build`)
- [x] ESLint clean on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)