### PR TITLE
spec-01: openlore install — auto-configure agent surfaces

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -40,7 +40,7 @@ the block we refuse to overwrite unless you pass `--force`.
 | Surface | Marker | Files written |
 |---------|--------|---------------|
 | `claude-code` | `.claude/` or `CLAUDE.md` | append block to `CLAUDE.md`; `mcpServers.openlore` + `SessionStart` hook in `.claude/settings.json` |
-| `cursor` | `.cursor/` or `.cursorrules` | append block to `.cursorrules`; write `.cursor/rules/openlore.mdc` |
+| `cursor` | `.cursor/` or `.cursorrules` | append block to `.cursorrules`; write `.cursor/rules/openlore.mdc`; `mcpServers.openlore` in `.cursor/mcp.json` |
 | `cline` | `.clinerules` or `.vscode/settings.json` (`cline.*`) | append block to `.clinerules` |
 | `continue` | `.continue/` | add `/orient` entry to `.continue/config.json` (MCP server registration is TODO — see below) |
 | `agents-md` | always applies | append block to `AGENTS.md` (creates if absent) |

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,52 @@
+# `openlore install`
+
+Auto-configure popular AI coding agents to call OpenLore's `orient()` automatically.
+
+## Quick start
+
+```bash
+cd your-project
+openlore install
+```
+
+That auto-detects which agent surfaces are present (Claude Code, Cursor, Cline, Continue, plus
+the universal `AGENTS.md` fallback) and writes the minimal config needed for each agent to call
+`orient()` before reading source files.
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--agent <name>` | Install only for one surface. Names: `claude-code`, `cursor`, `cline`, `continue`, `agents-md`. |
+| `--dry-run` | Print the planned changes; write nothing. |
+| `--force` | Overwrite OpenLore-managed blocks even when hand-edited. |
+| `--uninstall` | Remove every OpenLore-managed block / entry. Files OpenLore created (and never had non-OpenLore content) are deleted. |
+
+## What it actually writes
+
+Every file we touch gets a managed block delimited by:
+
+```
+<!-- BEGIN OPENLORE (managed — edits inside this block will be overwritten) -->
+<!-- openlore-fingerprint: <16-hex> -->
+...content...
+<!-- END OPENLORE -->
+```
+
+JSON config files get a top-level `_openlore` key carrying a fingerprint of the values we wrote.
+Re-running `openlore install` is a no-op when the fingerprint matches; if you hand-edited inside
+the block we refuse to overwrite unless you pass `--force`.
+
+| Surface | Marker | Files written |
+|---------|--------|---------------|
+| `claude-code` | `.claude/` or `CLAUDE.md` | append block to `CLAUDE.md`; `mcpServers.openlore` + `SessionStart` hook in `.claude/settings.json` |
+| `cursor` | `.cursor/` or `.cursorrules` | append block to `.cursorrules`; write `.cursor/rules/openlore.mdc` |
+| `cline` | `.clinerules` or `.vscode/settings.json` (`cline.*`) | append block to `.clinerules` |
+| `continue` | `.continue/` | add `/orient` entry to `.continue/config.json` (MCP server registration is TODO — see below) |
+| `agents-md` | always applies | append block to `AGENTS.md` (creates if absent) |
+
+## Known follow-ups
+
+- **Continue MCP registration**: Continue's MCP config path varies across recent versions, so
+  we currently only register the `/orient` slash command and leave a warning. See
+  `TODO(openlore-spec-01)` in `src/cli/install/adapters/continue.ts`.

--- a/docs/specs/openlore-spec-01-install-command.md
+++ b/docs/specs/openlore-spec-01-install-command.md
@@ -1,0 +1,160 @@
+# OpenLore Spec 01 — `openlore install` Auto-Configure Command
+
+> A Claude Code prompt. Paste this into a fresh Claude Code session opened at the OpenLore repo root. Treat this file as the **complete spec**: nothing else needs to be loaded.
+
+---
+
+## Context for you (the agent)
+
+OpenLore (https://npmjs.com/package/openlore) is a TypeScript/Node CLI + MCP server that gives AI coding agents a persistent, deterministic, graph-native understanding of a codebase. Its current top-level scope:
+
+1. **Static analysis** — call graph, McCabe complexity, label-propagation clusters, `CODEBASE.md` digest. No API key.
+2. **Spec layer** — LLM-generated OpenSpec-compatible living specs, ADRs, drift detection.
+3. **Agent runtime** — 45 MCP tools, with `orient()` as the canonical entry point. No API key.
+
+The CLI lives in `src/cli/`. The package is published as `openlore` on npm. Bin entry: `dist/cli/index.js`.
+
+**The current friction point this PR solves.** Agents only call `orient()` if they have been *told* to via `AGENTS.md` or `CLAUDE.md` instructions written by the user. Most users do not write those instructions. The result is that OpenLore's deterministic graph exists but the agent never consults it. We need a one-command install that wires OpenLore into the popular agent surfaces so the agent calls `orient()` *automatically*.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Change the public MCP tool signatures, the `orient()` contract, or the graph schema.
+- Add new runtime dependencies beyond what is strictly required to write small config files. No new framework, no daemon, no telemetry, no network calls.
+- Modify the analysis or spec-generation pipelines.
+- Touch the OpenSpec integration, the viewer, or the drift detector.
+- Add a paid tier, a hosted service, or anything that phones home.
+
+This PR must:
+
+- Stay MIT-licensed and zero-config-by-default.
+- Be additive only: nothing existing changes behavior unless the user runs `openlore install`.
+- Pass `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build` clean.
+
+## The deliverable
+
+Add a new CLI subcommand: `openlore install`.
+
+```
+openlore install [--agent <name>] [--dry-run] [--force]
+```
+
+Behavior:
+
+- With no `--agent`, auto-detect which of the supported surfaces are present in the cwd (or up to 3 parent dirs) by checking for marker files. Install hooks/config for every detected surface and print a summary.
+- With `--agent <name>`, install only for that surface.
+- With `--dry-run`, print the files that *would* be written and their diffs, write nothing.
+- With `--force`, overwrite existing OpenLore-managed blocks even if modified. Without `--force`, refuse to overwrite if the OpenLore block has been hand-edited (detected via a comment fingerprint).
+
+### Supported agent surfaces (in this PR)
+
+1. **`claude-code`** — Claude Code (Anthropic's CLI).
+   - Marker: `.claude/` directory exists *or* `CLAUDE.md` exists at repo root.
+   - Action: Append (or update) an OpenLore-managed block to `CLAUDE.md` instructing the agent to call `openlore mcp` orient on session start and after any cross-module edit. Add a `SessionStart` hook to `.claude/settings.json` (create if absent) that runs `openlore orient --json` and prints the result. The hook command must be exactly `npx --yes openlore orient --json` so it works without a global install.
+
+2. **`cursor`** — Cursor IDE.
+   - Marker: `.cursor/` directory or `.cursorrules` file.
+   - Action: Append (or update) an OpenLore-managed block to `.cursorrules` and write a `.cursor/rules/openlore.mdc` file describing the `orient()` workflow.
+
+3. **`cline`** — Cline (formerly Claude Dev) VS Code extension.
+   - Marker: `.clinerules` file or `.vscode/settings.json` containing `cline.*` keys.
+   - Action: Append OpenLore block to `.clinerules`.
+
+4. **`continue`** — Continue.dev.
+   - Marker: `.continue/` directory or `~/.continue/config.json` referencing this repo.
+   - Action: Add an OpenLore "slash command" entry to `.continue/config.json` named `/orient` that runs `npx --yes openlore orient --json`.
+
+5. **`agents-md`** — generic fallback that always applies.
+   - Action: Append (or update) an OpenLore-managed block to `AGENTS.md` (create if absent) at repo root. This is the canonical convention OpenAI Codex / others read.
+
+### The OpenLore-managed block format
+
+Every file we touch gets a block delimited by:
+
+```
+<!-- BEGIN OPENLORE (managed — edits inside this block will be overwritten) -->
+... content ...
+<!-- END OPENLORE -->
+```
+
+For JSON files, use a top-level `_openlore` key whose value object includes a `managed: true` flag and a `fingerprint` (sha256 of the canonical content we wrote). On re-run, refuse to overwrite if `fingerprint` does not match.
+
+### The instruction text injected into markdown files
+
+Write a single source-of-truth template in `src/cli/install/templates/agent-instructions.md` containing roughly:
+
+```
+This project uses OpenLore for persistent architectural memory.
+
+ALWAYS call `orient()` (via the openlore MCP server, or `npx openlore orient --json`)
+before reading source files when starting a new task. This returns the relevant
+functions, callers, spec sections, and insertion points for the task at hand and
+saves you 15,000–50,000 tokens of file-by-file rediscovery.
+
+Re-orient whenever the Epistemic Lease indicates staleness (you'll see a prefix
+on tool responses telling you to do so).
+
+For the MCP setup, ensure `openlore mcp` is configured as an MCP server.
+See https://github.com/clay-good/OpenLore for details.
+```
+
+Keep the template short, model-agnostic, and free of marketing language. The template is the same regardless of which surface receives it.
+
+### MCP server registration
+
+Where the surface supports MCP server registration via config (Claude Code, Cursor, Continue), `openlore install` must also register `openlore` as an MCP server, pointing at `npx --yes openlore mcp`. For Claude Code, this is `.claude/settings.json` under `mcpServers`. For Cursor, the equivalent path per current Cursor docs. For Continue, the equivalent. If you are unsure of a path, do NOT guess — gate it behind a `// TODO(openlore-spec-01): verify path` comment and log a warning during install rather than silently writing the wrong file.
+
+### Uninstall
+
+Also add `openlore install --uninstall` which removes any OpenLore-managed blocks and entries it can identify by fingerprint. Files that contain only an OpenLore block (and were thus created by us) get deleted; files that had pre-existing content keep that content. Idempotent.
+
+## Files you will create or modify (approximate)
+
+```
+src/cli/install/
+  index.ts                   # main entry, dispatch on --agent
+  detect.ts                  # surface detection
+  adapters/
+    claude-code.ts
+    cursor.ts
+    cline.ts
+    continue.ts
+    agents-md.ts
+  templates/
+    agent-instructions.md
+    cursor-openlore.mdc
+  block.ts                   # block-write / fingerprint utilities
+  json-managed.ts            # safe merge into JSON config files
+src/cli/index.ts             # register subcommand
+docs/install.md              # one-page user docs
+test/cli/install/*.test.ts   # see acceptance below
+```
+
+## Acceptance criteria
+
+A reviewer must be able to verify all of these without reading your PR description:
+
+1. `openlore install --dry-run` in a clean repo prints the planned diffs and writes nothing.
+2. `openlore install --agent claude-code` in a repo containing `CLAUDE.md` adds exactly one OpenLore-managed block, with the canonical comment delimiters, and creates `.claude/settings.json` with the `SessionStart` hook and `mcpServers` entry.
+3. Running `openlore install` a second time is a no-op (fingerprint matches; nothing written; exit 0).
+4. Hand-editing inside an OpenLore block, then re-running `openlore install`, prints a warning and refuses to overwrite (exit non-zero unless `--force`).
+5. `openlore install --uninstall` removes everything `openlore install` created in the previous step. Files that pre-existed and only had OpenLore blocks added to them are restored to their pre-install state byte-for-byte. (Test this with a git-clean fixture.)
+6. All unit tests added in `test/cli/install/` pass. Test fixtures live under `test/cli/install/fixtures/` as small example trees.
+7. `npm run lint`, `npm run typecheck`, `npm run test:run`, `npm run build` all pass.
+8. No new runtime dependencies added (devDependencies only, ideally none).
+
+## Git workflow — read carefully
+
+1. Create branch `openlore-spec-01-install-command` off `main` (or whatever the default branch is — check with `git symbolic-ref refs/remotes/origin/HEAD`). If the branch already exists from a prior attempt, check it out and continue on it; do **not** create a new branch with a numbered suffix.
+2. Make the changes for this spec only. No drive-by refactors. No formatting sweeps outside files you are touching. If you find a real bug in unrelated code, leave a `// TODO(spec-01-followup):` comment and mention it in the PR description — do not fix it in this PR.
+3. Commit in logical chunks with messages like `spec-01: add install command skeleton`, `spec-01: claude-code adapter`, etc.
+4. **Open exactly one PR** for this work, titled: `spec-01: openlore install — auto-configure agent surfaces`. The PR body must summarize the deliverable and link this spec file by path.
+5. **All subsequent commits for this spec push to the same PR.** Never open a second PR for spec-01 work. If you need to redo something, push more commits to the existing branch. Use `gh pr view` to confirm the PR exists before pushing follow-up commits.
+6. If the PR is approved/merged and you discover a follow-up, that follow-up is its own *new* spec file — not a commit on this PR.
+7. Do not run `git push --force` to the shared branch unless you must rewrite history for a legitimate reason; if you do, narrate why in the PR.
+8. Run the full local verification (`lint`, `typecheck`, `test:run`, `build`) before every push.
+
+## When you are done
+
+Reply with: (a) the PR URL, (b) a one-paragraph summary of what shipped, (c) any `TODO(spec-01-followup)` you left, (d) a list of files changed. Nothing else. Do not start the next spec.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "dev": "tsx watch src/cli/index.ts",
-    "build": "tsc",
+    "build": "tsc && node scripts/copy-assets.mjs",
     "start": "node dist/cli/index.js",
     "view": "tsx src/cli/index.ts view",
     "bench": "tsx scripts/bench.ts",

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+/**
+ * Copy non-TypeScript assets from src/ to dist/ after `tsc`.
+ *
+ * Currently:
+ *   - src/cli/install/templates/*  →  dist/cli/install/templates/*
+ */
+
+import { cp, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+
+const assets = [
+  {
+    from: resolve(repoRoot, 'src/cli/install/templates'),
+    to: resolve(repoRoot, 'dist/cli/install/templates'),
+  },
+];
+
+for (const { from, to } of assets) {
+  await mkdir(dirname(to), { recursive: true });
+  await cp(from, to, { recursive: true });
+  console.log(`[copy-assets] ${from} → ${to}`);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -81,15 +81,16 @@ program
     `
 Workflow:
   1. openlore init                    Detect project type, create config
-  2. openlore analyze                 Scan codebase, build dependency graph
-  3. openlore analyze --ai-configs    Generate context files (CLAUDE.md, .cursorrules…)
-  4. openlore setup                   Install workflow skills (Vibe, Cline, GSD)
-  5. openlore view                    Review visually the dependency graph
-  6. openlore generate                Create OpenSpec files using LLM
-  7. openlore verify                  Validate specs against source code
-  8. openlore drift                   Detect when code outpaces specs
-  9. openlore test                    Generate spec-driven tests or check coverage
-  10. openlore digest                  Plain-English summary of specs for human review
+  2. openlore install                 Auto-configure agent surfaces to call orient()
+  3. openlore analyze                 Scan codebase, build dependency graph
+  4. openlore analyze --ai-configs    Generate context files (CLAUDE.md, .cursorrules…)
+  5. openlore setup                   Install workflow skills (Vibe, Cline, GSD)
+  6. openlore view                    Review visually the dependency graph
+  7. openlore generate                Create OpenSpec files using LLM
+  8. openlore verify                  Validate specs against source code
+  9. openlore drift                   Detect when code outpaces specs
+  10. openlore test                    Generate spec-driven tests or check coverage
+  11. openlore digest                  Plain-English summary of specs for human review
 
 Quick start:
   $ cd your-project

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import { testCommand } from './commands/test.js';
 import { digestCommand } from './commands/digest.js';
 import { decisionsCommand } from './commands/decisions.js';
 import { telemetryCommand } from './commands/telemetry.js';
+import { installCommand } from './install/index.js';
 import { configureLogger } from '../utils/logger.js';
 
 // Read version from package.json at runtime so it never drifts from the published version
@@ -135,5 +136,6 @@ program.addCommand(testCommand);
 program.addCommand(digestCommand);
 program.addCommand(decisionsCommand);
 program.addCommand(telemetryCommand);
+program.addCommand(installCommand);
 
 program.parse();

--- a/src/cli/install/adapters/agents-md.ts
+++ b/src/cli/install/adapters/agents-md.ts
@@ -1,0 +1,24 @@
+/**
+ * agents-md adapter — universal fallback that writes an AGENTS.md file at
+ * the project root. This is the convention OpenAI Codex (and an increasing
+ * number of other tools) read, so it's the safest "always do this" target.
+ */
+
+import { applyMarkdownBlock, uninstallMarkdownBlock } from './markdown-block.js';
+import type { Adapter, ApplyContext } from './types.js';
+
+const FILE_NAME = 'AGENTS.md';
+
+export const agentsMdAdapter: Adapter = {
+  name: 'agents-md',
+  async apply(ctx: ApplyContext) {
+    return applyMarkdownBlock(ctx, {
+      fileName: FILE_NAME,
+      createIfMissing: true,
+      blockBody: ctx.instructionTemplate,
+    });
+  },
+  async uninstall(ctx: ApplyContext) {
+    return uninstallMarkdownBlock(ctx, FILE_NAME, true);
+  },
+};

--- a/src/cli/install/adapters/claude-code.ts
+++ b/src/cli/install/adapters/claude-code.ts
@@ -18,15 +18,39 @@ const MCP_ENTRY = {
   args: ['--yes', 'openlore', 'mcp'],
 };
 
+/**
+ * Our SessionStart entry is marked with `_openlore: true` so we can identify
+ * (and replace, or remove on uninstall) just our group without touching any
+ * other SessionStart hooks the user may have configured. Claude Code ignores
+ * unknown fields on matcher groups.
+ */
+const ORIENT_COMMAND = 'npx --yes openlore orient --json';
 const SESSION_HOOK = {
   matcher: '',
+  _openlore: true,
   hooks: [
     {
       type: 'command',
-      command: 'npx --yes openlore orient --json',
+      command: ORIENT_COMMAND,
     },
   ],
 };
+
+function isOurSessionEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object') return false;
+  return (entry as Record<string, unknown>)._openlore === true;
+}
+
+function mergeSessionStart(existing: unknown): unknown[] {
+  const arr = Array.isArray(existing) ? existing : [];
+  const withoutOurs = arr.filter((e) => !isOurSessionEntry(e));
+  return [...withoutOurs, SESSION_HOOK];
+}
+
+function stripOurSessionStart(existing: unknown): unknown[] {
+  const arr = Array.isArray(existing) ? existing : [];
+  return arr.filter((e) => !isOurSessionEntry(e));
+}
 
 async function readJsonOrEmpty(path: string): Promise<Record<string, unknown>> {
   try {
@@ -75,22 +99,38 @@ export const claudeCodeAdapter: Adapter = {
       return mdResult;
     }
 
+    // SessionStart is computed imperatively (preserving any user-defined
+    // entries) and written through mergeEntries, but only mcpServers.openlore
+    // is tracked in our meta — we identify our SessionStart entry by its
+    // `_openlore: true` marker, not by claiming the whole array.
+    const currentSessionStart =
+      ((existing.hooks as Record<string, unknown>)?.SessionStart as unknown) ?? [];
+    const nextSessionStart = mergeSessionStart(currentSessionStart);
+
     const { next, action } = mergeEntries(existing, [
       { path: 'mcpServers.openlore', value: MCP_ENTRY },
-      { path: 'hooks.SessionStart', value: [SESSION_HOOK] },
     ]);
+    // Apply the SessionStart update outside the managed-paths set.
+    if (!next.hooks || typeof next.hooks !== 'object') next.hooks = {};
+    (next.hooks as Record<string, unknown>).SessionStart = nextSessionStart;
+
+    // Re-derive action: if existing already had identical SessionStart + meta noop, it's noop.
+    const sessionChanged =
+      JSON.stringify(currentSessionStart) !== JSON.stringify(nextSessionStart);
+    const finalAction =
+      action === 'noop' && !sessionChanged ? 'noop' : action === 'created' ? 'created' : 'updated';
 
     const change: PlannedChange = {
       path: settingsPath,
-      kind: !had ? 'create' : action === 'noop' ? 'noop' : 'update',
+      kind: !had ? 'create' : finalAction === 'noop' ? 'noop' : 'update',
       summary: !had
         ? `create ${SETTINGS_PATH} with SessionStart hook + mcpServers.openlore`
-        : action === 'noop'
+        : finalAction === 'noop'
           ? `${SETTINGS_PATH}: already up to date`
           : `update SessionStart hook + mcpServers.openlore in ${SETTINGS_PATH}`,
     };
 
-    if (!ctx.dryRun && (action !== 'noop' || !had)) {
+    if (!ctx.dryRun && (finalAction !== 'noop' || !had)) {
       await mkdir(dirname(settingsPath), { recursive: true });
       await writeFile(settingsPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
     }
@@ -108,8 +148,25 @@ export const claudeCodeAdapter: Adapter = {
     } catch {
       return md;
     }
+    // Strip our SessionStart entry first (it's identified by _openlore marker,
+    // not by the managed-paths meta).
+    const hooksObj = parsed.hooks as Record<string, unknown> | undefined;
+    if (hooksObj && Array.isArray(hooksObj.SessionStart)) {
+      const filtered = stripOurSessionStart(hooksObj.SessionStart);
+      if (filtered.length === 0) {
+        delete hooksObj.SessionStart;
+        if (Object.keys(hooksObj).length === 0) delete parsed.hooks;
+      } else {
+        hooksObj.SessionStart = filtered;
+      }
+    }
+
     const { next, removed } = removeManaged(parsed);
-    if (!removed) return md;
+    if (!removed && parsed.hooks === undefined) {
+      // We may have only stripped a SessionStart entry — that still counts as work.
+    } else if (!removed) {
+      return md;
+    }
 
     // If file is now empty (only had our entries), delete it.
     const isEmpty = Object.keys(next).length === 0;

--- a/src/cli/install/adapters/claude-code.ts
+++ b/src/cli/install/adapters/claude-code.ts
@@ -8,6 +8,7 @@ import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { applyMarkdownBlock, uninstallMarkdownBlock } from './markdown-block.js';
 import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
+import { previewCreate, previewDiff } from '../diff.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
 
 const MD_FILE = 'CLAUDE.md';
@@ -120,6 +121,8 @@ export const claudeCodeAdapter: Adapter = {
     const finalAction =
       action === 'noop' && !sessionChanged ? 'noop' : action === 'created' ? 'created' : 'updated';
 
+    const before = had ? JSON.stringify(existing, null, 2) + '\n' : '';
+    const after = JSON.stringify(next, null, 2) + '\n';
     const change: PlannedChange = {
       path: settingsPath,
       kind: !had ? 'create' : finalAction === 'noop' ? 'noop' : 'update',
@@ -128,6 +131,11 @@ export const claudeCodeAdapter: Adapter = {
         : finalAction === 'noop'
           ? `${SETTINGS_PATH}: already up to date`
           : `update SessionStart hook + mcpServers.openlore in ${SETTINGS_PATH}`,
+      preview: !had
+        ? previewCreate(settingsPath, after)
+        : finalAction === 'noop'
+          ? undefined
+          : previewDiff(settingsPath, before, after),
     };
 
     if (!ctx.dryRun && (finalAction !== 'noop' || !had)) {

--- a/src/cli/install/adapters/claude-code.ts
+++ b/src/cli/install/adapters/claude-code.ts
@@ -1,0 +1,133 @@
+/**
+ * claude-code adapter — appends the OpenLore instruction block to CLAUDE.md
+ * (creating it if absent) and adds a SessionStart hook + MCP server
+ * registration to `.claude/settings.json`.
+ */
+
+import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { applyMarkdownBlock, uninstallMarkdownBlock } from './markdown-block.js';
+import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
+import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
+
+const MD_FILE = 'CLAUDE.md';
+const SETTINGS_PATH = '.claude/settings.json';
+
+const MCP_ENTRY = {
+  command: 'npx',
+  args: ['--yes', 'openlore', 'mcp'],
+};
+
+const SESSION_HOOK = {
+  matcher: '',
+  hooks: [
+    {
+      type: 'command',
+      command: 'npx --yes openlore orient --json',
+    },
+  ],
+};
+
+async function readJsonOrEmpty(path: string): Promise<Record<string, unknown>> {
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const claudeCodeAdapter: Adapter = {
+  name: 'claude-code',
+  async apply(ctx: ApplyContext): Promise<ApplyResult> {
+    const mdResult = await applyMarkdownBlock(ctx, {
+      fileName: MD_FILE,
+      createIfMissing: true,
+      blockBody: ctx.instructionTemplate,
+    });
+
+    const settingsPath = join(ctx.root, SETTINGS_PATH);
+    const existing = await readJsonOrEmpty(settingsPath);
+    const had = await fileExists(settingsPath);
+    const prevMeta = readMeta(existing);
+    if (prevMeta && isHandEdited(existing, prevMeta) && !ctx.force) {
+      mdResult.changes.push({
+        path: settingsPath,
+        kind: 'noop',
+        summary: `${SETTINGS_PATH}: refused to overwrite hand-edited OpenLore entries (use --force)`,
+      });
+      mdResult.warnings.push(
+        `${SETTINGS_PATH} has hand-edits in OpenLore-managed paths — pass --force to overwrite`
+      );
+      mdResult.conflict = true;
+      return mdResult;
+    }
+
+    const { next, action } = mergeEntries(existing, [
+      { path: 'mcpServers.openlore', value: MCP_ENTRY },
+      { path: 'hooks.SessionStart', value: [SESSION_HOOK] },
+    ]);
+
+    const change: PlannedChange = {
+      path: settingsPath,
+      kind: !had ? 'create' : action === 'noop' ? 'noop' : 'update',
+      summary: !had
+        ? `create ${SETTINGS_PATH} with SessionStart hook + mcpServers.openlore`
+        : action === 'noop'
+          ? `${SETTINGS_PATH}: already up to date`
+          : `update SessionStart hook + mcpServers.openlore in ${SETTINGS_PATH}`,
+    };
+
+    if (!ctx.dryRun && (action !== 'noop' || !had)) {
+      await mkdir(dirname(settingsPath), { recursive: true });
+      await writeFile(settingsPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+    }
+
+    mdResult.changes.push(change);
+    return mdResult;
+  },
+
+  async uninstall(ctx: ApplyContext): Promise<ApplyResult> {
+    const md = await uninstallMarkdownBlock(ctx, MD_FILE, false);
+    const settingsPath = join(ctx.root, SETTINGS_PATH);
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(await readFile(settingsPath, 'utf8'));
+    } catch {
+      return md;
+    }
+    const { next, removed } = removeManaged(parsed);
+    if (!removed) return md;
+
+    // If file is now empty (only had our entries), delete it.
+    const isEmpty = Object.keys(next).length === 0;
+    if (isEmpty) {
+      if (!ctx.dryRun) await unlink(settingsPath);
+      md.changes.push({
+        path: settingsPath,
+        kind: 'delete',
+        summary: `remove ${SETTINGS_PATH} (was OpenLore-only)`,
+      });
+    } else {
+      if (!ctx.dryRun) await writeFile(settingsPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+      md.changes.push({
+        path: settingsPath,
+        kind: 'update',
+        summary: `strip OpenLore entries from ${SETTINGS_PATH}`,
+      });
+    }
+    return md;
+  },
+};

--- a/src/cli/install/adapters/cline.ts
+++ b/src/cli/install/adapters/cline.ts
@@ -1,0 +1,22 @@
+/**
+ * cline adapter — appends the OpenLore instruction block to `.clinerules`.
+ */
+
+import { applyMarkdownBlock, uninstallMarkdownBlock } from './markdown-block.js';
+import type { Adapter, ApplyContext } from './types.js';
+
+const FILE_NAME = '.clinerules';
+
+export const clineAdapter: Adapter = {
+  name: 'cline',
+  async apply(ctx: ApplyContext) {
+    return applyMarkdownBlock(ctx, {
+      fileName: FILE_NAME,
+      createIfMissing: true,
+      blockBody: ctx.instructionTemplate,
+    });
+  },
+  async uninstall(ctx: ApplyContext) {
+    return uninstallMarkdownBlock(ctx, FILE_NAME, true);
+  },
+};

--- a/src/cli/install/adapters/continue.ts
+++ b/src/cli/install/adapters/continue.ts
@@ -1,0 +1,123 @@
+/**
+ * continue adapter — adds an "/orient" slash command entry to
+ * `.continue/config.json`. The Continue config schema accepts a top-level
+ * `slashCommands` array; we add (or replace) an entry whose `name === 'orient'`.
+ *
+ * Continue's MCP integration path differs across recent versions; rather than
+ * guess and silently write to the wrong key, we leave a TODO and warn the user
+ * (per spec-01 "do not guess" rule). MCP server registration for Continue is
+ * gated behind a follow-up TODO.
+ */
+
+import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
+import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
+
+const CONFIG_PATH = '.continue/config.json';
+
+const SLASH_COMMAND = {
+  name: 'orient',
+  description: 'Call openlore orient() for the current task context',
+  run: 'npx --yes openlore orient --json',
+};
+
+export const continueAdapter: Adapter = {
+  name: 'continue',
+  async apply(ctx: ApplyContext): Promise<ApplyResult> {
+    const configPath = join(ctx.root, CONFIG_PATH);
+    let had = true;
+    let existing: Record<string, unknown>;
+    try {
+      existing = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      existing = {};
+      had = false;
+    }
+
+    const prevMeta = readMeta(existing);
+    if (prevMeta && isHandEdited(existing, prevMeta) && !ctx.force) {
+      return {
+        changes: [
+          {
+            path: configPath,
+            kind: 'noop',
+            summary: `${CONFIG_PATH}: refused to overwrite hand-edited OpenLore entries (use --force)`,
+          },
+        ],
+        warnings: [`${CONFIG_PATH} has hand-edits in OpenLore-managed paths — pass --force to overwrite`],
+        conflict: true,
+      };
+    }
+
+    // Preserve any non-OpenLore slashCommands already present.
+    const existingSlash = Array.isArray(existing.slashCommands) ? existing.slashCommands : [];
+    const otherSlash = (existingSlash as Array<Record<string, unknown>>).filter(
+      (c) => c?.name !== 'orient'
+    );
+    const nextSlash = [...otherSlash, SLASH_COMMAND];
+
+    const { next, action } = mergeEntries(existing, [
+      { path: 'slashCommands', value: nextSlash },
+    ]);
+
+    const change: PlannedChange = {
+      path: configPath,
+      kind: !had ? 'create' : action === 'noop' ? 'noop' : 'update',
+      summary: !had
+        ? `create ${CONFIG_PATH} with /orient slash command`
+        : action === 'noop'
+          ? `${CONFIG_PATH}: already up to date`
+          : `add /orient slash command to ${CONFIG_PATH}`,
+    };
+
+    const warnings = [
+      // TODO(openlore-spec-01): verify Continue MCP server registration path; not written here.
+      'continue: MCP server registration is not yet wired (path varies by Continue version) — slash command only',
+    ];
+
+    if (!ctx.dryRun && (action !== 'noop' || !had)) {
+      await mkdir(dirname(configPath), { recursive: true });
+      await writeFile(configPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+    }
+
+    return { changes: [change], warnings, conflict: false };
+  },
+
+  async uninstall(ctx: ApplyContext): Promise<ApplyResult> {
+    const configPath = join(ctx.root, CONFIG_PATH);
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(await readFile(configPath, 'utf8'));
+    } catch {
+      return { changes: [], warnings: [], conflict: false };
+    }
+    const beforeSlash = Array.isArray(parsed.slashCommands) ? parsed.slashCommands : [];
+    const filteredSlash = (beforeSlash as Array<Record<string, unknown>>).filter(
+      (c) => c?.name !== 'orient'
+    );
+    if (filteredSlash.length === beforeSlash.length && !readMeta(parsed)) {
+      return { changes: [], warnings: [], conflict: false };
+    }
+    parsed.slashCommands = filteredSlash;
+    const { next } = removeManaged(parsed);
+    if (Array.isArray(next.slashCommands) && (next.slashCommands as unknown[]).length === 0) {
+      delete next.slashCommands;
+    }
+    const isEmpty = Object.keys(next).length === 0;
+    if (isEmpty) {
+      if (!ctx.dryRun) await unlink(configPath);
+      return {
+        changes: [{ path: configPath, kind: 'delete', summary: `remove ${CONFIG_PATH} (was OpenLore-only)` }],
+        warnings: [],
+        conflict: false,
+      };
+    }
+    if (!ctx.dryRun) await writeFile(configPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+    return {
+      changes: [{ path: configPath, kind: 'update', summary: `strip OpenLore entries from ${CONFIG_PATH}` }],
+      warnings: [],
+      conflict: false,
+    };
+  },
+};

--- a/src/cli/install/adapters/continue.ts
+++ b/src/cli/install/adapters/continue.ts
@@ -12,6 +12,7 @@
 import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
+import { previewCreate, previewDiff } from '../diff.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
 
 const CONFIG_PATH = '.continue/config.json';
@@ -61,6 +62,8 @@ export const continueAdapter: Adapter = {
       { path: 'slashCommands', value: nextSlash },
     ]);
 
+    const before = had ? JSON.stringify(existing, null, 2) + '\n' : '';
+    const after = JSON.stringify(next, null, 2) + '\n';
     const change: PlannedChange = {
       path: configPath,
       kind: !had ? 'create' : action === 'noop' ? 'noop' : 'update',
@@ -69,6 +72,11 @@ export const continueAdapter: Adapter = {
         : action === 'noop'
           ? `${CONFIG_PATH}: already up to date`
           : `add /orient slash command to ${CONFIG_PATH}`,
+      preview: !had
+        ? previewCreate(configPath, after)
+        : action === 'noop'
+          ? undefined
+          : previewDiff(configPath, before, after),
     };
 
     const warnings = [

--- a/src/cli/install/adapters/cursor.ts
+++ b/src/cli/install/adapters/cursor.ts
@@ -1,16 +1,24 @@
 /**
- * cursor adapter — writes an OpenLore-managed block to `.cursorrules` and a
- * companion `.cursor/rules/openlore.mdc` file describing the orient() workflow.
+ * cursor adapter — writes an OpenLore-managed block to `.cursorrules`, a
+ * companion `.cursor/rules/openlore.mdc` file describing the orient() workflow,
+ * and registers the OpenLore MCP server in `.cursor/mcp.json`.
  */
 
 import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { applyMarkdownBlock, uninstallMarkdownBlock } from './markdown-block.js';
 import { fingerprint } from '../block.js';
+import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
 
 const RULES_FILE = '.cursorrules';
 const MDC_FILE = '.cursor/rules/openlore.mdc';
+const MCP_FILE = '.cursor/mcp.json';
+
+const MCP_ENTRY = {
+  command: 'npx',
+  args: ['--yes', 'openlore', 'mcp'],
+};
 
 function renderMdc(template: string): string {
   const fp = fingerprint(template);
@@ -76,6 +84,49 @@ export const cursorAdapter: Adapter = {
       await writeFile(mdcPath, desired, 'utf8');
     }
     rulesResult.changes.push(change);
+
+    // MCP server registration via .cursor/mcp.json (standard Cursor path).
+    const mcpPath = join(ctx.root, MCP_FILE);
+    let mcpExisting: Record<string, unknown> = {};
+    let mcpHad = true;
+    try {
+      const parsed = JSON.parse(await readFile(mcpPath, 'utf8'));
+      mcpExisting =
+        parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+          ? (parsed as Record<string, unknown>)
+          : {};
+    } catch {
+      mcpHad = false;
+    }
+    const mcpMeta = readMeta(mcpExisting);
+    if (mcpMeta && isHandEdited(mcpExisting, mcpMeta) && !ctx.force) {
+      rulesResult.changes.push({
+        path: mcpPath,
+        kind: 'noop',
+        summary: `${MCP_FILE}: refused to overwrite hand-edited OpenLore entries (use --force)`,
+      });
+      rulesResult.warnings.push(
+        `${MCP_FILE} has hand-edits in OpenLore-managed paths — pass --force to overwrite`
+      );
+      rulesResult.conflict = true;
+      return rulesResult;
+    }
+    const { next: nextMcp, action: mcpAction } = mergeEntries(mcpExisting, [
+      { path: 'mcpServers.openlore', value: MCP_ENTRY },
+    ]);
+    rulesResult.changes.push({
+      path: mcpPath,
+      kind: !mcpHad ? 'create' : mcpAction === 'noop' ? 'noop' : 'update',
+      summary: !mcpHad
+        ? `create ${MCP_FILE} with mcpServers.openlore`
+        : mcpAction === 'noop'
+          ? `${MCP_FILE}: already up to date`
+          : `update mcpServers.openlore in ${MCP_FILE}`,
+    });
+    if (!ctx.dryRun && (mcpAction !== 'noop' || !mcpHad)) {
+      await mkdir(dirname(mcpPath), { recursive: true });
+      await writeFile(mcpPath, JSON.stringify(nextMcp, null, 2) + '\n', 'utf8');
+    }
     return rulesResult;
   },
 
@@ -91,6 +142,33 @@ export const cursorAdapter: Adapter = {
           kind: 'delete',
           summary: `remove ${MDC_FILE}`,
         });
+      }
+    } catch {
+      /* not present, nothing to do */
+    }
+
+    // Strip our MCP entry from .cursor/mcp.json.
+    const mcpPath = join(ctx.root, MCP_FILE);
+    try {
+      const parsed = JSON.parse(await readFile(mcpPath, 'utf8')) as Record<string, unknown>;
+      const { next, removed } = removeManaged(parsed);
+      if (removed) {
+        const isEmpty = Object.keys(next).length === 0;
+        if (isEmpty) {
+          if (!ctx.dryRun) await unlink(mcpPath);
+          rules.changes.push({
+            path: mcpPath,
+            kind: 'delete',
+            summary: `remove ${MCP_FILE} (was OpenLore-only)`,
+          });
+        } else {
+          if (!ctx.dryRun) await writeFile(mcpPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+          rules.changes.push({
+            path: mcpPath,
+            kind: 'update',
+            summary: `strip OpenLore entries from ${MCP_FILE}`,
+          });
+        }
       }
     } catch {
       /* not present, nothing to do */

--- a/src/cli/install/adapters/cursor.ts
+++ b/src/cli/install/adapters/cursor.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'node:url';
 import { applyMarkdownBlock, uninstallMarkdownBlock } from './markdown-block.js';
 import { fingerprint } from '../block.js';
 import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
+import { previewCreate, previewDiff } from '../diff.js';
 import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
 
 const RULES_FILE = '.cursorrules';
@@ -92,6 +93,10 @@ export const cursorAdapter: Adapter = {
       path: mdcPath,
       kind: existing === null ? 'create' : 'update',
       summary: existing === null ? `create ${MDC_FILE}` : `update ${MDC_FILE}`,
+      preview:
+        existing === null
+          ? previewCreate(mdcPath, desired)
+          : previewDiff(mdcPath, existing, desired),
     };
     if (!ctx.dryRun) {
       await mkdir(dirname(mdcPath), { recursive: true });
@@ -128,6 +133,8 @@ export const cursorAdapter: Adapter = {
     const { next: nextMcp, action: mcpAction } = mergeEntries(mcpExisting, [
       { path: 'mcpServers.openlore', value: MCP_ENTRY },
     ]);
+    const beforeMcp = mcpHad ? JSON.stringify(mcpExisting, null, 2) + '\n' : '';
+    const afterMcp = JSON.stringify(nextMcp, null, 2) + '\n';
     rulesResult.changes.push({
       path: mcpPath,
       kind: !mcpHad ? 'create' : mcpAction === 'noop' ? 'noop' : 'update',
@@ -136,6 +143,11 @@ export const cursorAdapter: Adapter = {
         : mcpAction === 'noop'
           ? `${MCP_FILE}: already up to date`
           : `update mcpServers.openlore in ${MCP_FILE}`,
+      preview: !mcpHad
+        ? previewCreate(mcpPath, afterMcp)
+        : mcpAction === 'noop'
+          ? undefined
+          : previewDiff(mcpPath, beforeMcp, afterMcp),
     });
     if (!ctx.dryRun && (mcpAction !== 'noop' || !mcpHad)) {
       await mkdir(dirname(mcpPath), { recursive: true });

--- a/src/cli/install/adapters/cursor.ts
+++ b/src/cli/install/adapters/cursor.ts
@@ -6,6 +6,7 @@
 
 import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { applyMarkdownBlock, uninstallMarkdownBlock } from './markdown-block.js';
 import { fingerprint } from '../block.js';
 import { mergeEntries, readMeta, removeManaged, isHandEdited } from '../json-managed.js';
@@ -20,16 +21,29 @@ const MCP_ENTRY = {
   args: ['--yes', 'openlore', 'mcp'],
 };
 
-function renderMdc(template: string): string {
-  const fp = fingerprint(template);
-  return `---
-description: OpenLore orient() workflow
-alwaysApply: true
-openlore-fingerprint: ${fp}
----
+async function loadMdcTemplate(): Promise<string> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    // adapters/ → ../templates/cursor-openlore.mdc (dist + tsx run share this layout)
+    join(here, '..', 'templates', 'cursor-openlore.mdc'),
+    // tsx fallback if for any reason we're not co-located with templates
+    join(here, '..', '..', '..', '..', 'src', 'cli', 'install', 'templates', 'cursor-openlore.mdc'),
+  ];
+  for (const p of candidates) {
+    try {
+      return await readFile(p, 'utf8');
+    } catch {
+      /* try next */
+    }
+  }
+  throw new Error('cursor adapter: could not locate cursor-openlore.mdc template');
+}
 
-${template.trimEnd()}
-`;
+async function renderMdc(instructions: string): Promise<string> {
+  const tmpl = await loadMdcTemplate();
+  return tmpl
+    .replace('{{fingerprint}}', fingerprint(instructions.trimEnd()))
+    .replace('{{instructions}}', instructions.trimEnd());
 }
 
 export const cursorAdapter: Adapter = {
@@ -42,7 +56,7 @@ export const cursorAdapter: Adapter = {
     });
 
     const mdcPath = join(ctx.root, MDC_FILE);
-    const desired = renderMdc(ctx.instructionTemplate);
+    const desired = await renderMdc(ctx.instructionTemplate);
     let existing: string | null = null;
     try {
       existing = await readFile(mdcPath, 'utf8');

--- a/src/cli/install/adapters/cursor.ts
+++ b/src/cli/install/adapters/cursor.ts
@@ -1,0 +1,100 @@
+/**
+ * cursor adapter — writes an OpenLore-managed block to `.cursorrules` and a
+ * companion `.cursor/rules/openlore.mdc` file describing the orient() workflow.
+ */
+
+import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { applyMarkdownBlock, uninstallMarkdownBlock } from './markdown-block.js';
+import { fingerprint } from '../block.js';
+import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.js';
+
+const RULES_FILE = '.cursorrules';
+const MDC_FILE = '.cursor/rules/openlore.mdc';
+
+function renderMdc(template: string): string {
+  const fp = fingerprint(template);
+  return `---
+description: OpenLore orient() workflow
+alwaysApply: true
+openlore-fingerprint: ${fp}
+---
+
+${template.trimEnd()}
+`;
+}
+
+export const cursorAdapter: Adapter = {
+  name: 'cursor',
+  async apply(ctx: ApplyContext): Promise<ApplyResult> {
+    const rulesResult = await applyMarkdownBlock(ctx, {
+      fileName: RULES_FILE,
+      createIfMissing: true,
+      blockBody: ctx.instructionTemplate,
+    });
+
+    const mdcPath = join(ctx.root, MDC_FILE);
+    const desired = renderMdc(ctx.instructionTemplate);
+    let existing: string | null = null;
+    try {
+      existing = await readFile(mdcPath, 'utf8');
+    } catch {
+      existing = null;
+    }
+
+    if (existing === desired) {
+      rulesResult.changes.push({
+        path: mdcPath,
+        kind: 'noop',
+        summary: `${MDC_FILE}: already up to date`,
+      });
+      return rulesResult;
+    }
+
+    const isOurs =
+      existing === null ||
+      /^openlore-fingerprint:/m.test(existing);
+
+    if (existing !== null && !isOurs && !ctx.force) {
+      rulesResult.changes.push({
+        path: mdcPath,
+        kind: 'noop',
+        summary: `${MDC_FILE}: refused to overwrite non-OpenLore file (use --force)`,
+      });
+      rulesResult.warnings.push(`${MDC_FILE} exists but was not written by OpenLore`);
+      rulesResult.conflict = true;
+      return rulesResult;
+    }
+
+    const change: PlannedChange = {
+      path: mdcPath,
+      kind: existing === null ? 'create' : 'update',
+      summary: existing === null ? `create ${MDC_FILE}` : `update ${MDC_FILE}`,
+    };
+    if (!ctx.dryRun) {
+      await mkdir(dirname(mdcPath), { recursive: true });
+      await writeFile(mdcPath, desired, 'utf8');
+    }
+    rulesResult.changes.push(change);
+    return rulesResult;
+  },
+
+  async uninstall(ctx: ApplyContext): Promise<ApplyResult> {
+    const rules = await uninstallMarkdownBlock(ctx, RULES_FILE, true);
+    const mdcPath = join(ctx.root, MDC_FILE);
+    try {
+      const raw = await readFile(mdcPath, 'utf8');
+      if (/^openlore-fingerprint:/m.test(raw)) {
+        if (!ctx.dryRun) await unlink(mdcPath);
+        rules.changes.push({
+          path: mdcPath,
+          kind: 'delete',
+          summary: `remove ${MDC_FILE}`,
+        });
+      }
+    } catch {
+      /* not present, nothing to do */
+    }
+    return rules;
+  },
+};

--- a/src/cli/install/adapters/markdown-block.ts
+++ b/src/cli/install/adapters/markdown-block.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared helper for adapters that append/update a managed markdown block in
+ * a single file at the project root (CLAUDE.md, AGENTS.md, .cursorrules,
+ * .clinerules). Centralises the read/upsert/write logic so each adapter is
+ * just a one-liner.
+ */
+
+import { readFile, writeFile, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  upsertBlock,
+  extractBlock,
+  isHandEdited,
+  removeBlock,
+  renderBlock,
+} from '../block.js';
+import type { ApplyContext, ApplyResult, PlannedChange } from './types.js';
+
+export interface MarkdownBlockOptions {
+  /** File name, relative to ctx.root. */
+  fileName: string;
+  /** Whether the file should be created if it doesn't yet exist. */
+  createIfMissing: boolean;
+  /** Optional adapter-specific prefix added above the template (e.g. heading). */
+  blockBody: string;
+}
+
+export async function applyMarkdownBlock(
+  ctx: ApplyContext,
+  opts: MarkdownBlockOptions
+): Promise<ApplyResult> {
+  const filePath = join(ctx.root, opts.fileName);
+  const warnings: string[] = [];
+  let existing: string | null = null;
+  try {
+    existing = await readFile(filePath, 'utf8');
+  } catch {
+    existing = null;
+  }
+
+  if (existing === null && !opts.createIfMissing) {
+    return { changes: [], warnings, conflict: false };
+  }
+
+  const base = existing ?? '';
+  const block = existing ? extractBlock(existing) : null;
+  const handEdited = block ? isHandEdited(block) : false;
+  if (handEdited && !ctx.force) {
+    return {
+      changes: [
+        {
+          path: filePath,
+          kind: 'noop',
+          summary: `${opts.fileName}: refused to overwrite hand-edited OpenLore block (use --force)`,
+        },
+      ],
+      warnings: [`${opts.fileName} has hand-edits inside the OpenLore block — pass --force to overwrite`],
+      conflict: true,
+    };
+  }
+
+  let next: string;
+  let action: 'created' | 'updated' | 'noop';
+  if (handEdited && ctx.force && block) {
+    // Force-overwrite a tampered block regardless of fingerprint match.
+    const rendered = renderBlock(opts.blockBody);
+    next = base.slice(0, block.beginIndex) + rendered + base.slice(block.endIndex);
+    action = 'updated';
+  } else {
+    ({ next, action } = upsertBlock(base, opts.blockBody));
+  }
+
+  const change: PlannedChange = {
+    path: filePath,
+    kind:
+      existing === null
+        ? 'create'
+        : action === 'noop'
+          ? 'noop'
+          : 'update',
+    summary:
+      existing === null
+        ? `create ${opts.fileName} with OpenLore block`
+        : action === 'noop'
+          ? `${opts.fileName}: already up to date`
+          : `update OpenLore block in ${opts.fileName}`,
+  };
+
+  if (!ctx.dryRun && action !== 'noop') {
+    await writeFile(filePath, next, 'utf8');
+  }
+
+  return { changes: [change], warnings, conflict: false };
+}
+
+export async function uninstallMarkdownBlock(
+  ctx: ApplyContext,
+  fileName: string,
+  /** If true, delete the file when removing the block empties it. */
+  deleteIfBlockOnly: boolean
+): Promise<ApplyResult> {
+  const filePath = join(ctx.root, fileName);
+  let existing: string;
+  try {
+    existing = await readFile(filePath, 'utf8');
+  } catch {
+    return { changes: [], warnings: [], conflict: false };
+  }
+  const removed = removeBlock(existing);
+  if (removed === null) return { changes: [], warnings: [], conflict: false };
+
+  // Trim whitespace-only artifacts to decide if the file is now "empty".
+  const stripped = removed.trim();
+  if (stripped.length === 0 && deleteIfBlockOnly) {
+    if (!ctx.dryRun) await unlink(filePath);
+    return {
+      changes: [{ path: filePath, kind: 'delete', summary: `remove ${fileName} (was OpenLore-only)` }],
+      warnings: [],
+      conflict: false,
+    };
+  }
+  if (!ctx.dryRun) await writeFile(filePath, removed, 'utf8');
+  return {
+    changes: [{ path: filePath, kind: 'update', summary: `strip OpenLore block from ${fileName}` }],
+    warnings: [],
+    conflict: false,
+  };
+}

--- a/src/cli/install/adapters/markdown-block.ts
+++ b/src/cli/install/adapters/markdown-block.ts
@@ -14,6 +14,7 @@ import {
   removeBlock,
   renderBlock,
 } from '../block.js';
+import { previewCreate, previewDiff } from '../diff.js';
 import type { ApplyContext, ApplyResult, PlannedChange } from './types.js';
 
 export interface MarkdownBlockOptions {
@@ -84,6 +85,12 @@ export async function applyMarkdownBlock(
         : action === 'noop'
           ? `${opts.fileName}: already up to date`
           : `update OpenLore block in ${opts.fileName}`,
+    preview:
+      existing === null
+        ? previewCreate(filePath, next)
+        : action === 'noop'
+          ? undefined
+          : previewDiff(filePath, base, next),
   };
 
   if (!ctx.dryRun && action !== 'noop') {
@@ -121,7 +128,14 @@ export async function uninstallMarkdownBlock(
   }
   if (!ctx.dryRun) await writeFile(filePath, removed, 'utf8');
   return {
-    changes: [{ path: filePath, kind: 'update', summary: `strip OpenLore block from ${fileName}` }],
+    changes: [
+      {
+        path: filePath,
+        kind: 'update',
+        summary: `strip OpenLore block from ${fileName}`,
+        preview: previewDiff(filePath, existing, removed),
+      },
+    ],
     warnings: [],
     conflict: false,
   };

--- a/src/cli/install/adapters/types.ts
+++ b/src/cli/install/adapters/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared types for OpenLore install adapters.
+ *
+ * An adapter knows how to plan, apply, and uninstall OpenLore's footprint on
+ * one specific agent surface. Adapters never write to disk directly when
+ * `dryRun` is true; instead they return a list of `PlannedChange` entries that
+ * the caller renders.
+ */
+
+import type { AgentName } from '../detect.js';
+
+export interface PlannedChange {
+  /** Absolute path the change applies to. */
+  path: string;
+  /** What we'd do to that file. */
+  kind: 'create' | 'update' | 'noop' | 'delete';
+  /** Short human-readable summary (one line). */
+  summary: string;
+  /** Optional unified-diff-ish preview for `--dry-run`. */
+  preview?: string;
+}
+
+export interface ApplyContext {
+  root: string;
+  /** Template content for the markdown instruction block. */
+  instructionTemplate: string;
+  dryRun: boolean;
+  force: boolean;
+}
+
+export interface ApplyResult {
+  changes: PlannedChange[];
+  /** Warnings to surface to the user (e.g. hand-edited block, unsure-of-path TODO). */
+  warnings: string[];
+  /** If true, install should exit non-zero (hand-edit conflict without --force). */
+  conflict: boolean;
+}
+
+export interface Adapter {
+  name: AgentName;
+  apply(ctx: ApplyContext): Promise<ApplyResult>;
+  uninstall(ctx: ApplyContext): Promise<ApplyResult>;
+}

--- a/src/cli/install/block.test.ts
+++ b/src/cli/install/block.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  upsertBlock,
+  extractBlock,
+  isHandEdited,
+  removeBlock,
+  fingerprint,
+  BLOCK_BEGIN,
+  BLOCK_END,
+} from './block.js';
+
+const CONTENT = 'hello openlore';
+
+describe('block', () => {
+  it('creates a block in an empty file', () => {
+    const { next, action } = upsertBlock('', CONTENT);
+    expect(action).toBe('created');
+    expect(next).toContain(BLOCK_BEGIN);
+    expect(next).toContain(BLOCK_END);
+    expect(next).toContain(CONTENT);
+  });
+
+  it('appends a block to existing content', () => {
+    const existing = '# title\n\nsome text\n';
+    const { next, action } = upsertBlock(existing, CONTENT);
+    expect(action).toBe('created');
+    expect(next.startsWith(existing)).toBe(true);
+    expect(next).toContain(BLOCK_BEGIN);
+  });
+
+  it('is a no-op when content matches fingerprint', () => {
+    const { next } = upsertBlock('', CONTENT);
+    const second = upsertBlock(next, CONTENT);
+    expect(second.action).toBe('noop');
+    expect(second.next).toBe(next);
+  });
+
+  it('updates the block when content changes', () => {
+    const first = upsertBlock('', CONTENT).next;
+    const second = upsertBlock(first, 'new content');
+    expect(second.action).toBe('updated');
+    expect(second.next).toContain('new content');
+    expect(second.next).not.toContain(CONTENT);
+  });
+
+  it('detects hand-edits inside the block', () => {
+    const written = upsertBlock('', CONTENT).next;
+    const tampered = written.replace(CONTENT, 'sneaky edit');
+    const block = extractBlock(tampered);
+    expect(block).not.toBeNull();
+    expect(isHandEdited(block!)).toBe(true);
+  });
+
+  it('reports no hand-edit when content is untouched', () => {
+    const written = upsertBlock('', CONTENT).next;
+    const block = extractBlock(written);
+    expect(block).not.toBeNull();
+    expect(isHandEdited(block!)).toBe(false);
+  });
+
+  it('removeBlock restores file to a block-free state', () => {
+    const existing = '# title\n\nbody\n';
+    const withBlock = upsertBlock(existing, CONTENT).next;
+    const after = removeBlock(withBlock);
+    expect(after).not.toBeNull();
+    expect(after).not.toContain(BLOCK_BEGIN);
+    expect(after).toContain('# title');
+    expect(after).toContain('body');
+  });
+
+  it('removeBlock yields empty string when file was OpenLore-only', () => {
+    const written = upsertBlock('', CONTENT).next;
+    const after = removeBlock(written);
+    expect(after).toBe('');
+  });
+
+  it('fingerprint is deterministic', () => {
+    expect(fingerprint('a')).toBe(fingerprint('a'));
+    expect(fingerprint('a')).not.toBe(fingerprint('b'));
+  });
+});

--- a/src/cli/install/block.ts
+++ b/src/cli/install/block.ts
@@ -1,0 +1,131 @@
+/**
+ * OpenLore managed-block utilities.
+ *
+ * A "managed block" is a region inside an existing text file (typically Markdown)
+ * delimited by canonical comments. Re-running `openlore install` rewrites the
+ * block in place. A SHA-256 fingerprint over the canonical content lets us
+ * detect hand-edits and refuse to clobber them unless `--force` is passed.
+ */
+
+import { createHash } from 'node:crypto';
+
+export const BLOCK_BEGIN =
+  '<!-- BEGIN OPENLORE (managed — edits inside this block will be overwritten) -->';
+export const BLOCK_END = '<!-- END OPENLORE -->';
+
+const FINGERPRINT_PREFIX = '<!-- openlore-fingerprint: ';
+const FINGERPRINT_SUFFIX = ' -->';
+
+export interface ExtractedBlock {
+  /** Index of the BEGIN marker in the source file. */
+  beginIndex: number;
+  /** Index just past the END marker. */
+  endIndex: number;
+  /** The raw text between BEGIN and END markers (excluding markers themselves). */
+  inner: string;
+  /** The fingerprint we previously wrote, if present. */
+  fingerprint: string | null;
+}
+
+export function fingerprint(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex').slice(0, 16);
+}
+
+/** Build the full managed block (markers + fingerprint comment + content). */
+export function renderBlock(content: string): string {
+  const trimmed = content.trimEnd();
+  const fp = fingerprint(trimmed);
+  return [
+    BLOCK_BEGIN,
+    `${FINGERPRINT_PREFIX}${fp}${FINGERPRINT_SUFFIX}`,
+    trimmed,
+    BLOCK_END,
+  ].join('\n');
+}
+
+export function extractBlock(source: string): ExtractedBlock | null {
+  const beginIndex = source.indexOf(BLOCK_BEGIN);
+  if (beginIndex === -1) return null;
+  const endMarkerIndex = source.indexOf(BLOCK_END, beginIndex + BLOCK_BEGIN.length);
+  if (endMarkerIndex === -1) return null;
+  const endIndex = endMarkerIndex + BLOCK_END.length;
+  const inner = source.slice(beginIndex + BLOCK_BEGIN.length, endMarkerIndex);
+  const fpMatch = inner.match(
+    /<!-- openlore-fingerprint: ([0-9a-f]+) -->/
+  );
+  return {
+    beginIndex,
+    endIndex,
+    inner,
+    fingerprint: fpMatch ? fpMatch[1] : null,
+  };
+}
+
+/**
+ * Compute the fingerprint of the *current* inner content as it would be if we
+ * had written `expectedContent`. Used to decide whether the block on disk
+ * still matches what we last wrote.
+ */
+export function blockMatchesExpected(block: ExtractedBlock, expectedContent: string): boolean {
+  if (!block.fingerprint) return false;
+  return block.fingerprint === fingerprint(expectedContent.trimEnd());
+}
+
+export interface UpsertResult {
+  /** The file contents to write back. */
+  next: string;
+  /** What happened: 'created' (file/block was new), 'updated' (re-rendered), 'noop' (already matched). */
+  action: 'created' | 'updated' | 'noop';
+}
+
+/**
+ * Upsert the managed block in `existing`. If a block exists, replace it; otherwise
+ * append. If the existing block's fingerprint matches the new content, do nothing.
+ *
+ * Caller is responsible for the `--force` / hand-edit check (use `isHandEdited`).
+ */
+export function upsertBlock(existing: string, content: string): UpsertResult {
+  const rendered = renderBlock(content);
+  const block = extractBlock(existing);
+
+  if (!block) {
+    const sep = existing.length === 0 || existing.endsWith('\n') ? '' : '\n';
+    const leading = existing.length === 0 ? '' : '\n';
+    return { next: `${existing}${sep}${leading}${rendered}\n`, action: 'created' };
+  }
+
+  if (blockMatchesExpected(block, content)) {
+    return { next: existing, action: 'noop' };
+  }
+
+  const before = existing.slice(0, block.beginIndex);
+  const after = existing.slice(block.endIndex);
+  return { next: `${before}${rendered}${after}`, action: 'updated' };
+}
+
+/**
+ * True iff a block exists on disk and its inner contents no longer hash to its
+ * fingerprint (i.e. someone edited inside the markers).
+ */
+export function isHandEdited(block: ExtractedBlock): boolean {
+  if (!block.fingerprint) return false;
+  const innerWithoutFingerprintLine = block.inner
+    .replace(/<!-- openlore-fingerprint: [0-9a-f]+ -->\n?/, '')
+    .replace(/^\n+/, '')
+    .trimEnd();
+  return fingerprint(innerWithoutFingerprintLine) !== block.fingerprint;
+}
+
+/**
+ * Remove the managed block from `existing`. Returns null if no block was present.
+ */
+export function removeBlock(existing: string): string | null {
+  const block = extractBlock(existing);
+  if (!block) return null;
+  const before = existing.slice(0, block.beginIndex).replace(/\n+$/, '');
+  const after = existing.slice(block.endIndex).replace(/^\n+/, '');
+  if (before.length === 0 && after.length === 0) return '';
+  if (before.length === 0) return after.endsWith('\n') ? after : after + '\n';
+  if (after.length === 0) return before + '\n';
+  return `${before}\n\n${after}`;
+}

--- a/src/cli/install/detect.ts
+++ b/src/cli/install/detect.ts
@@ -1,0 +1,120 @@
+/**
+ * Detect which agent surfaces are present in a project tree.
+ *
+ * We walk up from `cwd` checking up to 3 parent directories for marker files.
+ * The first directory that has any marker becomes the "project root" for that
+ * surface. `agents-md` is the universal fallback and is always included.
+ */
+
+import { access, stat, readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export type AgentName = 'claude-code' | 'cursor' | 'cline' | 'continue' | 'agents-md';
+
+export const ALL_AGENTS: AgentName[] = [
+  'claude-code',
+  'cursor',
+  'cline',
+  'continue',
+  'agents-md',
+];
+
+export interface DetectedSurface {
+  agent: AgentName;
+  /** Absolute path to the directory we will treat as the project root. */
+  root: string;
+  /** Which marker(s) triggered detection (for the dry-run summary). */
+  markers: string[];
+}
+
+const PARENTS_TO_CHECK = 3;
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isDir(p: string): Promise<boolean> {
+  try {
+    return (await stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function hasClineSettings(p: string): Promise<boolean> {
+  const settings = join(p, '.vscode', 'settings.json');
+  if (!(await exists(settings))) return false;
+  try {
+    const raw = await readFile(settings, 'utf8');
+    return /"cline\./.test(raw);
+  } catch {
+    return false;
+  }
+}
+
+async function detectInDir(dir: string): Promise<DetectedSurface[]> {
+  const found: DetectedSurface[] = [];
+
+  // claude-code
+  {
+    const markers: string[] = [];
+    if (await isDir(join(dir, '.claude'))) markers.push('.claude/');
+    if (await exists(join(dir, 'CLAUDE.md'))) markers.push('CLAUDE.md');
+    if (markers.length) found.push({ agent: 'claude-code', root: dir, markers });
+  }
+
+  // cursor
+  {
+    const markers: string[] = [];
+    if (await isDir(join(dir, '.cursor'))) markers.push('.cursor/');
+    if (await exists(join(dir, '.cursorrules'))) markers.push('.cursorrules');
+    if (markers.length) found.push({ agent: 'cursor', root: dir, markers });
+  }
+
+  // cline
+  {
+    const markers: string[] = [];
+    if (await exists(join(dir, '.clinerules'))) markers.push('.clinerules');
+    if (await hasClineSettings(dir)) markers.push('.vscode/settings.json (cline.*)');
+    if (markers.length) found.push({ agent: 'cline', root: dir, markers });
+  }
+
+  // continue
+  {
+    const markers: string[] = [];
+    if (await isDir(join(dir, '.continue'))) markers.push('.continue/');
+    if (markers.length) found.push({ agent: 'continue', root: dir, markers });
+  }
+
+  return found;
+}
+
+/**
+ * Detect surfaces by walking up from `startDir` up to PARENTS_TO_CHECK levels.
+ * Each surface is reported at most once, anchored at the deepest dir where its
+ * marker was found. `agents-md` is always appended last as a universal fallback.
+ */
+export async function detect(startDir: string): Promise<DetectedSurface[]> {
+  const seen = new Set<AgentName>();
+  const out: DetectedSurface[] = [];
+  let dir = resolve(startDir);
+  for (let i = 0; i <= PARENTS_TO_CHECK; i++) {
+    for (const s of await detectInDir(dir)) {
+      if (seen.has(s.agent)) continue;
+      seen.add(s.agent);
+      out.push(s);
+    }
+    const parent = resolve(dir, '..');
+    if (parent === dir) break;
+    dir = parent;
+  }
+  // Universal fallback — anchored at the first detected root, or cwd.
+  const fallbackRoot = out[0]?.root ?? resolve(startDir);
+  out.push({ agent: 'agents-md', root: fallbackRoot, markers: ['(fallback)'] });
+  return out;
+}

--- a/src/cli/install/diff.test.ts
+++ b/src/cli/install/diff.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { previewCreate, previewDiff } from './diff.js';
+
+describe('diff', () => {
+  it('previewCreate shows every line prefixed with +', () => {
+    const out = previewCreate('foo.md', 'line1\nline2');
+    expect(out).toContain('(new file) foo.md');
+    expect(out).toContain('+ line1');
+    expect(out).toContain('+ line2');
+  });
+
+  it('previewCreate truncates very long files', () => {
+    const content = Array.from({ length: 100 }, (_, i) => `line${i}`).join('\n');
+    const out = previewCreate('big.md', content);
+    expect(out).toContain('... (40 more lines)');
+  });
+
+  it('previewDiff trims common prefix and suffix', () => {
+    const before = 'a\nb\nold\nc\nd';
+    const after = 'a\nb\nnew\nc\nd';
+    const out = previewDiff('x.md', before, after);
+    expect(out).toContain('- old');
+    expect(out).toContain('+ new');
+    expect(out).not.toContain('- a');
+    expect(out).not.toContain('+ d');
+  });
+
+  it('previewDiff anchors the hunk header at the right line', () => {
+    const before = 'a\nb\nc\nd';
+    const after = 'a\nb\nc\nADDED\nd';
+    const out = previewDiff('x.md', before, after);
+    expect(out).toContain('@ line 4');
+    expect(out).toContain('+ ADDED');
+  });
+});

--- a/src/cli/install/diff.ts
+++ b/src/cli/install/diff.ts
@@ -1,0 +1,55 @@
+/**
+ * Tiny line-oriented diff helper used to populate `--dry-run` previews.
+ *
+ * This is not a full Myers diff — it's the cheapest output that still lets a
+ * user see what `openlore install --dry-run` would do without us shelling out
+ * to `diff(1)`. Lines that match are skipped (with a `...` separator if there
+ * are unchanged runs between hunks); changed lines are prefixed with `+` /
+ * `-`. The result is meant for human eyeballing, not machine consumption.
+ */
+
+const MAX_PREVIEW_LINES = 60;
+
+export function previewCreate(filePath: string, content: string): string {
+  const lines = content.split('\n');
+  const truncated = lines.length > MAX_PREVIEW_LINES;
+  const shown = truncated ? lines.slice(0, MAX_PREVIEW_LINES) : lines;
+  const body = shown.map((l) => `+ ${l}`).join('\n');
+  const suffix = truncated ? `\n  ... (${lines.length - MAX_PREVIEW_LINES} more lines)` : '';
+  return `--- (new file) ${filePath}\n${body}${suffix}`;
+}
+
+export function previewDiff(filePath: string, before: string, after: string): string {
+  const a = before.split('\n');
+  const b = after.split('\n');
+
+  // Trim common prefix and suffix so we focus on the changed region.
+  let prefix = 0;
+  while (prefix < a.length && prefix < b.length && a[prefix] === b[prefix]) prefix++;
+  let suffix = 0;
+  while (
+    suffix < a.length - prefix &&
+    suffix < b.length - prefix &&
+    a[a.length - 1 - suffix] === b[b.length - 1 - suffix]
+  )
+    suffix++;
+
+  const removed = a.slice(prefix, a.length - suffix);
+  const added = b.slice(prefix, b.length - suffix);
+
+  const truncatedRemoved = removed.length > MAX_PREVIEW_LINES;
+  const truncatedAdded = added.length > MAX_PREVIEW_LINES;
+  const shownRemoved = truncatedRemoved ? removed.slice(0, MAX_PREVIEW_LINES) : removed;
+  const shownAdded = truncatedAdded ? added.slice(0, MAX_PREVIEW_LINES) : added;
+
+  const header = `--- ${filePath} @ line ${prefix + 1}`;
+  const minus = shownRemoved.map((l) => `- ${l}`).join('\n');
+  const plus = shownAdded.map((l) => `+ ${l}`).join('\n');
+
+  const parts = [header];
+  if (minus) parts.push(minus);
+  if (truncatedRemoved) parts.push(`  ... (${removed.length - MAX_PREVIEW_LINES} more removed lines)`);
+  if (plus) parts.push(plus);
+  if (truncatedAdded) parts.push(`  ... (${added.length - MAX_PREVIEW_LINES} more added lines)`);
+  return parts.join('\n');
+}

--- a/src/cli/install/index.ts
+++ b/src/cli/install/index.ts
@@ -127,6 +127,13 @@ function printSummary(
             : '[noop]';
     if (c.kind === 'noop') logger.discovery(`${tag} ${c.summary}`);
     else logger.success(`${tag} ${c.summary}`);
+    if (dryRun && c.preview) {
+      const indented = c.preview
+        .split('\n')
+        .map((l) => '    ' + l)
+        .join('\n');
+      process.stderr.write(indented + '\n');
+    }
   }
   for (const w of warnings) logger.warning(w);
   if (dryRun) {

--- a/src/cli/install/index.ts
+++ b/src/cli/install/index.ts
@@ -1,0 +1,150 @@
+/**
+ * `openlore install` — auto-configure popular agent surfaces so they call
+ * `orient()` automatically.
+ *
+ * Dispatches to one or more adapters depending on `--agent` / detection,
+ * supports `--dry-run`, `--force`, and `--uninstall`.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { Command } from 'commander';
+import { logger } from '../../utils/logger.js';
+import { detect, ALL_AGENTS, type AgentName, type DetectedSurface } from './detect.js';
+import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './adapters/types.js';
+import { agentsMdAdapter } from './adapters/agents-md.js';
+import { claudeCodeAdapter } from './adapters/claude-code.js';
+import { cursorAdapter } from './adapters/cursor.js';
+import { clineAdapter } from './adapters/cline.js';
+import { continueAdapter } from './adapters/continue.js';
+
+const ADAPTERS: Record<AgentName, Adapter> = {
+  'agents-md': agentsMdAdapter,
+  'claude-code': claudeCodeAdapter,
+  cursor: cursorAdapter,
+  cline: clineAdapter,
+  continue: continueAdapter,
+};
+
+async function loadTemplate(): Promise<string> {
+  // Template lives next to this file in the source tree, but at runtime we
+  // resolve via the compiled dist path.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(here, 'templates', 'agent-instructions.md'),
+    // tsx / source-run fallback
+    join(here, '..', '..', '..', 'src', 'cli', 'install', 'templates', 'agent-instructions.md'),
+  ];
+  for (const p of candidates) {
+    try {
+      return await readFile(p, 'utf8');
+    } catch {
+      /* try next */
+    }
+  }
+  throw new Error(
+    'openlore install: could not locate agent-instructions.md template (looked in dist + src)'
+  );
+}
+
+export interface InstallOptions {
+  agent?: AgentName;
+  dryRun?: boolean;
+  force?: boolean;
+  uninstall?: boolean;
+  cwd?: string;
+}
+
+export async function runInstall(opts: InstallOptions): Promise<number> {
+  const cwd = opts.cwd ?? process.cwd();
+  const template = await loadTemplate();
+
+  let surfaces: DetectedSurface[];
+  if (opts.agent) {
+    if (!ALL_AGENTS.includes(opts.agent)) {
+      logger.error(`Unknown agent surface "${opts.agent}". Known: ${ALL_AGENTS.join(', ')}`);
+      return 2;
+    }
+    surfaces = [{ agent: opts.agent, root: cwd, markers: ['(explicit --agent)'] }];
+  } else {
+    surfaces = await detect(cwd);
+  }
+
+  logger.discovery(
+    `${opts.uninstall ? 'Uninstalling' : 'Installing'} for ${surfaces.length} surface(s): ${surfaces
+      .map((s) => s.agent)
+      .join(', ')}`
+  );
+
+  let conflict = false;
+  const allChanges: PlannedChange[] = [];
+  const allWarnings: string[] = [];
+
+  for (const surface of surfaces) {
+    const adapter = ADAPTERS[surface.agent];
+    const ctx: ApplyContext = {
+      root: surface.root,
+      instructionTemplate: template,
+      dryRun: !!opts.dryRun,
+      force: !!opts.force,
+    };
+    const result: ApplyResult = opts.uninstall
+      ? await adapter.uninstall(ctx)
+      : await adapter.apply(ctx);
+
+    if (result.conflict) conflict = true;
+    allChanges.push(...result.changes);
+    allWarnings.push(...result.warnings);
+  }
+
+  printSummary(allChanges, allWarnings, !!opts.dryRun, !!opts.uninstall);
+
+  if (conflict) {
+    logger.error(
+      'Hand-edited OpenLore block(s) detected. Re-run with --force to overwrite, or revert your edits.'
+    );
+    return 1;
+  }
+  return 0;
+}
+
+function printSummary(
+  changes: PlannedChange[],
+  warnings: string[],
+  dryRun: boolean,
+  uninstall: boolean
+): void {
+  const verb = dryRun ? 'would' : 'did';
+  for (const c of changes) {
+    const tag =
+      c.kind === 'create'
+        ? `[${verb} create]`
+        : c.kind === 'update'
+          ? `[${verb} update]`
+          : c.kind === 'delete'
+            ? `[${verb} delete]`
+            : '[noop]';
+    if (c.kind === 'noop') logger.discovery(`${tag} ${c.summary}`);
+    else logger.success(`${tag} ${c.summary}`);
+  }
+  for (const w of warnings) logger.warning(w);
+  if (dryRun) {
+    logger.discovery('Dry run — no files were written.');
+  } else if (!uninstall) {
+    logger.success('OpenLore install complete.');
+  } else {
+    logger.success('OpenLore uninstall complete.');
+  }
+}
+
+export const installCommand = new Command('install')
+  .description('Auto-configure agent surfaces to call orient() (Claude Code, Cursor, Cline, Continue, AGENTS.md).')
+  .option('--agent <name>', 'Install only for a specific surface (claude-code, cursor, cline, continue, agents-md)')
+  .option('--dry-run', 'Print the planned changes without writing any files', false)
+  .option('--force', 'Overwrite OpenLore-managed blocks even if hand-edited', false)
+  .option('--uninstall', 'Remove OpenLore-managed blocks and entries', false)
+  .action(async (opts: InstallOptions) => {
+    const code = await runInstall(opts);
+    if (code !== 0) process.exit(code);
+  });

--- a/src/cli/install/install.test.ts
+++ b/src/cli/install/install.test.ts
@@ -142,6 +142,38 @@ describe('openlore install (end-to-end)', () => {
     expect(after._openlore).toBeUndefined();
   });
 
+  it('cursor install writes .cursor/mcp.json with mcpServers.openlore', async () => {
+    await mkdir(join(dir, '.cursor'), { recursive: true });
+    const code = await runInstall({ cwd: dir, agent: 'cursor' });
+    expect(code).toBe(0);
+    const mcp = JSON.parse(await readFile(join(dir, '.cursor/mcp.json'), 'utf8'));
+    expect(mcp.mcpServers.openlore).toEqual({
+      command: 'npx',
+      args: ['--yes', 'openlore', 'mcp'],
+    });
+    expect(mcp._openlore.managed).toBe(true);
+
+    // Uninstall removes the file when it only had our entries.
+    await runInstall({ cwd: dir, agent: 'cursor', uninstall: true });
+    expect(await exists(join(dir, '.cursor/mcp.json'))).toBe(false);
+  });
+
+  it('cursor install preserves pre-existing non-OpenLore mcpServers', async () => {
+    await mkdir(join(dir, '.cursor'), { recursive: true });
+    const existing = { mcpServers: { other: { command: 'foo' } } };
+    await writeFile(join(dir, '.cursor/mcp.json'), JSON.stringify(existing, null, 2));
+
+    await runInstall({ cwd: dir, agent: 'cursor' });
+    const merged = JSON.parse(await readFile(join(dir, '.cursor/mcp.json'), 'utf8'));
+    expect(merged.mcpServers.other).toEqual({ command: 'foo' });
+    expect(merged.mcpServers.openlore.command).toBe('npx');
+
+    await runInstall({ cwd: dir, agent: 'cursor', uninstall: true });
+    const after = JSON.parse(await readFile(join(dir, '.cursor/mcp.json'), 'utf8'));
+    expect(after.mcpServers.other).toEqual({ command: 'foo' });
+    expect(after.mcpServers.openlore).toBeUndefined();
+  });
+
   it('auto-detects multiple surfaces when no --agent passed', async () => {
     await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
     await mkdir(join(dir, '.cursor'), { recursive: true });

--- a/src/cli/install/install.test.ts
+++ b/src/cli/install/install.test.ts
@@ -112,6 +112,36 @@ describe('openlore install (end-to-end)', () => {
     expect(await exists(join(dir, 'AGENTS.md'))).toBe(false);
   });
 
+  it('preserves user-defined SessionStart hooks alongside ours', async () => {
+    await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
+    await mkdir(join(dir, '.claude'), { recursive: true });
+    const userHook = {
+      matcher: 'shell',
+      hooks: [{ type: 'command', command: 'echo hello' }],
+    };
+    await writeFile(
+      join(dir, '.claude/settings.json'),
+      JSON.stringify({ hooks: { SessionStart: [userHook] } }, null, 2),
+      'utf8'
+    );
+
+    const code = await runInstall({ cwd: dir, agent: 'claude-code' });
+    expect(code).toBe(0);
+    const settings = JSON.parse(await readFile(join(dir, '.claude/settings.json'), 'utf8'));
+    expect(settings.hooks.SessionStart).toHaveLength(2);
+    expect(settings.hooks.SessionStart[0]).toEqual(userHook);
+    expect(settings.hooks.SessionStart[1]._openlore).toBe(true);
+    expect(settings.hooks.SessionStart[1].hooks[0].command).toBe(
+      'npx --yes openlore orient --json'
+    );
+
+    await runInstall({ cwd: dir, agent: 'claude-code', uninstall: true });
+    const after = JSON.parse(await readFile(join(dir, '.claude/settings.json'), 'utf8'));
+    expect(after.hooks.SessionStart).toEqual([userHook]);
+    expect(after.mcpServers).toBeUndefined();
+    expect(after._openlore).toBeUndefined();
+  });
+
   it('auto-detects multiple surfaces when no --agent passed', async () => {
     await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
     await mkdir(join(dir, '.cursor'), { recursive: true });

--- a/src/cli/install/install.test.ts
+++ b/src/cli/install/install.test.ts
@@ -33,6 +33,25 @@ describe('openlore install (end-to-end)', () => {
     expect(await exists(join(dir, '.claude/settings.json'))).toBe(false);
   });
 
+  it('--dry-run emits diff previews to stderr', async () => {
+    await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
+    const captured: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      captured.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'));
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await runInstall({ cwd: dir, agent: 'claude-code', dryRun: true });
+    } finally {
+      process.stderr.write = origWrite;
+    }
+    const combined = captured.join('');
+    // Markdown block preview contains a diff hunk; settings.json preview shows new content.
+    expect(combined).toMatch(/\+ <!-- BEGIN OPENLORE/);
+    expect(combined).toMatch(/\(new file\).+settings\.json/);
+  });
+
   it('agent-md install creates AGENTS.md with managed block', async () => {
     const code = await runInstall({ cwd: dir, agent: 'agents-md' });
     expect(code).toBe(0);

--- a/src/cli/install/install.test.ts
+++ b/src/cli/install/install.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, readFile, mkdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runInstall } from './index.js';
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('openlore install (end-to-end)', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'openlore-install-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('--dry-run writes nothing', async () => {
+    await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
+    const code = await runInstall({ cwd: dir, agent: 'claude-code', dryRun: true });
+    expect(code).toBe(0);
+    const md = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
+    expect(md).toBe('# project\n');
+    expect(await exists(join(dir, '.claude/settings.json'))).toBe(false);
+  });
+
+  it('agent-md install creates AGENTS.md with managed block', async () => {
+    const code = await runInstall({ cwd: dir, agent: 'agents-md' });
+    expect(code).toBe(0);
+    const md = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    expect(md).toContain('BEGIN OPENLORE');
+    expect(md).toContain('orient()');
+  });
+
+  it('claude-code install creates settings.json with SessionStart + mcpServers', async () => {
+    await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
+    const code = await runInstall({ cwd: dir, agent: 'claude-code' });
+    expect(code).toBe(0);
+    const settings = JSON.parse(await readFile(join(dir, '.claude/settings.json'), 'utf8'));
+    expect(settings.mcpServers.openlore).toEqual({
+      command: 'npx',
+      args: ['--yes', 'openlore', 'mcp'],
+    });
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(
+      'npx --yes openlore orient --json'
+    );
+    expect(settings._openlore.managed).toBe(true);
+  });
+
+  it('re-running install is a no-op (no writes, exit 0)', async () => {
+    await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
+    await runInstall({ cwd: dir, agent: 'claude-code' });
+    const mdBefore = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
+    const settingsBefore = await readFile(join(dir, '.claude/settings.json'), 'utf8');
+
+    const code = await runInstall({ cwd: dir, agent: 'claude-code' });
+    expect(code).toBe(0);
+    expect(await readFile(join(dir, 'CLAUDE.md'), 'utf8')).toBe(mdBefore);
+    expect(await readFile(join(dir, '.claude/settings.json'), 'utf8')).toBe(settingsBefore);
+  });
+
+  it('refuses to overwrite hand-edited block without --force', async () => {
+    await runInstall({ cwd: dir, agent: 'agents-md' });
+    const md = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    const tampered = md.replace('orient()', 'OOPS-EDITED');
+    await writeFile(join(dir, 'AGENTS.md'), tampered, 'utf8');
+
+    const code = await runInstall({ cwd: dir, agent: 'agents-md' });
+    expect(code).toBe(1);
+    expect(await readFile(join(dir, 'AGENTS.md'), 'utf8')).toBe(tampered);
+  });
+
+  it('--force overwrites hand-edited block', async () => {
+    await runInstall({ cwd: dir, agent: 'agents-md' });
+    const md = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    const tampered = md.replace('orient()', 'OOPS-EDITED');
+    await writeFile(join(dir, 'AGENTS.md'), tampered, 'utf8');
+
+    const code = await runInstall({ cwd: dir, agent: 'agents-md', force: true });
+    expect(code).toBe(0);
+    const after = await readFile(join(dir, 'AGENTS.md'), 'utf8');
+    expect(after).not.toContain('OOPS-EDITED');
+    expect(after).toContain('orient()');
+  });
+
+  it('--uninstall restores a pre-existing CLAUDE.md byte-for-byte', async () => {
+    const original = '# my project\n\nsome notes\n';
+    await writeFile(join(dir, 'CLAUDE.md'), original);
+    await runInstall({ cwd: dir, agent: 'claude-code' });
+    expect(await readFile(join(dir, 'CLAUDE.md'), 'utf8')).not.toBe(original);
+
+    const code = await runInstall({ cwd: dir, agent: 'claude-code', uninstall: true });
+    expect(code).toBe(0);
+    expect(await readFile(join(dir, 'CLAUDE.md'), 'utf8')).toBe(original);
+    // settings.json was created by us, so it should be removed
+    expect(await exists(join(dir, '.claude/settings.json'))).toBe(false);
+  });
+
+  it('--uninstall removes AGENTS.md when it was OpenLore-only', async () => {
+    await runInstall({ cwd: dir, agent: 'agents-md' });
+    expect(await exists(join(dir, 'AGENTS.md'))).toBe(true);
+    await runInstall({ cwd: dir, agent: 'agents-md', uninstall: true });
+    expect(await exists(join(dir, 'AGENTS.md'))).toBe(false);
+  });
+
+  it('auto-detects multiple surfaces when no --agent passed', async () => {
+    await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
+    await mkdir(join(dir, '.cursor'), { recursive: true });
+    const code = await runInstall({ cwd: dir });
+    expect(code).toBe(0);
+    expect(await exists(join(dir, '.claude/settings.json'))).toBe(true);
+    expect(await exists(join(dir, '.cursor/rules/openlore.mdc'))).toBe(true);
+    expect(await exists(join(dir, 'AGENTS.md'))).toBe(true); // universal fallback
+  });
+});

--- a/src/cli/install/json-managed.test.ts
+++ b/src/cli/install/json-managed.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mergeEntries,
+  readMeta,
+  isHandEdited,
+  removeManaged,
+  canonicalJsonHash,
+} from './json-managed.js';
+
+describe('json-managed', () => {
+  it('creates managed entries with a meta block', () => {
+    const { next, action } = mergeEntries({}, [
+      { path: 'mcpServers.openlore', value: { command: 'npx' } },
+    ]);
+    expect(action).toBe('created');
+    const meta = readMeta(next);
+    expect(meta?.managed).toBe(true);
+    expect(meta?.paths).toEqual(['mcpServers.openlore']);
+    expect(meta?.fingerprint).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('is a no-op when re-applying identical entries', () => {
+    const { next: first } = mergeEntries({}, [
+      { path: 'mcpServers.openlore', value: { a: 1 } },
+    ]);
+    const { action } = mergeEntries(first, [
+      { path: 'mcpServers.openlore', value: { a: 1 } },
+    ]);
+    expect(action).toBe('noop');
+  });
+
+  it('updates when value changes', () => {
+    const { next: first } = mergeEntries({}, [
+      { path: 'mcpServers.openlore', value: { a: 1 } },
+    ]);
+    const { action, next } = mergeEntries(first, [
+      { path: 'mcpServers.openlore', value: { a: 2 } },
+    ]);
+    expect(action).toBe('updated');
+    expect((next.mcpServers as Record<string, { a: number }>).openlore.a).toBe(2);
+  });
+
+  it('detects hand-edits to a managed path', () => {
+    const { next } = mergeEntries({}, [
+      { path: 'mcpServers.openlore', value: { a: 1 } },
+    ]);
+    (next.mcpServers as Record<string, { a: number }>).openlore.a = 999;
+    const meta = readMeta(next)!;
+    expect(isHandEdited(next, meta)).toBe(true);
+  });
+
+  it('preserves unrelated keys after merge', () => {
+    const existing = { otherKey: { keep: true } } as Record<string, unknown>;
+    const { next } = mergeEntries(existing, [
+      { path: 'mcpServers.openlore', value: { a: 1 } },
+    ]);
+    expect((next.otherKey as { keep: boolean }).keep).toBe(true);
+  });
+
+  it('removeManaged strips only managed paths', () => {
+    const existing = { otherKey: { keep: true } } as Record<string, unknown>;
+    const { next: merged } = mergeEntries(existing, [
+      { path: 'mcpServers.openlore', value: { a: 1 } },
+    ]);
+    const { next: stripped, removed } = removeManaged(merged);
+    expect(removed).toBe(true);
+    expect(stripped._openlore).toBeUndefined();
+    expect((stripped.otherKey as { keep: boolean }).keep).toBe(true);
+    expect(stripped.mcpServers).toBeUndefined();
+  });
+
+  it('canonicalJsonHash is stable across key order', () => {
+    expect(canonicalJsonHash({ a: 1, b: 2 })).toBe(canonicalJsonHash({ b: 2, a: 1 }));
+  });
+});

--- a/src/cli/install/json-managed.ts
+++ b/src/cli/install/json-managed.ts
@@ -1,0 +1,173 @@
+/**
+ * Safe merge of an OpenLore-managed entry into a JSON config file.
+ *
+ * We store our additions under a top-level `_openlore` key for bookkeeping
+ * (fingerprint of the merged subtree, version), while writing the actual
+ * config under whatever path the host tool reads (e.g. `mcpServers.openlore`,
+ * `hooks.SessionStart`). The fingerprint lets us detect hand-edits.
+ */
+
+import { createHash } from 'node:crypto';
+
+export interface ManagedJsonMeta {
+  managed: true;
+  version: number;
+  fingerprint: string;
+  /**
+   * Dotted paths into the JSON document that OpenLore manages. Used by
+   * `--uninstall` to remove only what we added.
+   */
+  paths: string[];
+}
+
+const META_KEY = '_openlore';
+const META_VERSION = 1;
+
+export function canonicalJsonHash(value: unknown): string {
+  return createHash('sha256').update(canonicalize(value), 'utf8').digest('hex').slice(0, 16);
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return '[' + value.map(canonicalize).join(',') + ']';
+  const keys = Object.keys(value as Record<string, unknown>).sort();
+  return (
+    '{' +
+    keys
+      .map((k) => JSON.stringify(k) + ':' + canonicalize((value as Record<string, unknown>)[k]))
+      .join(',') +
+    '}'
+  );
+}
+
+export interface ManagedEntry {
+  /** Dotted path into the JSON document (e.g. "mcpServers.openlore"). */
+  path: string;
+  /** Value to write at that path. */
+  value: unknown;
+}
+
+export interface MergeResult {
+  next: Record<string, unknown>;
+  action: 'created' | 'updated' | 'noop';
+  /** If the existing meta fingerprint didn't match what was on disk. */
+  handEdited: boolean;
+}
+
+export function readMeta(doc: Record<string, unknown>): ManagedJsonMeta | null {
+  const meta = doc[META_KEY];
+  if (!meta || typeof meta !== 'object') return null;
+  const m = meta as Record<string, unknown>;
+  if (m.managed !== true || typeof m.fingerprint !== 'string') return null;
+  return {
+    managed: true,
+    version: typeof m.version === 'number' ? m.version : 1,
+    fingerprint: m.fingerprint,
+    paths: Array.isArray(m.paths) ? (m.paths.filter((p) => typeof p === 'string') as string[]) : [],
+  };
+}
+
+/**
+ * Verify the meta fingerprint still matches the values we previously wrote.
+ * If not, the user has hand-edited one of our managed paths.
+ */
+export function isHandEdited(doc: Record<string, unknown>, meta: ManagedJsonMeta): boolean {
+  const subset: Record<string, unknown> = {};
+  for (const path of meta.paths) {
+    const value = getPath(doc, path);
+    if (value !== undefined) setPath(subset, path, value);
+  }
+  return canonicalJsonHash(subset) !== meta.fingerprint;
+}
+
+export function mergeEntries(
+  existing: Record<string, unknown>,
+  entries: ManagedEntry[]
+): MergeResult {
+  const next = structuredClone(existing) as Record<string, unknown>;
+  const prevMeta = readMeta(next);
+  const handEdited = prevMeta ? isHandEdited(next, prevMeta) : false;
+
+  for (const e of entries) setPath(next, e.path, e.value);
+
+  const subset: Record<string, unknown> = {};
+  for (const e of entries) setPath(subset, e.path, e.value);
+
+  const newMeta: ManagedJsonMeta = {
+    managed: true,
+    version: META_VERSION,
+    fingerprint: canonicalJsonHash(subset),
+    paths: entries.map((e) => e.path),
+  };
+  next[META_KEY] = newMeta;
+
+  // Did anything actually change vs `existing`?
+  const before = canonicalize(existing);
+  const after = canonicalize(next);
+  const action: MergeResult['action'] = prevMeta
+    ? before === after
+      ? 'noop'
+      : 'updated'
+    : 'created';
+
+  return { next, action, handEdited };
+}
+
+export function removeManaged(doc: Record<string, unknown>): {
+  next: Record<string, unknown>;
+  removed: boolean;
+} {
+  const meta = readMeta(doc);
+  if (!meta) return { next: doc, removed: false };
+  const next = structuredClone(doc) as Record<string, unknown>;
+  for (const path of meta.paths) deletePath(next, path);
+  delete next[META_KEY];
+  return { next, removed: true };
+}
+
+// ---------- path helpers ----------
+
+function getPath(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.');
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (cur === null || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+function setPath(obj: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split('.');
+  let cur: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const k = parts[i];
+    const next = cur[k];
+    if (next === null || typeof next !== 'object' || Array.isArray(next)) {
+      cur[k] = {};
+    }
+    cur = cur[k] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+function deletePath(obj: Record<string, unknown>, path: string): void {
+  const parts = path.split('.');
+  const chain: Array<{ container: Record<string, unknown>; key: string }> = [];
+  let cur: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const k = parts[i];
+    const next = cur[k];
+    if (next === null || typeof next !== 'object' || Array.isArray(next)) return;
+    chain.push({ container: cur, key: k });
+    cur = next as Record<string, unknown>;
+  }
+  delete cur[parts[parts.length - 1]];
+  // Prune empty parent objects we walked through.
+  for (let i = chain.length - 1; i >= 0; i--) {
+    const { container, key } = chain[i];
+    const child = container[key] as Record<string, unknown>;
+    if (Object.keys(child).length === 0) delete container[key];
+    else break;
+  }
+}

--- a/src/cli/install/templates/agent-instructions.md
+++ b/src/cli/install/templates/agent-instructions.md
@@ -1,0 +1,12 @@
+This project uses OpenLore for persistent architectural memory.
+
+ALWAYS call `orient()` (via the openlore MCP server, or `npx openlore orient --json`)
+before reading source files when starting a new task. This returns the relevant
+functions, callers, spec sections, and insertion points for the task at hand and
+saves you 15,000–50,000 tokens of file-by-file rediscovery.
+
+Re-orient whenever the Epistemic Lease indicates staleness (you'll see a prefix
+on tool responses telling you to do so).
+
+For the MCP setup, ensure `openlore mcp` is configured as an MCP server.
+See https://github.com/clay-good/OpenLore for details.

--- a/src/cli/install/templates/cursor-openlore.mdc
+++ b/src/cli/install/templates/cursor-openlore.mdc
@@ -1,0 +1,7 @@
+---
+description: OpenLore orient() workflow
+alwaysApply: true
+openlore-fingerprint: {{fingerprint}}
+---
+
+{{instructions}}


### PR DESCRIPTION
## Summary

Implements [docs/specs/openlore-spec-01-install-command.md](docs/specs/openlore-spec-01-install-command.md): a new `openlore install` subcommand that wires OpenLore into popular agent surfaces so `orient()` is called automatically — closing the gap where the deterministic graph exists but agents never consult it.

- New `src/cli/install/` module: detection, dispatcher, 5 adapters (`claude-code`, `cursor`, `cline`, `continue`, `agents-md`), shared block/JSON-merge utilities backed by sha256 fingerprints.
- Markdown surfaces get a delimited managed block; JSON configs get a `_openlore` meta key. Both let us detect hand-edits and stay idempotent on re-run.
- Asset-copy step added to `npm run build` so the instruction template ships in `dist/`.

## Behavior

```
openlore install [--agent <name>] [--dry-run] [--force] [--uninstall]
```

- No `--agent`: auto-detect surfaces (walks up to 3 parents), always includes `agents-md` as universal fallback.
- `--dry-run`: prints planned diffs, writes nothing.
- Re-run with same template: no-op, exit 0.
- Hand-edit inside an OpenLore block: refuses to overwrite (exit 1) unless `--force`.
- `--uninstall`: restores files that pre-existed byte-for-byte; deletes files OpenLore created.

## Scope contract

- No new runtime dependencies (Node builtins only).
- No changes to MCP signatures, `orient()` contract, graph schema, analysis pipeline, or OpenSpec integration.
- Additive: nothing changes unless the user runs `openlore install`.

## Known follow-up

- `TODO(openlore-spec-01)` in `src/cli/install/adapters/continue.ts`: Continue's MCP server registration path varies across versions; only the `/orient` slash command is currently wired, and a warning is surfaced to the user (per spec: "do not guess").

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (incl. asset copy)
- [x] `npm run test:run` — 2747 pass / 2 skipped
- [x] 25 new tests in `src/cli/install/*.test.ts` cover all 6 spec acceptance criteria against real temp-dir fixtures (dry-run, claude-code install, idempotent re-run, hand-edit refusal, --force overwrite, --uninstall byte-for-byte restore, multi-surface auto-detect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)