### PR TITLE
spec-03: openlore preflight — CI staleness gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ npm install -g openlore
 cd /path/to/your-project
 
 openlore analyze          # build call graph, clusters, CODEBASE.md
+openlore install          # auto-configure your agent (Claude Code, Cursor, …)
 openlore mcp              # start MCP server
 ```
+
+`openlore install` auto-detects which agent surfaces are present (Claude Code, Cursor, Cline, Continue, AGENTS.md) and wires each one to call `orient()` automatically — no manual `CLAUDE.md` editing needed. See [docs/install.md](docs/install.md).
 
 Then ask your agent: **`orient("add a new payment method")`**
 
@@ -178,6 +181,14 @@ Sends the analysis to an LLM in 6 structured stages: project survey → entity e
 
 Compares git changes against spec mappings in milliseconds. Detects: Gap (code changed, spec not updated), Uncovered (new file, no spec), Stale (spec references deleted files), ADR gap (code changed in an ADR-referenced domain). Installs as a pre-commit hook.
 
+**Install** (no API key)
+
+`openlore install` auto-wires the popular agent surfaces (Claude Code, Cursor, Cline, Continue, AGENTS.md) so they call `orient()` automatically — no `CLAUDE.md` editing required. Each integration uses a fingerprinted managed block so re-runs are idempotent and hand-edits are detected. `--dry-run` previews diffs; `--uninstall` cleanly removes everything. See [docs/install.md](docs/install.md).
+
+**Preflight** (no API key)
+
+`openlore preflight` is a CI staleness gate: any pull request that edits files in the graph fails the check until the graph is refreshed. Drop-in templates for GitHub Actions, GitLab CI, and generic shell live in [`examples/ci/`](examples/ci/). Weighted scoring surfaces hubs first so a one-line leaf edit doesn't fail the same way a refactor of a top-of-stack module does. See [docs/preflight.md](docs/preflight.md).
+
 **MCP** (no API key)
 
 45 graph-native tools exposed over stdio. Together they act as a persistent architectural runtime for coding agents: orientation, graph traversal, semantic retrieval, drift awareness, decision context, and structural risk analysis.
@@ -267,6 +278,7 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 |-------|-----|
 | MCP tools reference (45 tools + parameters) | [docs/mcp-tools.md](docs/mcp-tools.md) |
 | Agent setup (Claude Code, Cline, OpenCode, Vibe…) | [docs/agent-setup.md](docs/agent-setup.md) |
+| `openlore install` — auto-configure agent surfaces | [docs/install.md](docs/install.md) |
 | LLM providers + embedding config | [docs/providers.md](docs/providers.md) |
 | Drift detection in depth | [docs/drift-detection.md](docs/drift-detection.md) |
 | Spec-driven tests + spec digest | [docs/spec-tests.md](docs/spec-tests.md) |

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 | Drift detection in depth | [docs/drift-detection.md](docs/drift-detection.md) |
 | Spec-driven tests + spec digest | [docs/spec-tests.md](docs/spec-tests.md) |
 | CI/CD integration | [docs/ci-cd.md](docs/ci-cd.md) |
+| Preflight CI staleness gate | [docs/preflight.md](docs/preflight.md) |
 | CLI command reference | [docs/cli-reference.md](docs/cli-reference.md) |
 | Interactive graph viewer | [docs/viewer.md](docs/viewer.md) |
 | Analysis output files | [docs/output.md](docs/output.md) |

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -55,11 +55,16 @@ Staleness:     score 11 (threshold 0)
 Status:        STALE — run `openlore analyze` or re-run with --fix
 
 Changed:
-  - src/core/services/llm-service.ts
-  - src/core/services/chat-agent.ts
-  - src/cli/commands/verify.ts
+  - src/core/services/llm-service.ts  (hub, fan-in 38, weight 6)
+  - src/core/services/chat-agent.ts   (hub, fan-in 14, weight 5)
+  - src/cli/commands/verify.ts        (fan-in 3, weight 2)
+  - src/cli/commands/generate.ts      (weight 1)
   ...
 ```
+
+Lines are sorted by weight (DESC) so the files most likely to invalidate `orient()` answers surface first. New/untracked files are shown with `(new/untracked, weight 0)` and never contribute to the score.
+
+When there are no changed files at all (e.g. a docs-only PR after a fresh analyze), the Status line reads `FRESH — nothing to check` so it's obvious the gate passed because there was nothing to verify, not because everything was verified clean.
 
 ## How the staleness score is computed
 
@@ -101,24 +106,33 @@ When the process detects `GITHUB_ACTIONS=true`, preflight additionally emits per
 
 ## JSON schema (`--json`)
 
-```json
+```jsonc
 {
+  // Required by the spec
   "status": "FRESH" | "STALE" | "ERROR",
   "graph_built_at": "2026-04-12T10:11:08.000Z" | null,
-  "graph_commit": null,
+  "graph_commit": null,                              // TODO(spec-03-followup)
   "working_commit": "7d8e1b4" | null,
-  "changed_files": ["src/foo.ts", ...],
-  "unknown_files": ["new-file.ts", ...],
-  "hub_count": 3,
-  "leaf_count": 4,
+  "changed_files": ["src/foo.ts", "..."],
   "staleness_score": 11,
   "threshold": 0,
-  "mechanism": "git" | "mtime",
-  "warnings": []
+
+  // Additive extras (always emitted)
+  "unknown_files": ["new-file.ts", "..."],           // weight-0 files (new/untracked, docs, etc.)
+  "per_file": [                                      // sorted by weight DESC in human output;
+    { "file": "src/foo.ts",                          // emitted in changed_files order here
+      "weight": 6, "hub": true, "max_fan_in": 38, "unknown": false }
+  ],
+  "hub_count": 3,
+  "leaf_count": 4,
+  "mechanism": "git" | "mtime",                      // how the changed-files list was produced
+  "warnings": []                                     // e.g. "no .git found — falling back to mtime"
 }
 ```
 
 `graph_commit` is currently always `null` — see `TODO(spec-03-followup)` in [`src/cli/preflight/index.ts`](../src/cli/preflight/index.ts). Once `openlore analyze` records the git HEAD at build time, this field becomes populated.
+
+`per_file` lets CI scripts make per-file decisions without re-querying the graph (e.g. "only fail if a hub changed" → `jq '.per_file[] | select(.hub)'`).
 
 ## Edge cases
 

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -1,0 +1,130 @@
+# `openlore preflight`
+
+A non-zero-exit staleness gate for CI: have files relevant to this PR been edited in ways that would invalidate `orient()` answers? Run it on every pull request to catch out-of-date analysis graphs at the cheap boundary, instead of letting them silently degrade agent runtime.
+
+## What it checks
+
+OpenLore persists a SQLite call graph (`.openlore/analysis/call-graph.db`) plus a `fingerprint.json` recording when the graph was built. `preflight` compares the working tree against that snapshot and reports a structural staleness score.
+
+| Check | Done by |
+|---|---|
+| Have source files changed since the graph was built? | `git diff` (preferred) or file mtime fallback |
+| Are the changed files structurally important (hubs vs leaves)? | Lookup in `nodes` table |
+| Is the cumulative score over the threshold? | Configurable via `--max-staleness` |
+
+## What it does NOT check
+
+`preflight` is **structural staleness only**. It does not check:
+
+- **Spec drift** — when code outpaces the documentation in `openspec/`. That's the existing [`openlore drift`](../README.md) command's job. Run that separately.
+- **Embedding/vector freshness** — the semantic search index is rebuilt by `openlore analyze --embed`, not addressed here.
+- **Decision-log staleness** — pending decisions live in their own gate (see CLAUDE.md). `preflight` doesn't read them.
+
+If you want a "block PR until everything is current" gate, chain `openlore preflight` and `openlore drift` in CI.
+
+## Usage
+
+```
+openlore preflight [--fix] [--json] [--since <ref>] [--max-staleness <n>]
+```
+
+| Flag | Meaning |
+|---|---|
+| `--since <ref>` | Diff against this git ref (e.g. `origin/main`). CI-friendly: scopes to "what this PR changed." |
+| `--max-staleness <n>` | Threshold above which the gate fails. Default `0` (any structural change to an in-graph file fails); `5` is a sensible "permissive" setting. |
+| `--fix` | If stale, run `openlore analyze` then re-check. Exits 0 if the fix succeeds. |
+| `--json` | Machine-readable output; see schema below. |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Fresh — graph is current relative to the working tree. |
+| `1` | Stale — staleness score exceeds threshold. |
+| `2` | Error — no graph found, invalid `--since` ref, file-system failure, etc. |
+
+## Sample output
+
+```
+OpenLore preflight
+──────────────────
+Graph built:   2026-04-12T10:11:08.000Z   commit 3a91f02
+Working tree:  2026-04-12T15:24:31.000Z   commit 7d8e1b4
+Changed files: 7 (3 hub, 4 leaf)
+Staleness:     score 11 (threshold 0)
+Status:        STALE — run `openlore analyze` or re-run with --fix
+
+Changed:
+  - src/core/services/llm-service.ts
+  - src/core/services/chat-agent.ts
+  - src/cli/commands/verify.ts
+  ...
+```
+
+## How the staleness score is computed
+
+```
+per-file weight =
+  1                                base
+  + 2 if any node in the file is a hub (high fan-in node)
+  + min(3, ceil(maxFanIn/5))       contribution scaled by how many
+                                    other functions depend on this file
+
+staleness_score = sum(per-file weight) across changed files that map
+                  to nodes in the graph
+```
+
+- Files that **don't** appear in the graph (new/untracked files, build artifacts, docs) are **reported** but **do not** contribute to the score. We can't reason about them without re-analyzing.
+- A hub change (something called from many places) is worth up to **6** weight units. A leaf change is worth **1**. A change to nothing-in-graph is **0**.
+- The scoring is deliberately a heuristic — see [`src/cli/preflight/score.ts`](../src/cli/preflight/score.ts).
+
+### Interpreting the score
+
+| Score | Typical situation |
+|---|---|
+| `0` | Working tree changed only docs / build artifacts / new files. Re-analyzing would not change orient() answers. |
+| `1–4` | One or two leaf-level changes. Often safe to defer the re-analyze. |
+| `5–10` | Substantial leaf-level activity OR one hub touched. Re-analyze recommended. |
+| `>10` | Multiple hubs touched or many connected files changed. Re-analyze required for orient() to remain trustworthy. |
+
+## Wiring into CI
+
+Drop-in templates live in [`examples/ci/`](../examples/ci/):
+
+- [`openlore-preflight.yml`](../examples/ci/openlore-preflight.yml) — GitHub Actions
+- [`openlore-preflight.gitlab.yml`](../examples/ci/openlore-preflight.gitlab.yml) — GitLab CI
+- [`openlore-preflight.sh`](../examples/ci/openlore-preflight.sh) — generic shell snippet for any other system
+
+All three run `openlore preflight --since <base-ref>` and exit non-zero on stale.
+
+## JSON schema (`--json`)
+
+```json
+{
+  "status": "FRESH" | "STALE" | "ERROR",
+  "graph_built_at": "2026-04-12T10:11:08.000Z" | null,
+  "graph_commit": null,
+  "working_commit": "7d8e1b4" | null,
+  "changed_files": ["src/foo.ts", ...],
+  "unknown_files": ["new-file.ts", ...],
+  "hub_count": 3,
+  "leaf_count": 4,
+  "staleness_score": 11,
+  "threshold": 0,
+  "mechanism": "git" | "mtime",
+  "warnings": []
+}
+```
+
+`graph_commit` is currently always `null` — see `TODO(spec-03-followup)` in [`src/cli/preflight/index.ts`](../src/cli/preflight/index.ts). Once `openlore analyze` records the git HEAD at build time, this field becomes populated.
+
+## Edge cases
+
+- **No `.git` directory:** falls back to mtime-based comparison; a warning appears in `warnings[]`.
+- **Graph built against a commit no longer in the repo** (force-push / rebase): mtime fallback engages automatically.
+- **`--since` ref does not exist:** exits 2 with a clear message.
+- **Repo with no source files changed:** exits 0 with `nothing to check`.
+
+## Performance
+
+Designed to run in **under 5 seconds** on a warm SQLite for a repo of ~10k functions. The default path does not re-analyze; it only diffs and scores. `--fix` is the only path that re-runs the (currently full, not incremental) analyzer — see `TODO(spec-03-followup): incremental analyzer`.

--- a/docs/preflight.md
+++ b/docs/preflight.md
@@ -97,6 +97,8 @@ Drop-in templates live in [`examples/ci/`](../examples/ci/):
 
 All three run `openlore preflight --since <base-ref>` and exit non-zero on stale.
 
+When the process detects `GITHUB_ACTIONS=true`, preflight additionally emits per-file [workflow-command annotations](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) — each stale file appears inline in the PR diff UI as a warning, and a top-level error annotation summarises the staleness score. No extra setup required; the GHA template above already runs in that environment.
+
 ## JSON schema (`--json`)
 
 ```json

--- a/docs/specs/openlore-spec-03-preflight-ci.md
+++ b/docs/specs/openlore-spec-03-preflight-ci.md
@@ -1,0 +1,133 @@
+# OpenLore Spec 03 — `openlore preflight` CI Staleness Check
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+
+---
+
+## Context for you (the agent)
+
+OpenLore persists an architectural graph (call graph + clusters + complexity + specs + decisions) to a SQLite store. The graph is built by `openlore analyze` and consumed by `openlore orient` / the MCP server. If the graph is **stale** relative to the source — i.e., source files have changed since the graph was last built — then `orient()` returns out-of-date information and the deterministic guarantees of OpenLore quietly degrade.
+
+Today, freshness is the user's responsibility. They are expected to re-run `openlore analyze` after meaningful changes. In practice, many teams forget. The Epistemic Lease subsystem catches this at *agent runtime* via a freshness signal, but it does not catch it at *PR time*, which is the cheap place to enforce.
+
+**This PR adds a `preflight` mode** that any CI system can run as a non-zero-exit check on every PR: it determines whether the graph is current relative to the working tree, and optionally rebuilds the delta and commits the result. This is the staleness gate at the boundary where it is cheapest.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Change the graph schema, the analyzer, or `orient()` output.
+- Add new runtime dependencies (the analyzer is already in-process; we just need to call it differently).
+- Require an API key for the staleness check itself (spec layer with LLM generation is out of scope for preflight; only structural staleness matters here).
+- Add telemetry, network calls, or anything that phones home.
+- Couple to a specific CI system. The command must work on GitHub Actions, GitLab CI, CircleCI, Buildkite, local dev, anywhere.
+
+This PR must:
+
+- Be exit-code-clean (0 = fresh, 1 = stale, 2 = error).
+- Be fast (< 5s on a warm SQLite for a repo of ~10k functions; we are only diffing, not re-analyzing in the default path).
+- Print a human-readable summary by default and a `--json` mode for machine consumption.
+
+## The deliverable
+
+Add a new CLI subcommand: `openlore preflight`.
+
+```
+openlore preflight [--fix] [--json] [--since <git-ref>] [--max-staleness <int>]
+```
+
+Behavior:
+
+- Loads the existing graph (refuse with exit 2 and a clear message if none exists; suggest `openlore analyze`).
+- Determines the set of source files that have changed since the graph was built. The "graph build commit" is stored as graph metadata; if missing, fall back to the graph's `built_at` timestamp vs. file mtimes.
+- With `--since <git-ref>` (e.g. `--since origin/main`), use git diff against that ref instead of graph metadata. This is the CI-friendly mode: "have files relevant to this PR changed in ways that would invalidate orient() answers?"
+- Computes a *staleness score*: number of changed files × weight, weighted by how connected they are in the graph (a change to a hub function invalidates more than a change to a leaf). Pick a simple weighting; document it.
+- With `--max-staleness <n>` (default `0` for hard, `5` permissive), exits 1 if score > n.
+- Prints, by default:
+  ```
+  OpenLore preflight
+  ──────────────────
+  Graph built:   <iso8601>   commit <short-hash>
+  Working tree:  <iso8601>   commit <short-hash>
+  Changed files: 7 (3 hub, 4 leaf)
+  Staleness:     score 11 (threshold 0)
+  Status:        STALE — run `openlore analyze --incremental` or re-run with --fix
+  ```
+- With `--fix`, runs `openlore analyze --incremental` (if it exists) or `openlore analyze` (full re-run) and re-checks. Exits 0 if the fix succeeds.
+- With `--json`, prints a JSON object with `{ status, graph_built_at, graph_commit, working_commit, changed_files: [...], staleness_score, threshold }` and skips the human-readable output.
+
+### CI template
+
+Ship a copy-pasteable GitHub Actions workflow at `examples/ci/openlore-preflight.yml`:
+
+```yaml
+name: OpenLore preflight
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with: { node-version: '22' }
+      - run: npx --yes openlore preflight --since origin/${{ github.base_ref }}
+```
+
+Also ship a GitLab CI snippet and a generic shell snippet in the same `examples/ci/` directory. Keep them short.
+
+### Edge cases to handle
+
+- No `.git` directory: fall back to mtime-based comparison; print a note in the human output.
+- Graph built against a commit that is no longer in the repo (force-push, rebase): fall back to file mtimes; print a warning.
+- `--since` ref does not exist: exit 2 with a clear message.
+- Repo with no source files matching the graph's language config: exit 0 with "nothing to check."
+
+### Documentation
+
+Add `docs/preflight.md` (~one page) covering: what it checks, what it does NOT check (spec drift is the existing drift detector's job — link to it), how to wire it into CI, how to interpret the staleness score.
+
+## Files you will create or modify (approximate)
+
+```
+src/cli/preflight/
+  index.ts           # subcommand entry
+  diff.ts            # changed-files computation (git + mtime fallback)
+  score.ts           # staleness scoring
+  report.ts          # human + JSON renderers
+src/cli/index.ts     # register subcommand
+examples/ci/
+  openlore-preflight.yml
+  openlore-preflight.gitlab.yml
+  openlore-preflight.sh
+docs/preflight.md
+test/cli/preflight/*.test.ts
+test/cli/preflight/fixtures/  # tiny repo fixtures
+```
+
+## Acceptance criteria
+
+1. In a freshly-analyzed clean repo, `openlore preflight` exits 0 with status `FRESH`.
+2. After editing one source file (no re-analyze), `openlore preflight` exits 1 with status `STALE` and lists the file.
+3. After running `openlore preflight --fix`, the graph is updated and a follow-up `openlore preflight` exits 0.
+4. `openlore preflight --json` produces parseable JSON with the documented schema; the shape is tested.
+5. `--since origin/main` works in a repo where `origin/main` is the merge base.
+6. The GitHub Actions example is syntactically valid YAML (test by parsing it in a unit test).
+7. `npm run lint`, `npm run typecheck`, `npm run test:run`, `npm run build` all pass.
+8. No new runtime dependencies.
+
+## Git workflow — read carefully
+
+1. Branch: `openlore-spec-03-preflight-ci` off the default branch.
+2. Implement only `preflight`. Do NOT extend `analyze` itself in this PR even if you discover the incremental path is missing. If `--fix` cannot incrementally analyze, run the full analyzer; leave a `TODO(spec-03-followup): incremental analyzer`.
+3. **Open exactly one PR** titled `spec-03: openlore preflight — CI staleness gate`. Body must include the human-readable output sample.
+4. All follow-up commits for this spec push to that same PR. Never open a second PR for spec-03. If you have to re-think the design, push more commits.
+5. Run `lint`, `typecheck`, `test:run`, `build` before every push.
+
+## When you are done
+
+Reply with: PR URL, summary, follow-ups, files changed. Nothing else.

--- a/examples/ci/openlore-preflight.gitlab.yml
+++ b/examples/ci/openlore-preflight.gitlab.yml
@@ -1,0 +1,16 @@
+# OpenLore preflight — GitLab CI
+# Include this in .gitlab-ci.yml as a stand-alone job. Fails the merge request
+# if the persisted OpenLore graph is stale relative to the files this MR
+# changed. GitLab provides CI_MERGE_REQUEST_TARGET_BRANCH_NAME for merge
+# request pipelines; we resolve it to a full ref before running preflight.
+
+openlore-preflight:
+  stage: test
+  image: node:22
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  variables:
+    GIT_DEPTH: 0
+  script:
+    - git fetch origin "$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"
+    - npx --yes openlore preflight --since "origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"

--- a/examples/ci/openlore-preflight.sh
+++ b/examples/ci/openlore-preflight.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# OpenLore preflight — generic shell snippet usable from any CI system
+# (CircleCI, Buildkite, Jenkins, your laptop). Set BASE_REF to whatever
+# branch this change should be compared against.
+#
+# Exit codes: 0 = fresh, 1 = stale, 2 = error.
+
+set -eu
+
+BASE_REF="${BASE_REF:-origin/main}"
+
+# Make sure the ref actually exists locally — shallow clones / CI runners
+# often need an explicit fetch.
+git fetch --no-tags --depth=0 origin "$(basename "$BASE_REF")" >/dev/null 2>&1 || true
+
+exec npx --yes openlore preflight --since "$BASE_REF" "$@"

--- a/examples/ci/openlore-preflight.yml
+++ b/examples/ci/openlore-preflight.yml
@@ -1,0 +1,30 @@
+# OpenLore preflight — GitHub Actions
+# Fails the PR if the persisted OpenLore graph is stale relative to the
+# files this PR changed. Drop this in as `.github/workflows/openlore-preflight.yml`.
+#
+# Exit codes: 0 = fresh, 1 = stale (PR fails), 2 = error.
+
+name: OpenLore preflight
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: openlore preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so `git diff origin/<base>...HEAD` can see the merge base.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run openlore preflight
+        run: npx --yes openlore preflight --since origin/${{ github.base_ref }}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,7 @@ import { digestCommand } from './commands/digest.js';
 import { decisionsCommand } from './commands/decisions.js';
 import { telemetryCommand } from './commands/telemetry.js';
 import { installCommand } from './install/index.js';
+import { preflightCommand } from './preflight/index.js';
 import { configureLogger } from '../utils/logger.js';
 
 // Read version from package.json at runtime so it never drifts from the published version
@@ -138,5 +139,6 @@ program.addCommand(digestCommand);
 program.addCommand(decisionsCommand);
 program.addCommand(telemetryCommand);
 program.addCommand(installCommand);
+program.addCommand(preflightCommand);
 
 program.parse();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -92,6 +92,7 @@ Workflow:
   9. openlore drift                   Detect when code outpaces specs
   10. openlore test                    Generate spec-driven tests or check coverage
   11. openlore digest                  Plain-English summary of specs for human review
+  12. openlore preflight               CI staleness gate: fail PRs when the graph is out of date
 
 Quick start:
   $ cd your-project

--- a/src/cli/preflight/diff.ts
+++ b/src/cli/preflight/diff.ts
@@ -1,0 +1,194 @@
+/**
+ * Compute the set of source files that have changed since the graph was built.
+ *
+ * Two paths:
+ *
+ *  1. `--since <git-ref>` (CI-friendly) — `git diff --name-only <ref>...HEAD`
+ *     plus uncommitted modifications. The merge-base form is intentional:
+ *     it captures every file the PR touched, not just the latest commit.
+ *
+ *  2. No `--since` flag — fall back to comparing file mtimes against
+ *     `fingerprint.json.computedAt`. Slower but works without git history.
+ *
+ * Either path returns paths relative to the repo root. Non-source files
+ * (anything not tracked by the analyzer's language config) are filtered out
+ * by the caller via the node table.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { stat, readdir, readFile, access } from 'node:fs/promises';
+import { join, relative, resolve, sep } from 'node:path';
+import { OPENLORE_DIR } from '../../constants.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface DiffResult {
+  /** Repo-relative paths of files that may have changed since graph build. */
+  changed: string[];
+  /** Which mechanism produced the list. */
+  mechanism: 'git' | 'mtime';
+  /** Any non-fatal warnings (e.g. "no .git found, used mtime"). */
+  warnings: string[];
+  /** The short commit hash of HEAD at the moment of the check, if available. */
+  workingCommit: string | null;
+}
+
+export interface DiffOptions {
+  repoRoot: string;
+  /** Iso8601 timestamp the graph was built — used by mtime fallback. */
+  graphBuiltAt: string | null;
+  /** Optional git ref to diff against (e.g. "origin/main"). */
+  since?: string;
+}
+
+export async function hasGitDirectory(repoRoot: string): Promise<boolean> {
+  try {
+    await access(join(repoRoot, '.git'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function runGit(repoRoot: string, args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd: repoRoot });
+  return stdout;
+}
+
+export async function refExists(repoRoot: string, ref: string): Promise<boolean> {
+  try {
+    await runGit(repoRoot, ['rev-parse', '--verify', '--quiet', ref]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function shortHead(repoRoot: string): Promise<string | null> {
+  try {
+    return (await runGit(repoRoot, ['rev-parse', '--short', 'HEAD'])).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Changed files via git diff against `since`, plus uncommitted modifications. */
+async function diffViaGit(repoRoot: string, since: string): Promise<string[]> {
+  // Use ...HEAD (merge-base) so we capture every file the PR touched relative
+  // to the branch point, not just the latest commit's diff.
+  const tracked = (await runGit(repoRoot, ['diff', '--name-only', `${since}...HEAD`]))
+    .split('\n')
+    .filter(Boolean);
+  // Include uncommitted modifications so a developer running locally before
+  // committing also gets honest feedback.
+  const uncommitted = (await runGit(repoRoot, ['diff', '--name-only', 'HEAD']))
+    .split('\n')
+    .filter(Boolean);
+  const set = new Set([...tracked, ...uncommitted]);
+  return Array.from(set).sort();
+}
+
+/** Changed files via mtime comparison against graphBuiltAtMs. */
+async function diffViaMtime(repoRoot: string, graphBuiltAtMs: number): Promise<string[]> {
+  const out: string[] = [];
+  await walk(repoRoot, repoRoot, graphBuiltAtMs, out);
+  return out.sort();
+}
+
+const SKIP_DIRECTORIES = new Set([
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  OPENLORE_DIR,
+  '.git',
+]);
+
+async function walk(repoRoot: string, dir: string, cutoffMs: number, out: string[]): Promise<void> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of entries) {
+    if (ent.name.startsWith('.') && ent.name !== '.gitignore') continue;
+    if (SKIP_DIRECTORIES.has(ent.name)) continue;
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      await walk(repoRoot, full, cutoffMs, out);
+      continue;
+    }
+    if (!ent.isFile()) continue;
+    try {
+      const s = await stat(full);
+      if (s.mtimeMs > cutoffMs) {
+        out.push(relative(repoRoot, full).split(sep).join('/'));
+      }
+    } catch {
+      /* unreadable file — skip */
+    }
+  }
+}
+
+export async function computeDiff(opts: DiffOptions): Promise<DiffResult> {
+  const root = resolve(opts.repoRoot);
+  const warnings: string[] = [];
+  const workingCommit = await shortHead(root);
+  const gitAvailable = await hasGitDirectory(root);
+
+  if (opts.since) {
+    if (!gitAvailable) {
+      throw Object.assign(new Error(`--since requires a git repository`), { exitCode: 2 });
+    }
+    if (!(await refExists(root, opts.since))) {
+      throw Object.assign(
+        new Error(`git ref not found: ${opts.since}`),
+        { exitCode: 2 }
+      );
+    }
+    const changed = await diffViaGit(root, opts.since);
+    return { changed, mechanism: 'git', warnings, workingCommit };
+  }
+
+  if (!gitAvailable) {
+    warnings.push('no .git found — falling back to mtime comparison');
+  }
+
+  if (!opts.graphBuiltAt) {
+    warnings.push('graph has no build timestamp — everything will look stale');
+    // Treat as "everything changed since epoch" — caller can decide.
+    const changed = await diffViaMtime(root, 0);
+    return { changed, mechanism: 'mtime', warnings, workingCommit };
+  }
+
+  const cutoff = Date.parse(opts.graphBuiltAt);
+  if (Number.isNaN(cutoff)) {
+    warnings.push(`graph build timestamp unparseable: ${opts.graphBuiltAt}`);
+    const changed = await diffViaMtime(root, 0);
+    return { changed, mechanism: 'mtime', warnings, workingCommit };
+  }
+
+  const changed = await diffViaMtime(root, cutoff);
+  return { changed, mechanism: 'mtime', warnings, workingCommit };
+}
+
+/** Read `fingerprint.json` if present. */
+export async function readGraphFingerprint(repoRoot: string): Promise<{
+  computedAt: string | null;
+  fileCount: number | null;
+} | null> {
+  const path = join(repoRoot, OPENLORE_DIR, 'analysis', 'fingerprint.json');
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as { computedAt?: string; fileCount?: number };
+    return {
+      computedAt: parsed.computedAt ?? null,
+      fileCount: typeof parsed.fileCount === 'number' ? parsed.fileCount : null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/preflight/index.ts
+++ b/src/cli/preflight/index.ts
@@ -1,0 +1,158 @@
+/**
+ * `openlore preflight` — CI staleness gate.
+ *
+ * Determines whether the persisted analysis graph is current relative to
+ * the working tree. Designed to run on every PR so out-of-date graphs
+ * never reach orient() / agent runtime silently.
+ *
+ * Exit codes: 0 = fresh, 1 = stale, 2 = error.
+ */
+
+import { access } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+import { Command } from 'commander';
+import { logger } from '../../utils/logger.js';
+import {
+  OPENLORE_DIR,
+  OPENLORE_ANALYSIS_SUBDIR,
+  ARTIFACT_CALL_GRAPH_DB,
+} from '../../constants.js';
+import { computeDiff, readGraphFingerprint } from './diff.js';
+import { scoreChangedFiles } from './score.js';
+import { buildSummary, renderHuman, renderJson, type PreflightSummary } from './report.js';
+
+export interface PreflightOptions {
+  cwd?: string;
+  fix?: boolean;
+  json?: boolean;
+  since?: string;
+  maxStaleness?: number;
+}
+
+const DEFAULT_THRESHOLD = 0;
+
+export async function runPreflight(opts: PreflightOptions): Promise<{
+  code: number;
+  summary?: PreflightSummary;
+}> {
+  const cwd = resolve(opts.cwd ?? process.cwd());
+  const threshold = typeof opts.maxStaleness === 'number' ? opts.maxStaleness : DEFAULT_THRESHOLD;
+
+  // 1. Graph must exist.
+  const dbPath = join(cwd, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_CALL_GRAPH_DB);
+  try {
+    await access(dbPath);
+  } catch {
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            status: 'ERROR',
+            error: 'no graph found',
+            hint: 'run `openlore analyze` first',
+          },
+          null,
+          2
+        ) + '\n'
+      );
+    } else {
+      logger.error(
+        'No graph found. Run `openlore analyze` first to build the analysis graph.'
+      );
+    }
+    return { code: 2 };
+  }
+
+  // 2. Read graph metadata.
+  const fp = await readGraphFingerprint(cwd);
+  const graphBuiltAt = fp?.computedAt ?? null;
+  // We don't store the build commit today — leave null. Once analyze records
+  // it, this is the single place to surface it. (See TODO in docs/preflight.md.)
+  const graphCommit: string | null = null;
+
+  // 3. Compute changed files.
+  let diff;
+  try {
+    diff = await computeDiff({ repoRoot: cwd, graphBuiltAt, since: opts.since });
+  } catch (err) {
+    const e = err as Error & { exitCode?: number };
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify({ status: 'ERROR', error: e.message }, null, 2) + '\n'
+      );
+    } else {
+      logger.error(e.message);
+    }
+    return { code: e.exitCode ?? 2 };
+  }
+
+  // 4. Score.
+  const score = scoreChangedFiles(cwd, diff.changed);
+
+  // 5. Build summary.
+  const summary = buildSummary({ diff, score, graphBuiltAt, graphCommit, threshold });
+  const stale = summary.stalenessScore > threshold;
+
+  // 6. --fix path runs `openlore analyze` then re-checks.
+  if (stale && opts.fix) {
+    if (!opts.json) logger.discovery('Stale graph detected — running `openlore analyze --fix`');
+    const code = await runAnalyzeFix(cwd);
+    if (code !== 0) {
+      if (opts.json) {
+        process.stdout.write(
+          JSON.stringify({ status: 'ERROR', error: 'openlore analyze --fix failed' }, null, 2) +
+            '\n'
+        );
+      } else {
+        logger.error('openlore analyze failed during --fix; manual intervention required');
+      }
+      return { code: 2 };
+    }
+    // Re-run preflight WITHOUT --fix and WITHOUT --since (now everything
+    // should be current vs. the freshly built graph).
+    return runPreflight({
+      cwd,
+      json: opts.json,
+      maxStaleness: opts.maxStaleness,
+    });
+  }
+
+  // 7. Render.
+  if (opts.json) {
+    process.stdout.write(renderJson(summary) + '\n');
+  } else {
+    process.stdout.write(renderHuman(summary) + '\n');
+  }
+
+  return { code: stale ? 1 : 0, summary };
+}
+
+async function runAnalyzeFix(cwd: string): Promise<number> {
+  return new Promise((resolveProm) => {
+    // TODO(spec-03-followup): when `openlore analyze --incremental` exists,
+    // prefer that — it should be a fraction of the cost of the full re-run.
+    const child = spawn(process.execPath, [process.argv[1], 'analyze'], {
+      cwd,
+      stdio: 'inherit',
+    });
+    child.on('exit', (code) => resolveProm(code ?? 1));
+    child.on('error', () => resolveProm(1));
+  });
+}
+
+export const preflightCommand = new Command('preflight')
+  .description('CI staleness gate: check whether the analysis graph is current relative to the working tree.')
+  .option('--fix', 'Run `openlore analyze` if the graph is stale, then re-check', false)
+  .option('--json', 'Emit JSON instead of human-readable output', false)
+  .option('--since <ref>', 'Diff against this git ref (e.g. origin/main) instead of mtimes')
+  .option(
+    '--max-staleness <n>',
+    `Maximum allowed staleness score (default ${DEFAULT_THRESHOLD})`,
+    (v) => parseInt(v, 10),
+    DEFAULT_THRESHOLD
+  )
+  .action(async (opts: PreflightOptions) => {
+    const { code } = await runPreflight(opts);
+    process.exit(code);
+  });

--- a/src/cli/preflight/index.ts
+++ b/src/cli/preflight/index.ts
@@ -20,7 +20,13 @@ import {
 } from '../../constants.js';
 import { computeDiff, readGraphFingerprint } from './diff.js';
 import { scoreChangedFiles } from './score.js';
-import { buildSummary, renderHuman, renderJson, type PreflightSummary } from './report.js';
+import {
+  buildSummary,
+  renderHuman,
+  renderJson,
+  renderGithubAnnotations,
+  type PreflightSummary,
+} from './report.js';
 
 export interface PreflightOptions {
   cwd?: string;
@@ -124,6 +130,10 @@ export async function runPreflight(opts: PreflightOptions): Promise<{
   } else {
     process.stdout.write(renderHuman(summary) + '\n');
   }
+
+  // 8. GitHub Actions inline annotations (no-op outside GHA).
+  const annotations = renderGithubAnnotations(summary);
+  if (annotations) process.stdout.write(annotations + '\n');
 
   return { code: stale ? 1 : 0, summary };
 }

--- a/src/cli/preflight/index.ts
+++ b/src/cli/preflight/index.ts
@@ -34,6 +34,13 @@ export interface PreflightOptions {
   json?: boolean;
   since?: string;
   maxStaleness?: number;
+  /**
+   * Test-only seam: replace the analyzer invocation used by --fix. Returns
+   * the exit code (0 = success). Production code spawns `openlore analyze`;
+   * tests pass a stub that simulates the side-effect (refreshing
+   * fingerprint.json) without needing the full pipeline.
+   */
+  analyzeFn?: (cwd: string) => Promise<number>;
 }
 
 const DEFAULT_THRESHOLD = 0;
@@ -103,7 +110,7 @@ export async function runPreflight(opts: PreflightOptions): Promise<{
   // 6. --fix path runs `openlore analyze` then re-checks.
   if (stale && opts.fix) {
     if (!opts.json) logger.discovery('Stale graph detected — running `openlore analyze --fix`');
-    const code = await runAnalyzeFix(cwd);
+    const code = await (opts.analyzeFn ?? runAnalyzeFix)(cwd);
     if (code !== 0) {
       if (opts.json) {
         process.stdout.write(
@@ -121,6 +128,7 @@ export async function runPreflight(opts: PreflightOptions): Promise<{
       cwd,
       json: opts.json,
       maxStaleness: opts.maxStaleness,
+      analyzeFn: opts.analyzeFn,
     });
   }
 

--- a/src/cli/preflight/preflight.test.ts
+++ b/src/cli/preflight/preflight.test.ts
@@ -1,0 +1,225 @@
+/**
+ * End-to-end tests for `openlore preflight` against a real SQLite graph and
+ * a real git repo fixture. We don't shell out to the CLI binary — we call
+ * runPreflight() directly and assert on its return code + summary.
+ *
+ * Each test builds an isolated temp-dir fixture containing:
+ *   - a minimal .git repo with one commit
+ *   - a tiny call-graph.db with a couple of nodes
+ *   - a fingerprint.json
+ *
+ * That's enough to exercise every code path without depending on the real
+ * analyzer.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm, utimes } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+import { runPreflight } from './index.js';
+import { renderJson, renderHuman } from './report.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+interface FixtureNode {
+  id: string;
+  name: string;
+  file_path: string;
+  fan_in: number;
+  is_hub: 0 | 1;
+}
+
+async function makeGraphDb(dbPath: string, nodes: FixtureNode[]): Promise<void> {
+  await mkdir(dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec(`
+      CREATE TABLE nodes (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        file_path TEXT NOT NULL,
+        is_external INTEGER NOT NULL DEFAULT 0,
+        is_hub INTEGER NOT NULL DEFAULT 0,
+        fan_in INTEGER NOT NULL DEFAULT 0,
+        fan_out INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    const stmt = db.prepare(
+      'INSERT INTO nodes (id, name, file_path, is_external, is_hub, fan_in) VALUES (?,?,?,?,?,?)'
+    );
+    for (const n of nodes) stmt.run(n.id, n.name, n.file_path, 0, n.is_hub, n.fan_in);
+  } finally {
+    db.close();
+  }
+}
+
+async function makeFingerprint(dir: string, isoTs: string): Promise<void> {
+  await writeFile(
+    join(dir, '.openlore', 'analysis', 'fingerprint.json'),
+    JSON.stringify({ hash: 'fake', computedAt: isoTs, fileCount: 1 })
+  );
+}
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: ['ignore', 'ignore', 'pipe'] });
+}
+
+async function makeGitRepo(dir: string): Promise<void> {
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@test.test']);
+  git(dir, ['config', 'user.name', 'test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+}
+
+async function commitAll(dir: string, message: string): Promise<void> {
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', message]);
+}
+
+describe('openlore preflight', () => {
+  let dir: string;
+  const GRAPH_TS = '2025-01-01T00:00:00.000Z';
+  const GRAPH_MS = Date.parse(GRAPH_TS);
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'openlore-preflight-'));
+    await makeGitRepo(dir);
+    // One source file that exists in the graph.
+    await mkdir(join(dir, 'src'), { recursive: true });
+    await writeFile(join(dir, 'src/foo.ts'), 'export const foo = 1;\n');
+    await commitAll(dir, 'initial');
+    await makeGraphDb(join(dir, '.openlore', 'analysis', 'call-graph.db'), [
+      { id: 'src/foo.ts::foo', name: 'foo', file_path: 'src/foo.ts', fan_in: 0, is_hub: 0 },
+    ]);
+    await makeFingerprint(dir, GRAPH_TS);
+    // Set every file's mtime to BEFORE the graph build so "fresh" really is fresh.
+    const before = (GRAPH_MS - 60_000) / 1000;
+    await utimes(join(dir, 'src/foo.ts'), before, before);
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('AC#1: freshly-analyzed clean repo exits 0 with FRESH', async () => {
+    const { code, summary } = await runPreflight({ cwd: dir, json: true });
+    expect(code).toBe(0);
+    expect(summary?.status).toBe('FRESH');
+  });
+
+  it('AC#2: editing a source file produces STALE + lists the file', async () => {
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/foo.ts'), 'export const foo = 2;\n');
+    await utimes(join(dir, 'src/foo.ts'), after, after);
+    const { code, summary } = await runPreflight({ cwd: dir, json: true });
+    expect(code).toBe(1);
+    expect(summary?.status).toBe('STALE');
+    expect(summary?.changedFiles).toContain('src/foo.ts');
+    expect(summary?.stalenessScore).toBeGreaterThan(0);
+  });
+
+  it('AC#4: --json produces the documented schema', async () => {
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/foo.ts'), 'export const foo = 3;\n');
+    await utimes(join(dir, 'src/foo.ts'), after, after);
+    const { summary } = await runPreflight({ cwd: dir, json: true });
+    expect(summary).toBeDefined();
+    const parsed = JSON.parse(renderJson(summary!));
+    // Documented schema keys:
+    expect(parsed).toHaveProperty('status');
+    expect(parsed).toHaveProperty('graph_built_at');
+    expect(parsed).toHaveProperty('graph_commit');
+    expect(parsed).toHaveProperty('working_commit');
+    expect(parsed).toHaveProperty('changed_files');
+    expect(parsed).toHaveProperty('staleness_score');
+    expect(parsed).toHaveProperty('threshold');
+    expect(parsed.status).toBe('STALE');
+    expect(Array.isArray(parsed.changed_files)).toBe(true);
+  });
+
+  it('AC#5: --since <git-ref> uses git diff and works against the merge base', async () => {
+    // Branch off, edit, commit.
+    git(dir, ['checkout', '-q', '-b', 'feature']);
+    await writeFile(join(dir, 'src/foo.ts'), 'export const foo = 99;\n');
+    await commitAll(dir, 'feature change');
+    const { code, summary } = await runPreflight({ cwd: dir, since: 'main', json: true });
+    expect(code).toBe(1);
+    expect(summary?.mechanism).toBe('git');
+    expect(summary?.changedFiles).toContain('src/foo.ts');
+  });
+
+  it('exits 2 when no graph exists', async () => {
+    await rm(join(dir, '.openlore', 'analysis', 'call-graph.db'));
+    const { code } = await runPreflight({ cwd: dir, json: true });
+    expect(code).toBe(2);
+  });
+
+  it('exits 2 when --since ref does not exist', async () => {
+    const { code } = await runPreflight({ cwd: dir, since: 'no-such-ref', json: true });
+    expect(code).toBe(2);
+  });
+
+  it('AC#6: example GitHub Actions workflow is syntactically valid YAML', async () => {
+    const { parse } = await import('yaml');
+    const { readFile: rf } = await import('node:fs/promises');
+    const text = await rf(join(REPO_ROOT, 'examples/ci/openlore-preflight.yml'), 'utf8');
+    const parsed = parse(text);
+    expect(parsed).toBeTruthy();
+    expect(parsed.name).toBe('OpenLore preflight');
+    expect(parsed.on?.pull_request).toBeDefined();
+    expect(parsed.jobs?.preflight?.steps).toBeDefined();
+    // The GitLab example too.
+    const gitlab = await rf(join(REPO_ROOT, 'examples/ci/openlore-preflight.gitlab.yml'), 'utf8');
+    expect(parse(gitlab)).toBeTruthy();
+  });
+
+  it('renderHuman includes the standard banner and the status line', async () => {
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/foo.ts'), 'changed\n');
+    await utimes(join(dir, 'src/foo.ts'), after, after);
+    const { summary } = await runPreflight({ cwd: dir, json: true });
+    const human = renderHuman(summary!);
+    expect(human).toContain('OpenLore preflight');
+    expect(human).toContain('Status:');
+    expect(human).toContain('Staleness:');
+  });
+
+  it('AC#3: --fix updates graph fingerprint and re-check passes', async () => {
+    // Simulate "analyze fixed it" by directly bumping fingerprint.json + mtimes
+    // in a wrapper. We bypass the real analyzer (it requires the full pipeline);
+    // the contract under test is "preflight re-runs after fix and reports FRESH."
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/foo.ts'), 'changed\n');
+    await utimes(join(dir, 'src/foo.ts'), after, after);
+
+    // First confirm we're STALE.
+    let res = await runPreflight({ cwd: dir, json: true });
+    expect(res.code).toBe(1);
+
+    // Bump the fingerprint to "now" — the equivalent of what `analyze` does.
+    const nowIso = new Date().toISOString();
+    await makeFingerprint(dir, nowIso);
+
+    res = await runPreflight({ cwd: dir, json: true });
+    expect(res.code).toBe(0);
+    expect(res.summary?.status).toBe('FRESH');
+  });
+
+  it('hub files contribute more weight than leaf files', async () => {
+    // Replace the DB with one node marked as a hub with high fan-in.
+    await rm(join(dir, '.openlore', 'analysis', 'call-graph.db'));
+    await makeGraphDb(join(dir, '.openlore', 'analysis', 'call-graph.db'), [
+      { id: 'src/foo.ts::foo', name: 'foo', file_path: 'src/foo.ts', fan_in: 20, is_hub: 1 },
+    ]);
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/foo.ts'), 'changed\n');
+    await utimes(join(dir, 'src/foo.ts'), after, after);
+    const { summary } = await runPreflight({ cwd: dir, json: true });
+    // 1 base + 2 hub + min(3, ceil(20/5)=4) = 6
+    expect(summary?.stalenessScore).toBe(6);
+    expect(summary?.hubCount).toBe(1);
+  });
+});

--- a/src/cli/preflight/preflight.test.ts
+++ b/src/cli/preflight/preflight.test.ts
@@ -297,6 +297,66 @@ describe('openlore preflight', () => {
     }
   });
 
+  it('human output shows per-file weight + flags hubs', async () => {
+    // One hub file + one leaf file changed.
+    await rm(join(dir, '.openlore', 'analysis', 'call-graph.db'));
+    await makeGraphDb(join(dir, '.openlore', 'analysis', 'call-graph.db'), [
+      { id: 'src/hub.ts::hub', name: 'hub', file_path: 'src/hub.ts', fan_in: 20, is_hub: 1 },
+      { id: 'src/leaf.ts::leaf', name: 'leaf', file_path: 'src/leaf.ts', fan_in: 0, is_hub: 0 },
+    ]);
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/hub.ts'), 'hub change\n');
+    await writeFile(join(dir, 'src/leaf.ts'), 'leaf change\n');
+    await utimes(join(dir, 'src/hub.ts'), after, after);
+    await utimes(join(dir, 'src/leaf.ts'), after, after);
+
+    const { summary } = await runPreflight({ cwd: dir, json: true });
+    const human = renderHuman(summary!);
+
+    // Hub surfaces first (sorted DESC by weight)
+    const hubIdx = human.indexOf('src/hub.ts');
+    const leafIdx = human.indexOf('src/leaf.ts');
+    expect(hubIdx).toBeGreaterThan(-1);
+    expect(leafIdx).toBeGreaterThan(-1);
+    expect(hubIdx).toBeLessThan(leafIdx);
+
+    // Hub line is annotated with `hub` and a weight > leaf weight
+    expect(human).toMatch(/src\/hub\.ts.*hub.*weight 6/);
+    expect(human).toMatch(/src\/leaf\.ts.*weight 1/);
+  });
+
+  it('falls back to mtime + emits warning when no .git directory exists', async () => {
+    // Remove the .git dir entirely; the fixture should now have no git.
+    await rm(join(dir, '.git'), { recursive: true, force: true });
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/foo.ts'), 'no git\n');
+    await utimes(join(dir, 'src/foo.ts'), after, after);
+
+    const { code, summary } = await runPreflight({ cwd: dir, json: true });
+    expect(code).toBe(1);
+    expect(summary?.mechanism).toBe('mtime');
+    expect(summary?.warnings.some((w) => /no \.git/.test(w))).toBe(true);
+    // Working commit should be null when there's no git.
+    expect(summary?.workingCommit).toBeNull();
+  });
+
+  it('returns "nothing to check" + exit 0 when no source files have changed', async () => {
+    // Default fixture: foo.ts mtime is pre-graph-build, nothing changed since.
+    const { code, summary } = await runPreflight({ cwd: dir, json: true });
+    expect(code).toBe(0);
+    expect(summary?.status).toBe('FRESH');
+    expect(summary?.changedFiles).toEqual([]);
+    expect(summary?.message).toContain('nothing to check');
+  });
+
+  it('Status line distinguishes "nothing to check" from generic FRESH', async () => {
+    // Default fixture has no changed files (everything pre-dates graph build).
+    const { summary } = await runPreflight({ cwd: dir, json: true });
+    const human = renderHuman(summary!);
+    expect(human).toContain('Status:');
+    expect(human).toContain('nothing to check');
+  });
+
   it('hub files contribute more weight than leaf files', async () => {
     // Replace the DB with one node marked as a hub with high fan-in.
     await rm(join(dir, '.openlore', 'analysis', 'call-graph.db'));

--- a/src/cli/preflight/preflight.test.ts
+++ b/src/cli/preflight/preflight.test.ts
@@ -20,7 +20,7 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { DatabaseSync } from 'node:sqlite';
 import { runPreflight } from './index.js';
-import { renderJson, renderHuman } from './report.js';
+import { renderJson, renderHuman, renderGithubAnnotations, buildSummary } from './report.js';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
@@ -206,6 +206,85 @@ describe('openlore preflight', () => {
     res = await runPreflight({ cwd: dir, json: true });
     expect(res.code).toBe(0);
     expect(res.summary?.status).toBe('FRESH');
+  });
+
+  it('--max-staleness raises the threshold and lets a small change through', async () => {
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/foo.ts'), 'changed\n');
+    await utimes(join(dir, 'src/foo.ts'), after, after);
+
+    // Default threshold 0 → STALE
+    let res = await runPreflight({ cwd: dir, json: true });
+    expect(res.code).toBe(1);
+    expect(res.summary?.stalenessScore).toBe(1);
+
+    // Threshold 5 → FRESH (score 1 ≤ 5)
+    res = await runPreflight({ cwd: dir, json: true, maxStaleness: 5 });
+    expect(res.code).toBe(0);
+    expect(res.summary?.status).toBe('FRESH');
+    expect(res.summary?.threshold).toBe(5);
+  });
+
+  it('emits GitHub Actions annotations when GITHUB_ACTIONS=true and stale', () => {
+    // Direct unit test on the renderer — avoids env leakage in runPreflight.
+    const summary = buildSummary({
+      diff: {
+        changed: ['src/foo.ts', 'src/new-file.ts'],
+        mechanism: 'git',
+        warnings: [],
+        workingCommit: 'abc1234',
+      },
+      score: {
+        perFile: [
+          { filePath: 'src/foo.ts', inGraph: true, hub: true, maxFanIn: 20, nodeCount: 1, weight: 6 },
+        ],
+        totalScore: 6,
+        hubCount: 1,
+        leafCount: 0,
+        unknownFiles: ['src/new-file.ts'],
+      },
+      graphBuiltAt: GRAPH_TS,
+      graphCommit: null,
+      threshold: 0,
+    });
+
+    const prev = process.env.GITHUB_ACTIONS;
+    process.env.GITHUB_ACTIONS = 'true';
+    try {
+      const out = renderGithubAnnotations(summary);
+      expect(out).toContain('::warning file=src/foo.ts::');
+      // unknown file should NOT get an annotation (weight 0).
+      expect(out).not.toContain('::warning file=src/new-file.ts::');
+      expect(out).toContain('::error::OpenLore preflight: staleness score 6');
+    } finally {
+      if (prev === undefined) delete process.env.GITHUB_ACTIONS;
+      else process.env.GITHUB_ACTIONS = prev;
+    }
+  });
+
+  it('does NOT emit GHA annotations outside GitHub Actions', () => {
+    const summary = buildSummary({
+      diff: { changed: ['src/foo.ts'], mechanism: 'git', warnings: [], workingCommit: null },
+      score: {
+        perFile: [
+          { filePath: 'src/foo.ts', inGraph: true, hub: false, maxFanIn: 0, nodeCount: 1, weight: 1 },
+        ],
+        totalScore: 1,
+        hubCount: 0,
+        leafCount: 1,
+        unknownFiles: [],
+      },
+      graphBuiltAt: GRAPH_TS,
+      graphCommit: null,
+      threshold: 0,
+    });
+    const prev = process.env.GITHUB_ACTIONS;
+    delete process.env.GITHUB_ACTIONS;
+    try {
+      expect(renderGithubAnnotations(summary)).toBe('');
+    } finally {
+      if (prev !== undefined) process.env.GITHUB_ACTIONS = prev;
+    }
   });
 
   it('hub files contribute more weight than leaf files', async () => {

--- a/src/cli/preflight/preflight.test.ts
+++ b/src/cli/preflight/preflight.test.ts
@@ -187,25 +187,35 @@ describe('openlore preflight', () => {
     expect(human).toContain('Staleness:');
   });
 
-  it('AC#3: --fix updates graph fingerprint and re-check passes', async () => {
-    // Simulate "analyze fixed it" by directly bumping fingerprint.json + mtimes
-    // in a wrapper. We bypass the real analyzer (it requires the full pipeline);
-    // the contract under test is "preflight re-runs after fix and reports FRESH."
+  it('AC#3: --fix invokes analyzer, then re-check reports FRESH', async () => {
     const after = (GRAPH_MS + 60_000) / 1000;
     await writeFile(join(dir, 'src/foo.ts'), 'changed\n');
     await utimes(join(dir, 'src/foo.ts'), after, after);
 
-    // First confirm we're STALE.
-    let res = await runPreflight({ cwd: dir, json: true });
-    expect(res.code).toBe(1);
+    let analyzerCalls = 0;
+    const fakeAnalyze = async (cwd: string): Promise<number> => {
+      analyzerCalls++;
+      expect(cwd).toBe(dir);
+      // Real `analyze` rewrites fingerprint.json with a current timestamp;
+      // simulate that side-effect only.
+      await makeFingerprint(cwd, new Date().toISOString());
+      return 0;
+    };
 
-    // Bump the fingerprint to "now" — the equivalent of what `analyze` does.
-    const nowIso = new Date().toISOString();
-    await makeFingerprint(dir, nowIso);
-
-    res = await runPreflight({ cwd: dir, json: true });
+    const res = await runPreflight({ cwd: dir, json: true, fix: true, analyzeFn: fakeAnalyze });
+    expect(analyzerCalls).toBe(1);
     expect(res.code).toBe(0);
     expect(res.summary?.status).toBe('FRESH');
+  });
+
+  it('--fix exits 2 when the analyzer itself fails', async () => {
+    const after = (GRAPH_MS + 60_000) / 1000;
+    await writeFile(join(dir, 'src/foo.ts'), 'changed\n');
+    await utimes(join(dir, 'src/foo.ts'), after, after);
+
+    const failingAnalyze = async (): Promise<number> => 1;
+    const res = await runPreflight({ cwd: dir, json: true, fix: true, analyzeFn: failingAnalyze });
+    expect(res.code).toBe(2);
   });
 
   it('--max-staleness raises the threshold and lets a small change through', async () => {

--- a/src/cli/preflight/report.ts
+++ b/src/cli/preflight/report.ts
@@ -7,6 +7,16 @@ import type { ScoreResult } from './score.js';
 
 export type PreflightStatus = 'FRESH' | 'STALE' | 'ERROR';
 
+export interface PerFileEntry {
+  filePath: string;
+  weight: number;
+  hub: boolean;
+  /** Highest fan-in across nodes in the file (for "why is this a hub"). */
+  maxFanIn: number;
+  /** True if the file isn't represented in the graph at all. */
+  unknown: boolean;
+}
+
 export interface PreflightSummary {
   status: PreflightStatus;
   graphBuiltAt: string | null;
@@ -14,6 +24,8 @@ export interface PreflightSummary {
   workingCommit: string | null;
   changedFiles: string[];
   unknownFiles: string[];
+  /** Per-file detail with weight + hub flag. Same order as `changedFiles`. */
+  perFile: PerFileEntry[];
   hubCount: number;
   leafCount: number;
   stalenessScore: number;
@@ -46,6 +58,21 @@ export function buildSummary(input: BuildSummaryInput): PreflightSummary {
     message = 'FRESH';
   }
 
+  // Build per-file detail in the same order as diff.changed so renderers
+  // can show "why" each file matters without re-querying the graph.
+  const scoreByPath = new Map(score.perFile.map((f) => [f.filePath, f]));
+  const unknownSet = new Set(score.unknownFiles);
+  const perFile: PerFileEntry[] = diff.changed.map((p) => {
+    const s = scoreByPath.get(p);
+    return {
+      filePath: p,
+      weight: s?.weight ?? 0,
+      hub: s?.hub ?? false,
+      maxFanIn: s?.maxFanIn ?? 0,
+      unknown: unknownSet.has(p),
+    };
+  });
+
   return {
     status,
     graphBuiltAt,
@@ -53,6 +80,7 @@ export function buildSummary(input: BuildSummaryInput): PreflightSummary {
     workingCommit: diff.workingCommit,
     changedFiles: diff.changed,
     unknownFiles: score.unknownFiles,
+    perFile,
     hubCount: score.hubCount,
     leafCount: score.leafCount,
     stalenessScore: score.totalScore,
@@ -91,21 +119,45 @@ export function renderHuman(s: PreflightSummary): string {
   lines.push(
     `${pad('Staleness:', 15)}score ${s.stalenessScore} (threshold ${s.threshold})`
   );
-  lines.push(`${pad('Status:', 15)}${s.status === 'STALE' ? 'STALE — ' + s.message.replace('STALE — ', '') : s.status}`);
+  // Status line: STALE message wins; otherwise distinguish "FRESH" from the
+  // genuinely-empty "nothing to check" case so users can tell why CI passed.
+  let statusLine: string;
+  if (s.status === 'STALE') {
+    statusLine = 'STALE — ' + s.message.replace('STALE — ', '');
+  } else if (s.changedFiles.length === 0) {
+    statusLine = `FRESH — ${s.message}`;
+  } else {
+    statusLine = 'FRESH';
+  }
+  lines.push(`${pad('Status:', 15)}${statusLine}`);
   if (s.warnings.length) {
     lines.push('');
     for (const w of s.warnings) lines.push(`  warning: ${w}`);
   }
-  if (s.changedFiles.length > 0 && s.changedFiles.length <= 20) {
+  // Per-file breakdown — sorted by weight DESC so hubs surface first.
+  const ranked = [...s.perFile].sort((a, b) => b.weight - a.weight);
+  if (ranked.length > 0) {
     lines.push('');
-    lines.push('Changed:');
-    for (const f of s.changedFiles) lines.push(`  - ${f}`);
-  } else if (s.changedFiles.length > 20) {
-    lines.push('');
-    lines.push(`Changed (showing first 20 of ${s.changedFiles.length}):`);
-    for (const f of s.changedFiles.slice(0, 20)) lines.push(`  - ${f}`);
+    const cap = 20;
+    const header = ranked.length > cap ? `Changed (showing top ${cap} of ${ranked.length}, by weight):` : 'Changed:';
+    lines.push(header);
+    for (const f of ranked.slice(0, cap)) {
+      lines.push(`  - ${formatFileLine(f)}`);
+    }
   }
   return lines.join('\n');
+}
+
+function formatFileLine(f: PerFileEntry): string {
+  if (f.unknown) {
+    return `${f.filePath}  (new/untracked, weight 0)`;
+  }
+  const tags: string[] = [];
+  if (f.hub) tags.push('hub');
+  if (f.maxFanIn > 0 && !f.hub) tags.push(`fan-in ${f.maxFanIn}`);
+  else if (f.hub && f.maxFanIn > 0) tags.push(`fan-in ${f.maxFanIn}`);
+  const tagStr = tags.length ? tags.join(', ') + ', ' : '';
+  return `${f.filePath}  (${tagStr}weight ${f.weight})`;
 }
 
 /**
@@ -140,7 +192,11 @@ function escapeAnnotation(s: string): string {
 }
 
 export function renderJson(s: PreflightSummary): string {
-  // Exclude transient fields that don't belong in the documented schema.
+  // Schema is documented in docs/preflight.md. We deliberately ship more
+  // than the spec's minimum (status / graph_built_at / graph_commit /
+  // working_commit / changed_files / staleness_score / threshold) — the
+  // extras (`unknown_files`, `per_file`, `hub_count`, `leaf_count`,
+  // `mechanism`, `warnings`) are purely additive.
   const payload = {
     status: s.status,
     graph_built_at: s.graphBuiltAt,
@@ -148,6 +204,13 @@ export function renderJson(s: PreflightSummary): string {
     working_commit: s.workingCommit,
     changed_files: s.changedFiles,
     unknown_files: s.unknownFiles,
+    per_file: s.perFile.map((f) => ({
+      file: f.filePath,
+      weight: f.weight,
+      hub: f.hub,
+      max_fan_in: f.maxFanIn,
+      unknown: f.unknown,
+    })),
     hub_count: s.hubCount,
     leaf_count: s.leafCount,
     staleness_score: s.stalenessScore,

--- a/src/cli/preflight/report.ts
+++ b/src/cli/preflight/report.ts
@@ -1,0 +1,128 @@
+/**
+ * Human-readable + JSON renderers for preflight results.
+ */
+
+import type { DiffResult } from './diff.js';
+import type { ScoreResult } from './score.js';
+
+export type PreflightStatus = 'FRESH' | 'STALE' | 'ERROR';
+
+export interface PreflightSummary {
+  status: PreflightStatus;
+  graphBuiltAt: string | null;
+  graphCommit: string | null;
+  workingCommit: string | null;
+  changedFiles: string[];
+  unknownFiles: string[];
+  hubCount: number;
+  leafCount: number;
+  stalenessScore: number;
+  threshold: number;
+  mechanism: 'git' | 'mtime';
+  warnings: string[];
+  message: string;
+}
+
+export interface BuildSummaryInput {
+  diff: DiffResult;
+  score: ScoreResult;
+  graphBuiltAt: string | null;
+  graphCommit: string | null;
+  threshold: number;
+}
+
+export function buildSummary(input: BuildSummaryInput): PreflightSummary {
+  const { diff, score, graphBuiltAt, graphCommit, threshold } = input;
+  const totalChanged = diff.changed.length;
+  const stale = score.totalScore > threshold;
+  const status: PreflightStatus = stale ? 'STALE' : 'FRESH';
+
+  let message: string;
+  if (totalChanged === 0) {
+    message = 'nothing to check — no changed files since graph build';
+  } else if (stale) {
+    message = `STALE — run \`openlore analyze\` or re-run with --fix`;
+  } else {
+    message = 'FRESH';
+  }
+
+  return {
+    status,
+    graphBuiltAt,
+    graphCommit,
+    workingCommit: diff.workingCommit,
+    changedFiles: diff.changed,
+    unknownFiles: score.unknownFiles,
+    hubCount: score.hubCount,
+    leafCount: score.leafCount,
+    stalenessScore: score.totalScore,
+    threshold,
+    mechanism: diff.mechanism,
+    warnings: diff.warnings,
+    message,
+  };
+}
+
+function pad(s: string, n: number): string {
+  return s + ' '.repeat(Math.max(0, n - s.length));
+}
+
+export function renderHuman(s: PreflightSummary): string {
+  const lines: string[] = [];
+  lines.push('OpenLore preflight');
+  lines.push('──────────────────');
+  lines.push(
+    `${pad('Graph built:', 15)}${s.graphBuiltAt ?? '(unknown)'}` +
+      (s.graphCommit ? `   commit ${s.graphCommit}` : '')
+  );
+  lines.push(
+    `${pad('Working tree:', 15)}${new Date().toISOString()}` +
+      (s.workingCommit ? `   commit ${s.workingCommit}` : '')
+  );
+  if (s.changedFiles.length === 0) {
+    lines.push(`${pad('Changed files:', 15)}0`);
+  } else {
+    lines.push(
+      `${pad('Changed files:', 15)}${s.changedFiles.length} (${s.hubCount} hub, ${s.leafCount} leaf` +
+        (s.unknownFiles.length ? `, ${s.unknownFiles.length} new/untracked` : '') +
+        `)`
+    );
+  }
+  lines.push(
+    `${pad('Staleness:', 15)}score ${s.stalenessScore} (threshold ${s.threshold})`
+  );
+  lines.push(`${pad('Status:', 15)}${s.status === 'STALE' ? 'STALE — ' + s.message.replace('STALE — ', '') : s.status}`);
+  if (s.warnings.length) {
+    lines.push('');
+    for (const w of s.warnings) lines.push(`  warning: ${w}`);
+  }
+  if (s.changedFiles.length > 0 && s.changedFiles.length <= 20) {
+    lines.push('');
+    lines.push('Changed:');
+    for (const f of s.changedFiles) lines.push(`  - ${f}`);
+  } else if (s.changedFiles.length > 20) {
+    lines.push('');
+    lines.push(`Changed (showing first 20 of ${s.changedFiles.length}):`);
+    for (const f of s.changedFiles.slice(0, 20)) lines.push(`  - ${f}`);
+  }
+  return lines.join('\n');
+}
+
+export function renderJson(s: PreflightSummary): string {
+  // Exclude transient fields that don't belong in the documented schema.
+  const payload = {
+    status: s.status,
+    graph_built_at: s.graphBuiltAt,
+    graph_commit: s.graphCommit,
+    working_commit: s.workingCommit,
+    changed_files: s.changedFiles,
+    unknown_files: s.unknownFiles,
+    hub_count: s.hubCount,
+    leaf_count: s.leafCount,
+    staleness_score: s.stalenessScore,
+    threshold: s.threshold,
+    mechanism: s.mechanism,
+    warnings: s.warnings,
+  };
+  return JSON.stringify(payload, null, 2);
+}

--- a/src/cli/preflight/report.ts
+++ b/src/cli/preflight/report.ts
@@ -108,6 +108,37 @@ export function renderHuman(s: PreflightSummary): string {
   return lines.join('\n');
 }
 
+/**
+ * Emit GitHub Actions workflow-command annotations so that stale files
+ * appear inline in the PR diff UI when this runs in CI. No-op outside of
+ * GHA. Format docs:
+ *   https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+ */
+export function renderGithubAnnotations(s: PreflightSummary): string {
+  if (s.status !== 'STALE') return '';
+  if (process.env.GITHUB_ACTIONS !== 'true') return '';
+  const lines: string[] = [];
+  // Per-file warnings — point CI users at the exact files that pushed us
+  // over the threshold. Only annotate files that contributed weight (i.e.
+  // appeared in the graph); new/untracked files have weight 0.
+  for (const f of s.changedFiles) {
+    const inGraphContributor = !s.unknownFiles.includes(f);
+    if (!inGraphContributor) continue;
+    // Escape per GHA workflow-command escape rules.
+    const msg = `OpenLore graph is stale for this file — run \`openlore analyze\` to refresh`;
+    lines.push(`::warning file=${escapeAnnotation(f)}::${escapeAnnotation(msg)}`);
+  }
+  // Top-line error so the PR check fails visibly.
+  lines.push(
+    `::error::OpenLore preflight: staleness score ${s.stalenessScore} > threshold ${s.threshold} (${s.hubCount} hub, ${s.leafCount} leaf changes). Run \`openlore analyze\`.`
+  );
+  return lines.join('\n');
+}
+
+function escapeAnnotation(s: string): string {
+  return s.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
 export function renderJson(s: PreflightSummary): string {
   // Exclude transient fields that don't belong in the documented schema.
   const payload = {

--- a/src/cli/preflight/score.ts
+++ b/src/cli/preflight/score.ts
@@ -1,0 +1,128 @@
+/**
+ * Compute the staleness score for a set of changed files.
+ *
+ * Scoring model (deliberately simple, documented in docs/preflight.md):
+ *
+ *   per-file weight =
+ *     1                          base
+ *     + 2 if any node in the file is a hub (is_hub = 1)
+ *     + min(3, ceil(maxFanIn/5)) for the heaviest fan-in in the file
+ *
+ *   staleness_score = sum(per-file weight) over files that map to nodes in
+ *                     the graph; files not in the graph are reported but do
+ *                     not contribute to the score (we cannot reason about
+ *                     them without re-analyzing).
+ *
+ * This is intentionally a heuristic — a hub change matters more than a leaf
+ * change, but we never claim it's a true blast-radius computation. It is the
+ * cheapest signal that distinguishes "noisy editor save" from "ripped out a
+ * central module."
+ */
+
+import { DatabaseSync } from 'node:sqlite';
+import { join } from 'node:path';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_CALL_GRAPH_DB } from '../../constants.js';
+
+export interface FileScore {
+  filePath: string;
+  /** Whether the file appears in the graph at all. */
+  inGraph: boolean;
+  /** Did the file contain at least one hub? */
+  hub: boolean;
+  /** Max fan-in across nodes in the file. */
+  maxFanIn: number;
+  /** Number of nodes in the file. */
+  nodeCount: number;
+  /** Weight contribution. */
+  weight: number;
+}
+
+export interface ScoreResult {
+  perFile: FileScore[];
+  totalScore: number;
+  hubCount: number;
+  leafCount: number;
+  /** Files not represented in the graph at all (e.g. new files). */
+  unknownFiles: string[];
+}
+
+function dbPath(repoRoot: string): string {
+  return join(repoRoot, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_CALL_GRAPH_DB);
+}
+
+interface NodeRow {
+  file_path: string;
+  is_hub: number;
+  fan_in: number;
+}
+
+/** Stats keyed by file_path, computed from a single SELECT to keep things fast. */
+function loadFileStats(db: DatabaseSync, files: string[]): Map<string, FileScore> {
+  if (files.length === 0) return new Map();
+  const placeholders = files.map(() => '?').join(',');
+  const rows = db
+    .prepare(
+      `SELECT file_path, is_hub, fan_in FROM nodes WHERE is_external = 0 AND file_path IN (${placeholders})`
+    )
+    .all(...files) as unknown as NodeRow[];
+  const byFile = new Map<string, FileScore>();
+  for (const file of files) {
+    byFile.set(file, {
+      filePath: file,
+      inGraph: false,
+      hub: false,
+      maxFanIn: 0,
+      nodeCount: 0,
+      weight: 0,
+    });
+  }
+  for (const r of rows) {
+    const s = byFile.get(r.file_path);
+    if (!s) continue;
+    s.inGraph = true;
+    s.nodeCount += 1;
+    if (r.is_hub) s.hub = true;
+    if (r.fan_in > s.maxFanIn) s.maxFanIn = r.fan_in;
+  }
+  for (const s of byFile.values()) {
+    if (!s.inGraph) {
+      s.weight = 0;
+      continue;
+    }
+    let w = 1;
+    if (s.hub) w += 2;
+    w += Math.min(3, Math.ceil(s.maxFanIn / 5));
+    s.weight = w;
+  }
+  return byFile;
+}
+
+export function scoreChangedFiles(repoRoot: string, changedFiles: string[]): ScoreResult {
+  const result: ScoreResult = {
+    perFile: [],
+    totalScore: 0,
+    hubCount: 0,
+    leafCount: 0,
+    unknownFiles: [],
+  };
+  if (changedFiles.length === 0) return result;
+
+  const db = new DatabaseSync(dbPath(repoRoot), { readOnly: true });
+  try {
+    const stats = loadFileStats(db, changedFiles);
+    for (const file of changedFiles) {
+      const s = stats.get(file)!;
+      if (!s.inGraph) {
+        result.unknownFiles.push(file);
+        continue;
+      }
+      result.perFile.push(s);
+      result.totalScore += s.weight;
+      if (s.hub) result.hubCount += 1;
+      else result.leafCount += 1;
+    }
+  } finally {
+    db.close();
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Implements [docs/specs/openlore-spec-03-preflight-ci.md](docs/specs/openlore-spec-03-preflight-ci.md): a new `openlore preflight` subcommand that any CI system runs on every PR to fail fast when the persisted analysis graph is stale relative to the working tree.

Designed so out-of-date graphs never reach `orient()` / agent runtime silently — the check belongs at PR time, which is the cheap boundary.

```
openlore preflight [--fix] [--json] [--since <git-ref>] [--max-staleness <int>]
```

### Exit semantics

| Exit | Meaning |
|---|---|
| `0` | Fresh — graph current vs. working tree |
| `1` | Stale — staleness score exceeds threshold |
| `2` | Error — no graph / bad `--since` ref / fs failure |

### Sample human-readable output

```
OpenLore preflight
──────────────────
Graph built:   2025-01-01T00:00:00.000Z
Working tree:  2026-05-26T21:53:11.105Z   commit 6f29ba3
Changed files: 7 (3 hub, 4 leaf)
Staleness:     score 11 (threshold 0)
Status:        STALE — run `openlore analyze` or re-run with --fix

Changed:
  - src/core/services/llm-service.ts
  - ...
```

### Scoring model (documented in [docs/preflight.md](docs/preflight.md))

```
per-file weight = 1 (base) + 2 (if any node is a hub) + min(3, ceil(maxFanIn/5))
staleness_score = sum of per-file weights for files in the graph
```

Files not in the graph (new files, build artifacts, docs) are *reported* but do not contribute to the score — we can't reason about them without re-analyzing.

### What ships

| Area | Files |
|---|---|
| Subcommand | [src/cli/preflight/](src/cli/preflight/) — diff.ts, score.ts, report.ts, index.ts |
| Registration | [src/cli/index.ts](src/cli/index.ts) (one new line) |
| CI templates | [examples/ci/openlore-preflight.yml](examples/ci/openlore-preflight.yml) (GHA), [examples/ci/openlore-preflight.gitlab.yml](examples/ci/openlore-preflight.gitlab.yml), [examples/ci/openlore-preflight.sh](examples/ci/openlore-preflight.sh) |
| Docs | [docs/preflight.md](docs/preflight.md) — scoring model, JSON schema, CI wiring, edge cases |
| Tests | [src/cli/preflight/preflight.test.ts](src/cli/preflight/preflight.test.ts) — 10 tests against real SQLite + real git fixtures |

### Follow-ups

`TODO(spec-03-followup)` markers in code:
- **incremental analyzer** — `--fix` currently runs the full `openlore analyze`. A future spec should add `analyze --incremental` so `preflight --fix` becomes near-free.
- **graph commit recording** — `graph_commit` in the JSON output is always `null` today. Once `openlore analyze` records the HEAD commit at build time alongside `computedAt`, preflight will surface it. Per spec rule #2 this PR does not extend `analyze`.

## Test plan
- [x] AC#1: fresh repo → exit 0, status FRESH
- [x] AC#2: edited file → exit 1, status STALE, file listed
- [x] AC#3: `--fix` updates fingerprint, follow-up exits 0
- [x] AC#4: `--json` schema (status / graph_built_at / graph_commit / working_commit / changed_files / staleness_score / threshold)
- [x] AC#5: `--since main` works against the merge base
- [x] AC#6: example GHA workflow parses as valid YAML (test imports `yaml` and asserts shape)
- [x] AC#7: `npm run lint`, `npm run typecheck`, `npm run test:run` (2770 / 2 skipped), `npm run build` all clean
- [x] AC#8: no new runtime dependencies (uses `node:sqlite` built-in and existing `yaml` devdep)
- [x] Smoke test against the live repo: `node dist/cli/index.js preflight` and `--json` both run in well under 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)