### PR TITLE
spec-04: SCIP export for ecosystem interop

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,19 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 
 ---
 
+## Interop
+
+OpenLore exports [SCIP](https://github.com/sourcegraph/scip) (Source Code Intelligence Protocol). Plug it into Sourcegraph code nav, GitHub stack graphs, Glean importers, or any SCIP-aware tool:
+
+```bash
+openlore analyze            # build the graph (if you haven't already)
+openlore export scip        # writes ./index.scip
+```
+
+The SQLite graph stays canonical; SCIP is a one-way export of the subset SCIP can model (functions → symbols, call edges → occurrences). See [docs/scip-export.md](docs/scip-export.md) for what is and isn't exported and how to consume it.
+
+---
+
 ## Documentation
 
 | Topic | Doc |
@@ -284,6 +297,7 @@ The graph and the OpenSpec spec layer are co-equal: the graph makes orientation 
 | Spec-driven tests + spec digest | [docs/spec-tests.md](docs/spec-tests.md) |
 | CI/CD integration | [docs/ci-cd.md](docs/ci-cd.md) |
 | Preflight CI staleness gate | [docs/preflight.md](docs/preflight.md) |
+| SCIP export (Sourcegraph/Glean interop) | [docs/scip-export.md](docs/scip-export.md) |
 | CLI command reference | [docs/cli-reference.md](docs/cli-reference.md) |
 | Interactive graph viewer | [docs/viewer.md](docs/viewer.md) |
 | Analysis output files | [docs/output.md](docs/output.md) |

--- a/docs/scip-export.md
+++ b/docs/scip-export.md
@@ -1,0 +1,105 @@
+# SCIP Export
+
+`openlore export scip` emits an `index.scip` file derived from the analysis
+graph, making OpenLore consumable by the wider symbolic-code-graph ecosystem.
+
+## What is SCIP?
+
+[SCIP](https://github.com/sourcegraph/scip) (Source Code Intelligence Protocol)
+is Sourcegraph's open, protobuf-defined successor to LSIF. It models a symbolic
+code index as **documents** (files), **symbols** (monikers), and **occurrences**
+(symbol references with ranges and roles). Tools that already understand SCIP
+include Sourcegraph code navigation, GitHub's stack-graph viewer, and Glean
+importers.
+
+OpenLore vendors the upstream schema verbatim at
+[`src/core/scip/vendor/scip.proto`](../src/core/scip/vendor/scip.proto)
+(pinned — see the header comment in that file). We serialize with
+[`protobufjs`](https://www.npmjs.com/package/protobufjs), a pure-JS library with
+no native build step.
+
+## Usage
+
+```bash
+openlore analyze                       # build the graph first
+openlore export scip                   # writes ./index.scip
+
+openlore export scip --out build/index.scip
+openlore export scip --project-root /path/to/repo
+openlore export scip --include 'src/**' --exclude 'src/**/*.test.*'
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--out <path>` | `<project-root>/index.scip` | Output path |
+| `--project-root <path>` | current directory | Repo to export |
+| `--include <glob>` | (all) | Only include matching files (repeatable) |
+| `--exclude <glob>` | (none) | Drop matching files (repeatable) |
+
+Globs are matched against repo-relative POSIX paths and support `*`, `?`, `**`,
+and `**/`.
+
+## What we export
+
+- **One `Document` per source file**, with its SCIP `Language` tag and
+  occurrences sorted by `(line, column)`.
+- **One `Symbol` per function/method**, with a stable moniker:
+
+  ```
+  openlore npm <package> <version> `<repo-rel-path>`/<qualified-name>(<arity>).
+  ```
+
+  Example: ``openlore npm openlore 2.0.2 `src/core/scip/index.ts`/exportScip(1).``
+  The package coordinates come from the target repo's `package.json` (or a
+  manifest-inferred manager and the directory name when none exists).
+
+- **A `Definition` occurrence** at each function's defining line, and a
+  **`ReadAccess` occurrence** at each call site whose callee is also exported.
+
+Index-level metadata records `project_root` (as a `file://` URI),
+`tool_info { name = "openlore", version }`, and `text_document_encoding = UTF8`.
+
+The output is **byte-deterministic**: re-running on an unchanged graph produces
+an identical file (documents sorted by path, occurrences by `(line, col)`,
+symbols deduplicated and sorted).
+
+## What we don't export
+
+This is a one-way, lossy projection. OpenLore's graph carries information SCIP
+has no place for, and it is simply dropped: McCabe complexity, community-detection
+clusters, drift state, layer violations, hub/entry-point classification, and
+inheritance edges.
+
+Known fidelity gaps:
+
+- **Column-level ranges.** The analyzer records line numbers but not columns
+  today, so occurrences are emitted as zero-width ranges at column 0. The
+  exporter warns once per run.
+  `TODO(spec-04-followup): column ranges in analyzer.`
+- **Arity.** Parameter counts are parsed best-effort from the declaration
+  signature; when no signature is available the method disambiguator is empty.
+- **Languages without a SCIP enum value** are tagged `UnspecifiedLanguage` and
+  listed in the export summary.
+
+If a function node is missing even a defining *line* — a range a SCIP consumer
+fundamentally expects — the export **fails loudly** rather than writing a
+malformed index. Re-run `openlore analyze` to rebuild the graph.
+
+`scip import` (consuming an external SCIP index into OpenLore's graph) is not
+implemented. `TODO(spec-04-followup): scip import.`
+
+## Consuming the output
+
+```bash
+# Validate / inspect with Sourcegraph's scip CLI (optional, not a dev dep):
+scip print index.scip
+
+# Convert to LSIF for tools that still speak LSIF:
+scip convert --from index.scip --to dump.lsif
+
+# Upload to a Sourcegraph instance:
+src code-intel upload -file=index.scip
+```
+
+OpenLore itself does not require the Sourcegraph CLI; the protobuf schema is the
+contract.

--- a/docs/specs/openlore-spec-04-scip-export.md
+++ b/docs/specs/openlore-spec-04-scip-export.md
@@ -16,8 +16,22 @@ Branch: `openlore-spec-04-scip-export`. Export-only shipped; import deferred per
 - [x] Tests + 3-file fixture (`src/core/scip/` — tests are co-located per repo convention; `test/` is gitignored): round-trip parse, byte-determinism (SHA-256), exact counts (3 docs / 4 symbols / 8 occurrences / 4 definitions), include/exclude, external-node exclusion, missing-range throw
 - [x] Docs: `docs/scip-export.md` + README "Interop" section
 - [x] `lint`, `typecheck`, `test:run` (2789 pass), `build` (proto copied to dist; built CLI verified) all green — incl. CI fix: exclude `src/core/scip/fixtures/**` from ESLint typed-linting (fixtures are excluded from tsconfig, so `parserOptions.project` couldn't resolve them)
-- [ ] `TODO(spec-04-followup): scip import`
-- [ ] `TODO(spec-04-followup): column ranges in analyzer`
+
+**In-scope spec is 100% complete.** PR #89 is mergeable and self-contained as a SCIP *export*. Downstream-impact review passed: vendored proto ships in the npm package (`dist/core/scip/vendor/scip.proto`, 33.7kB — no runtime `ENOENT`), fixtures/test files are excluded from the package, `protobufjs` adds ~7ms load + one transitive dep (`long`), and no graph-schema/MCP/`orient` surfaces were touched.
+
+### Deferred follow-ups (NOT in this PR — documented for a later session)
+
+Both were explicitly fenced off by this spec ("Out of scope for this PR"). They are paused by owner decision (2026-05-27); capturing the analysis here so a future session can pick them up without re-deriving it.
+
+1. **`column ranges in analyzer`** — today the analyzer records line numbers but not columns, so SCIP occurrences are emitted as zero-width ranges at column 0 (with a one-time warning). Making them faithful requires:
+   - Definitions: derivable now — `FunctionNode.startIndex` is a byte offset and the builder already holds file contents, so `column = startIndex − lastNewlineBefore(startIndex)`.
+   - Call sites: NOT free — `RawEdge` carries only `line`; the AST walk in [call-graph.ts](../../src/core/analyzer/call-graph.ts) would need to capture each call expression's start column and thread it through to `CallEdge`.
+   - **Tension to resolve:** this adds column fields to `FunctionNode`/`CallEdge`, i.e. it *changes the internal graph schema* — exactly what this spec's scope contract said the PR must NOT do, and it touches the repo's highest-fan-out hub (regression risk across all 7 languages). Recommend doing it as its own spec/PR with additive optional fields and per-language tests. The exporter already falls back gracefully, so this is a fidelity upgrade, not a fix.
+
+2. **`scip import`** — consume an external `index.scip` into a "read-only OpenLore view." Underspecified; two interpretations surfaced:
+   - *Light:* `openlore import scip <file>` parses an index and prints/returns a summary (documents, symbols, occurrences, sample monikers). Self-contained, no writes to the canonical graph, round-trip-testable against the export. Matches "read-only view" literally. **Recommended starting point.**
+   - *Heavy:* reconstruct a call graph from the SCIP index and write it into the SQLite/llm-context store so MCP tools/`orient` can query imported symbols — much larger, and risks touching MCP/`orient`, which the scope contract forbids.
+   - Decision needed before implementing: which interpretation, and which PR.
 
 ---
 

--- a/docs/specs/openlore-spec-04-scip-export.md
+++ b/docs/specs/openlore-spec-04-scip-export.md
@@ -1,0 +1,127 @@
+# OpenLore Spec 04 — SCIP Export (Interop with Sourcegraph / Glean Ecosystem)
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+
+---
+
+## Progress
+
+Branch: `openlore-spec-04-scip-export`. Export-only shipped; import deferred per scope.
+
+- [x] Vendor pinned SCIP proto (`src/core/scip/vendor/scip.proto`) + add `protobufjs` runtime dep
+- [x] Core module: `schema.ts` (proto load), `moniker.ts` (symbol/language derivation), `index.ts` (`exportScip(graph, options): Buffer`)
+- [x] CLI: `openlore export scip [--out --project-root --include --exclude]` (`src/cli/export/`, registered in `src/cli/index.ts`)
+- [x] Glob filtering (small in-house matcher; dropped `ignore` dep over a NodeNext typing quirk)
+- [x] Fail-loudly when a node lacks a defining line; zero-width col-0 ranges + one-time warning otherwise (`TODO(spec-04-followup): column ranges in analyzer`)
+- [x] Tests + 3-file fixture (`src/core/scip/` — tests are co-located per repo convention; `test/` is gitignored): round-trip parse, byte-determinism (SHA-256), exact counts (3 docs / 4 symbols / 8 occurrences / 4 definitions), include/exclude, external-node exclusion, missing-range throw
+- [x] Docs: `docs/scip-export.md` + README "Interop" section
+- [x] `lint`, `typecheck`, `test:run` (2789 pass), `build` (proto copied to dist; built CLI verified) all green
+- [ ] `TODO(spec-04-followup): scip import`
+- [ ] `TODO(spec-04-followup): column ranges in analyzer`
+
+---
+
+## Context for you (the agent)
+
+**SCIP** (Source Code Intelligence Protocol) is Sourcegraph's open-source successor to LSIF. It is a protobuf-defined format for representing symbolic code indexes (occurrences, symbols, documents, ranges). Adopting SCIP as an *export* format is a small change that makes OpenLore consumable by the wider symbolic-code-graph ecosystem: Sourcegraph code nav, GitHub's stack-graph viewer, Glean importers, and any downstream agent tool that already knows how to parse SCIP.
+
+This is a one-way interop move. We are not replacing OpenLore's internal graph schema (which has McCabe complexity, community-detection clusters, drift state, and other fields SCIP does not model). We are adding `openlore export scip` that emits a `index.scip` file derived from the graph we already have. Optionally, also `openlore import scip` as a stub that ingests an existing `index.scip` into a read-only OpenLore view — but only if that fits cleanly; ship export-only if import would balloon scope.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Change OpenLore's internal graph schema, MCP tools, or `orient()`.
+- Make SCIP a *required* path; the existing SQLite graph remains canonical.
+- Add a hard dependency on Sourcegraph tooling. Use only the SCIP protobuf schema (published, MIT-licensed, generated client code is small).
+- Convert lossily and silently. If a field in the OpenLore graph has no SCIP equivalent, that is fine — but if information that an SCIP consumer would expect (a symbol's defining range, e.g.) is *missing* from our graph, fail the export with a clear diagnostic; do not write a malformed index.
+
+This PR must:
+
+- Use the upstream SCIP `.proto` schema (vendored or fetched at build time — vendored is fine, file is small). Reference: https://github.com/sourcegraph/scip/blob/main/scip.proto. Pin the version in a comment.
+- Produce a valid `index.scip` that Sourcegraph's `scip` CLI accepts (we cannot require Sourcegraph CLI as a dev dep, but the format is the spec — write tests that round-trip parse the output against the protobuf schema).
+- Be stable: re-running the export on an unchanged graph produces byte-identical output (deterministic ordering of documents, occurrences, symbols).
+
+## The deliverable
+
+Add a new CLI subcommand: `openlore export scip`.
+
+```
+openlore export scip [--out <path>] [--project-root <path>] [--include <glob>...] [--exclude <glob>...]
+```
+
+Behavior:
+
+- Loads the existing OpenLore graph.
+- For every function node, emit an SCIP `Symbol` with a stable symbol moniker derived from `<repo-rel-path>#<qualified-name>(<arity>)`.
+- For every call edge, emit an SCIP `Occurrence` with `symbol_roles = ReadAccess` at the call site and the corresponding `Definition` occurrence at the callee.
+- For every file, emit one `Document` with its language, path, and occurrences sorted by `(line, col)`.
+- Index-level metadata: `project_root`, `tool_info { name = "openlore", version = <pkg.version> }`, `text_document_encoding = UTF8`.
+- Default output path: `index.scip` at repo root.
+- `--include`/`--exclude` filter which files participate.
+
+### Choices to document, not invent
+
+- **Symbol moniker format.** Use SCIP's recommended scheme: `scheme=openlore manager=npm name=<pkg> version=<v> descriptor=<file>/<symbol>(<arity>).`. If the OpenLore graph does not carry enough info to fill any of these slots, use the literal string `local` per the SCIP spec.
+- **Languages.** Map OpenLore's language tags to SCIP's `Language` enum. For languages we analyze that SCIP has no enum value for, use `UnspecifiedLanguage` and note in the export summary.
+- **Ranges.** OpenLore's call sites should carry `(start_line, start_col, end_line, end_col)`. If only line is available, emit a zero-width range at column 0 and log a warning.
+
+### Implementation notes
+
+- Use the `protobufjs` package (pure JS, no native build) for serialization. Add as a runtime dependency *only* if no lighter option works. If a single-file generated `pb.js` from the SCIP `.proto` fits in <100KB, vendor that and skip the dep — preferred.
+- Put SCIP logic in `src/core/scip/` so it is cleanly isolated. Public surface: a single `exportScip(graph, options): Buffer` function plus the CLI wrapper.
+- Add a test fixture: a tiny 3-file repo, run analyze + export, parse the result back through the protobuf schema, and assert known invariants (file count, occurrence count, at least one `Definition`).
+
+### Documentation
+
+- `docs/scip-export.md` (~one page): what SCIP is, what we export, what we *don't* export, how to consume (`scip convert --to lsif`, upload to Sourcegraph, etc.).
+- One section in the main README under "Interop": "OpenLore exports SCIP. Plug it into Sourcegraph, GitHub stack graphs, or any SCIP-aware tool."
+
+### Out of scope for this PR
+
+- SCIP *import* (consume someone else's SCIP into OpenLore's graph). Leave `TODO(spec-04-followup): scip import` and ship export-only.
+- Language coverage gaps in the analyzer. If a language is missing from OpenLore's analyzer, that does not become this PR's problem.
+- LSIF export. SCIP is the modern path; downstream consumers can convert.
+
+## Files you will create or modify (approximate)
+
+```
+src/core/scip/
+  index.ts                 # exportScip()
+  schema.ts                # protobuf schema loading
+  moniker.ts               # symbol moniker derivation
+  vendor/scip.proto        # pinned SCIP proto, with version comment
+  vendor/scip-pb.js        # OR a generated pure-JS pb module if vendored
+src/cli/export/
+  index.ts                 # `openlore export <format>` dispatch
+  scip.ts                  # CLI wrapper
+src/cli/index.ts           # register `export` subcommand
+docs/scip-export.md
+test/core/scip/
+  export.test.ts
+  fixtures/tiny-repo/      # 3-file fixture
+README.md                  # add Interop section
+```
+
+## Acceptance criteria
+
+1. `openlore export scip` produces `index.scip` against the fixture; the file is non-empty and parses back through the SCIP protobuf schema in a unit test.
+2. Output is byte-deterministic across runs on the same graph (test by running twice and comparing SHA-256).
+3. Documents are sorted by relative path. Occurrences within a document are sorted by `(line, col)`. Symbols within a document are deduplicated.
+4. The fixture's expected occurrence count is asserted exactly (lock the number in once you compute it; small fixture).
+5. `openlore export scip --include 'src/**' --exclude 'src/**/*.test.*'` filters as documented.
+6. README "Interop" section is present; `docs/scip-export.md` exists.
+7. `npm run lint`, `npm run typecheck`, `npm run test:run`, `npm run build` all pass.
+8. If a new runtime dep (`protobufjs`) is added, the PR description justifies it explicitly and confirms the package's size and zero-native-build property.
+
+## Git workflow — read carefully
+
+1. Branch: `openlore-spec-04-scip-export` off the default branch.
+2. **Open exactly one PR** titled `spec-04: SCIP export for ecosystem interop`. Body: link to upstream SCIP spec, the pinned proto version, and a `wc -l` of the generated output against the fixture.
+3. All follow-up commits for this spec push to the same PR. Never open a second PR. If the design needs to change mid-flight, push more commits.
+4. If the analyzer is missing data needed to produce a faithful SCIP file (e.g., column-level ranges), STOP and fail loudly in the export with a clear error message telling the user which fields are missing. Do not invent data. Leave `TODO(spec-04-followup): column ranges in analyzer` and ship.
+5. Run `lint`, `typecheck`, `test:run`, `build` before every push.
+
+## When you are done
+
+Reply with: PR URL, summary, follow-ups, files changed. Nothing else.

--- a/docs/specs/openlore-spec-04-scip-export.md
+++ b/docs/specs/openlore-spec-04-scip-export.md
@@ -15,7 +15,7 @@ Branch: `openlore-spec-04-scip-export`. Export-only shipped; import deferred per
 - [x] Fail-loudly when a node lacks a defining line; zero-width col-0 ranges + one-time warning otherwise (`TODO(spec-04-followup): column ranges in analyzer`)
 - [x] Tests + 3-file fixture (`src/core/scip/` — tests are co-located per repo convention; `test/` is gitignored): round-trip parse, byte-determinism (SHA-256), exact counts (3 docs / 4 symbols / 8 occurrences / 4 definitions), include/exclude, external-node exclusion, missing-range throw
 - [x] Docs: `docs/scip-export.md` + README "Interop" section
-- [x] `lint`, `typecheck`, `test:run` (2789 pass), `build` (proto copied to dist; built CLI verified) all green
+- [x] `lint`, `typecheck`, `test:run` (2789 pass), `build` (proto copied to dist; built CLI verified) all green — incl. CI fix: exclude `src/core/scip/fixtures/**` from ESLint typed-linting (fixtures are excluded from tsconfig, so `parserOptions.project` couldn't resolve them)
 - [ ] `TODO(spec-04-followup): scip import`
 - [ ] `TODO(spec-04-followup): column ranges in analyzer`
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,6 +57,6 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['dist/**', 'node_modules/**', 'examples/**', '*.config.js', '*.config.ts'],
+    ignores: ['dist/**', 'node_modules/**', 'examples/**', '*.config.js', '*.config.ts', 'src/core/scip/fixtures/**'],
   }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "glob": "^11.0.0",
         "ignore": "^6.0.2",
         "ora": "^8.1.1",
+        "protobufjs": "^8.4.2",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "tree-sitter": "^0.22.4",
@@ -4900,6 +4901,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "11.2.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
@@ -5448,6 +5455,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.4.2.tgz",
+      "integrity": "sha512-64rfNzkWOZAIazXzpBFPWq6F9up6gMvTzjE2oWIzApx2N/dqVUEE7+bCn2+40780dFVtKOUab8QfxJ6KJDWbqA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "glob": "^11.0.0",
     "ignore": "^6.0.2",
     "ora": "^8.1.1",
+    "protobufjs": "^8.4.2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "tree-sitter": "^0.22.4",

--- a/scripts/copy-assets.mjs
+++ b/scripts/copy-assets.mjs
@@ -4,6 +4,7 @@
  *
  * Currently:
  *   - src/cli/install/templates/*  →  dist/cli/install/templates/*
+ *   - src/core/scip/vendor/*       →  dist/core/scip/vendor/*  (vendored scip.proto, loaded at runtime)
  */
 
 import { cp, mkdir } from 'node:fs/promises';
@@ -17,6 +18,10 @@ const assets = [
   {
     from: resolve(repoRoot, 'src/cli/install/templates'),
     to: resolve(repoRoot, 'dist/cli/install/templates'),
+  },
+  {
+    from: resolve(repoRoot, 'src/core/scip/vendor'),
+    to: resolve(repoRoot, 'dist/core/scip/vendor'),
   },
 ];
 

--- a/src/cli/export/index.ts
+++ b/src/cli/export/index.ts
@@ -1,0 +1,30 @@
+/**
+ * `openlore export <format>` — export the analysis graph to interop formats.
+ *
+ * Currently the only format is `scip` (Source Code Intelligence Protocol).
+ * The subcommand dispatch is kept thin so additional formats can be added as
+ * sibling subcommands without touching the SCIP logic.
+ */
+
+import { Command } from 'commander';
+import { runScipExport, type ScipExportOptions } from './scip.js';
+
+/** Commander collector for repeatable options (`--include a --include b`). */
+function collect(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+const scipSubcommand = new Command('scip')
+  .description('Export the analysis graph as an SCIP index (index.scip) for the Sourcegraph/Glean ecosystem.')
+  .option('--out <path>', 'Output path for the SCIP index (default: <project-root>/index.scip)')
+  .option('--project-root <path>', 'Project root to export (default: current directory)')
+  .option('--include <glob>', 'Only include files matching this glob (repeatable)', collect, [])
+  .option('--exclude <glob>', 'Exclude files matching this glob (repeatable)', collect, [])
+  .action(async (opts: ScipExportOptions) => {
+    const code = await runScipExport(opts);
+    process.exit(code);
+  });
+
+export const exportCommand = new Command('export')
+  .description('Export the analysis graph to an interop format (scip).')
+  .addCommand(scipSubcommand);

--- a/src/cli/export/scip.ts
+++ b/src/cli/export/scip.ts
@@ -1,0 +1,112 @@
+/**
+ * `openlore export scip` — emit an `index.scip` derived from the analysis graph.
+ *
+ * Loads the persisted call graph and projects it into SCIP (see
+ * src/core/scip/index.ts). The SQLite/JSON graph remains canonical; this is a
+ * one-way interop export for the Sourcegraph / Glean ecosystem.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { basename, join, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { logger } from '../../utils/logger.js';
+import { readCachedContext } from '../../core/services/mcp-handlers/utils.js';
+import { exportScip, type ExportReport } from '../../core/scip/index.js';
+import type { PackageInfo } from '../../core/scip/moniker.js';
+
+const require = createRequire(import.meta.url);
+
+export interface ScipExportOptions {
+  out?: string;
+  projectRoot?: string;
+  include?: string[];
+  exclude?: string[];
+}
+
+/** openlore's own version, emitted as SCIP tool_info.version. */
+function toolVersion(): string {
+  const pkg = require('../../../package.json') as { version: string };
+  return pkg.version;
+}
+
+/**
+ * Derive the SCIP `<package>` coordinates for the target project. Reads
+ * package.json when present (npm); otherwise infers the ecosystem from a
+ * manifest file and falls back to the directory name at version 0.0.0.
+ */
+export function derivePackageInfo(projectRoot: string): PackageInfo {
+  const pkgJsonPath = join(projectRoot, 'package.json');
+  if (existsSync(pkgJsonPath)) {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8')) as { name?: string; version?: string };
+      if (pkg.name) {
+        return { manager: 'npm', name: pkg.name, version: pkg.version ?? '0.0.0' };
+      }
+    } catch {
+      // fall through to manifest inference
+    }
+  }
+  const manifests: Array<[string, string]> = [
+    ['Cargo.toml', 'cargo'],
+    ['go.mod', 'gomod'],
+    ['pyproject.toml', 'pip'],
+    ['setup.py', 'pip'],
+    ['Gemfile', 'gem'],
+    ['pom.xml', 'maven'],
+  ];
+  const manager = manifests.find(([f]) => existsSync(join(projectRoot, f)))?.[1] ?? 'npm';
+  return { manager, name: basename(projectRoot), version: '0.0.0' };
+}
+
+export async function runScipExport(opts: ScipExportOptions): Promise<number> {
+  const projectRoot = resolve(opts.projectRoot ?? process.cwd());
+
+  const ctx = await readCachedContext(projectRoot);
+  const graph = ctx?.callGraph;
+  if (!graph || graph.nodes.length === 0) {
+    logger.error('No analysis graph found. Run `openlore analyze` first.');
+    return 2;
+  }
+
+  const report: ExportReport = {
+    documentCount: 0,
+    occurrenceCount: 0,
+    symbolCount: 0,
+    definitionCount: 0,
+    unspecifiedLanguageFiles: [],
+    warnings: [],
+  };
+
+  let buffer: Buffer;
+  try {
+    buffer = exportScip(graph, {
+      projectRoot,
+      package: derivePackageInfo(projectRoot),
+      toolVersion: toolVersion(),
+      include: opts.include,
+      exclude: opts.exclude,
+      report,
+    });
+  } catch (err) {
+    logger.error(err instanceof Error ? err.message : String(err));
+    return 2;
+  }
+
+  const outPath = resolve(opts.out ?? join(projectRoot, 'index.scip'));
+  await writeFile(outPath, buffer);
+
+  logger.success(`Wrote ${outPath} (${buffer.byteLength} bytes)`);
+  logger.info('documents', report.documentCount);
+  logger.info('symbols', report.symbolCount);
+  logger.info('occurrences', report.occurrenceCount);
+  logger.info('definitions', report.definitionCount);
+  if (report.unspecifiedLanguageFiles.length > 0) {
+    logger.warning(
+      `${report.unspecifiedLanguageFiles.length} file(s) have no SCIP language enum and were tagged UnspecifiedLanguage.`
+    );
+  }
+  for (const w of report.warnings) logger.warning(w);
+
+  return 0;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,6 +27,7 @@ import { decisionsCommand } from './commands/decisions.js';
 import { telemetryCommand } from './commands/telemetry.js';
 import { installCommand } from './install/index.js';
 import { preflightCommand } from './preflight/index.js';
+import { exportCommand } from './export/index.js';
 import { configureLogger } from '../utils/logger.js';
 
 // Read version from package.json at runtime so it never drifts from the published version
@@ -141,5 +142,6 @@ program.addCommand(decisionsCommand);
 program.addCommand(telemetryCommand);
 program.addCommand(installCommand);
 program.addCommand(preflightCommand);
+program.addCommand(exportCommand);
 
 program.parse();

--- a/src/core/scip/export.test.ts
+++ b/src/core/scip/export.test.ts
@@ -1,0 +1,194 @@
+/**
+ * SCIP export tests — run the real call-graph builder over a tiny 3-file
+ * fixture, export it to SCIP, and assert that the output parses back through
+ * the vendored protobuf schema with the expected invariants.
+ *
+ * Counts are locked exactly (the fixture is small and stable): see
+ * fixtures/tiny-repo/. If you change the fixture, re-derive the numbers.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { CallGraphBuilder, type SerializedCallGraph } from '../analyzer/call-graph.js';
+import { exportScip, type ExportReport } from './index.js';
+import { scipIndexType } from './schema.js';
+import { scipLanguageName } from './moniker.js';
+
+const FIXTURE_DIR = fileURLToPath(new URL('./fixtures/tiny-repo', import.meta.url));
+const FIXTURE_FILES = ['src/math.ts', 'src/greet.ts', 'src/index.ts'];
+
+function emptyReport(): ExportReport {
+  return {
+    documentCount: 0,
+    occurrenceCount: 0,
+    symbolCount: 0,
+    definitionCount: 0,
+    unspecifiedLanguageFiles: [],
+    warnings: [],
+  };
+}
+
+async function buildFixtureGraph(): Promise<SerializedCallGraph> {
+  const files = FIXTURE_FILES.map(rel => ({
+    path: rel,
+    language: 'TypeScript',
+    content: readFileSync(join(FIXTURE_DIR, rel), 'utf-8'),
+  }));
+  const r = await new CallGraphBuilder().build(files);
+  return {
+    nodes: [...r.nodes.values()],
+    edges: r.edges,
+    classes: r.classes,
+    inheritanceEdges: r.inheritanceEdges,
+    hubFunctions: r.hubFunctions,
+    entryPoints: r.entryPoints,
+    layerViolations: r.layerViolations,
+    stats: r.stats,
+  };
+}
+
+const BASE_OPTS = {
+  projectRoot: FIXTURE_DIR,
+  package: { manager: 'npm', name: 'tiny-repo', version: '1.0.0' },
+  toolVersion: '9.9.9',
+};
+
+describe('exportScip — tiny-repo fixture', () => {
+  let graph: SerializedCallGraph;
+  beforeAll(async () => {
+    graph = await buildFixtureGraph();
+  });
+
+  it('produces a non-empty index that parses back through the SCIP schema', () => {
+    const buf = exportScip(graph, { ...BASE_OPTS });
+    expect(buf.byteLength).toBeGreaterThan(0);
+
+    const Index = scipIndexType();
+    const decoded = Index.toObject(Index.decode(buf), { enums: String }) as {
+      metadata: { tool_info: { name: string; version: string }; project_root: string; text_document_encoding: string };
+      documents: Array<{ relative_path: string; language: string; occurrences: unknown[]; symbols: unknown[] }>;
+    };
+
+    expect(decoded.metadata.tool_info).toEqual({ name: 'openlore', version: '9.9.9' });
+    expect(decoded.metadata.text_document_encoding).toBe('UTF8');
+    expect(decoded.metadata.project_root).toMatch(/^file:\/\//);
+    expect(decoded.documents.length).toBe(3);
+  });
+
+  it('asserts exact document, symbol, occurrence, and definition counts', () => {
+    const report = emptyReport();
+    exportScip(graph, { ...BASE_OPTS, report });
+    expect(report).toMatchObject({
+      documentCount: 3,
+      symbolCount: 4,
+      occurrenceCount: 8,
+      definitionCount: 4,
+    });
+    expect(report.unspecifiedLanguageFiles).toEqual([]);
+  });
+
+  it('emits the spec-documented symbol moniker format', () => {
+    const buf = exportScip(graph, { ...BASE_OPTS });
+    const Index = scipIndexType();
+    const decoded = Index.toObject(Index.decode(buf)) as {
+      documents: Array<{ relative_path: string; symbols: Array<{ symbol: string }> }>;
+    };
+    const math = decoded.documents.find(d => d.relative_path === 'src/math.ts')!;
+    const symbols = math.symbols.map(s => s.symbol);
+    expect(symbols).toContain('openlore npm tiny-repo 1.0.0 `src/math.ts`/add(2).');
+    expect(symbols).toContain('openlore npm tiny-repo 1.0.0 `src/math.ts`/double(1).');
+  });
+
+  it('is byte-deterministic across runs on the same graph', () => {
+    const a = exportScip(graph, { ...BASE_OPTS });
+    const b = exportScip(graph, { ...BASE_OPTS });
+    const sha = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex');
+    expect(sha(a)).toBe(sha(b));
+  });
+
+  it('sorts documents by path, occurrences by (line, col), and dedups symbols', () => {
+    const buf = exportScip(graph, { ...BASE_OPTS });
+    const Index = scipIndexType();
+    const decoded = Index.toObject(Index.decode(buf)) as {
+      documents: Array<{ relative_path: string; occurrences: Array<{ range: number[] }>; symbols: Array<{ symbol: string }> }>;
+    };
+
+    const paths = decoded.documents.map(d => d.relative_path);
+    expect(paths).toEqual([...paths].sort());
+
+    for (const doc of decoded.documents) {
+      const ranges = doc.occurrences.map(o => [o.range[0] ?? 0, o.range[1] ?? 0]);
+      const sorted = [...ranges].sort((x, y) => x[0] - y[0] || x[1] - y[1]);
+      expect(ranges).toEqual(sorted);
+
+      const syms = doc.symbols.map(s => s.symbol);
+      expect(syms.length).toBe(new Set(syms).size);
+    }
+  });
+
+  it('warns once that column-level ranges are unavailable', () => {
+    const report = emptyReport();
+    exportScip(graph, { ...BASE_OPTS, report });
+    expect(report.warnings.some(w => /column-level ranges/i.test(w))).toBe(true);
+    expect(report.warnings.length).toBe(1);
+  });
+
+  it('filters with --include / --exclude globs', () => {
+    const report = emptyReport();
+    exportScip(graph, { ...BASE_OPTS, include: ['src/**'], exclude: ['src/math.ts'], report });
+    // math.ts dropped → only greet.ts and index.ts remain as documents.
+    expect(report.documentCount).toBe(2);
+    // add/double symbols gone → only greet + main definitions.
+    expect(report.definitionCount).toBe(2);
+  });
+
+  it('excludes synthetic external nodes', () => {
+    // External nodes carry isExternal and have no real file; they must never
+    // appear as exported symbols.
+    const withExternal: SerializedCallGraph = {
+      ...graph,
+      nodes: [
+        ...graph.nodes,
+        {
+          id: 'external::fetch',
+          name: 'fetch',
+          filePath: 'external',
+          isAsync: false,
+          language: 'unknown',
+          startIndex: 0,
+          endIndex: 0,
+          fanIn: 0,
+          fanOut: 0,
+          isExternal: true,
+        },
+      ],
+    };
+    const report = emptyReport();
+    exportScip(withExternal, { ...BASE_OPTS, report });
+    expect(report.symbolCount).toBe(4); // unchanged
+  });
+
+  it('fails loudly when a node lacks a defining line', () => {
+    const broken: SerializedCallGraph = {
+      ...graph,
+      nodes: graph.nodes.map(n => ({ ...n, startLine: undefined })),
+    };
+    expect(() => exportScip(broken, { ...BASE_OPTS })).toThrow(/no defining line/);
+  });
+});
+
+describe('scipLanguageName', () => {
+  it('maps known OpenLore tags to SCIP enum names', () => {
+    expect(scipLanguageName('TypeScript')).toBe('TypeScript');
+    expect(scipLanguageName('C++')).toBe('CPP');
+    expect(scipLanguageName('C#')).toBe('CSharp');
+  });
+
+  it('returns empty string for languages SCIP has no enum value for', () => {
+    expect(scipLanguageName('unknown')).toBe('');
+    expect(scipLanguageName('Brainfuck')).toBe('');
+  });
+});

--- a/src/core/scip/fixtures/tiny-repo/package.json
+++ b/src/core/scip/fixtures/tiny-repo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "tiny-repo",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/src/core/scip/fixtures/tiny-repo/src/greet.ts
+++ b/src/core/scip/fixtures/tiny-repo/src/greet.ts
@@ -1,0 +1,6 @@
+import { double } from './math.js';
+
+/** Greets a name, using its length doubled as a flourish. */
+export function greet(name: string): string {
+  return `Hello ${name} (${double(name.length)})`;
+}

--- a/src/core/scip/fixtures/tiny-repo/src/index.ts
+++ b/src/core/scip/fixtures/tiny-repo/src/index.ts
@@ -1,0 +1,8 @@
+import { greet } from './greet.js';
+import { add } from './math.js';
+
+/** Entry point: greets the world and adds two numbers. */
+export function main(): void {
+  greet('world');
+  add(1, 2);
+}

--- a/src/core/scip/fixtures/tiny-repo/src/math.ts
+++ b/src/core/scip/fixtures/tiny-repo/src/math.ts
@@ -1,0 +1,9 @@
+/** Adds two numbers. */
+export function add(a: number, b: number): number {
+  return a + b;
+}
+
+/** Doubles a number by adding it to itself. */
+export function double(n: number): number {
+  return add(n, n);
+}

--- a/src/core/scip/index.ts
+++ b/src/core/scip/index.ts
@@ -1,0 +1,267 @@
+/**
+ * SCIP export — derives a valid `index.scip` payload from an OpenLore call
+ * graph.
+ *
+ * SCIP (Source Code Intelligence Protocol) is Sourcegraph's open successor to
+ * LSIF. This is a one-way interop export: the SQLite/JSON graph remains
+ * canonical, and we lossily project the subset of it that SCIP can model
+ * (functions → symbols, call edges → reference/definition occurrences).
+ *
+ * Guarantees:
+ *  - Deterministic: documents sorted by relative path, occurrences by
+ *    `(line, col)`, symbols deduplicated and sorted. Re-running on an unchanged
+ *    graph produces byte-identical output.
+ *  - Faithful or loud: if a node we export lacks a defining line (a range a
+ *    SCIP consumer expects), the export throws rather than emitting a malformed
+ *    index. Column-level precision is unavailable in the analyzer today, so we
+ *    emit zero-width ranges at column 0 and warn once.
+ *    TODO(spec-04-followup): column ranges in analyzer.
+ *  - TODO(spec-04-followup): scip import (consume external SCIP into the graph).
+ */
+
+import type { SerializedCallGraph, FunctionNode } from '../analyzer/call-graph.js';
+import {
+  scipIndexType,
+  SymbolRole,
+  TextEncoding_UTF8,
+  SymbolKind_Function,
+} from './schema.js';
+import { symbolMoniker, scipLanguageName, type PackageInfo } from './moniker.js';
+
+export interface ExportScipOptions {
+  /** Absolute path to the project root. Emitted (URI-encoded) as project_root. */
+  projectRoot: string;
+  /** Package coordinates filling the SCIP `<package>` symbol slot. */
+  package: PackageInfo;
+  /** openlore's own version, emitted as tool_info.version. */
+  toolVersion: string;
+  /** Gitignore-style globs over repo-relative paths; if set, only matches participate. */
+  include?: string[];
+  /** Gitignore-style globs over repo-relative paths; matches are dropped. */
+  exclude?: string[];
+  /** Out-param: populated with summary statistics and warnings for the CLI. */
+  report?: ExportReport;
+}
+
+export interface ExportReport {
+  documentCount: number;
+  occurrenceCount: number;
+  symbolCount: number;
+  definitionCount: number;
+  /** Repo-relative paths whose language has no SCIP enum value. */
+  unspecifiedLanguageFiles: string[];
+  warnings: string[];
+}
+
+/**
+ * Compile a glob to a path-matching RegExp. Supports `*` (within a segment),
+ * `?`, `**` (across segments), and a globstar-plus-slash (zero or more leading
+ * path segments).
+ * Sufficient for the documented `--include`/`--exclude` patterns; not a full
+ * gitignore implementation.
+ */
+function globToRegExp(glob: string): RegExp {
+  let re = '';
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        if (glob[i + 2] === '/') {
+          re += '(?:.*/)?';
+          i += 2;
+        } else {
+          re += '.*';
+          i += 1;
+        }
+      } else {
+        re += '[^/]*';
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else if ('.+^${}()|[]\\'.includes(c)) {
+      re += '\\' + c;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp('^' + re + '$');
+}
+
+/** True iff `relPath` matches any of the compiled glob patterns. */
+function matchesAny(relPath: string, patterns: RegExp[]): boolean {
+  return patterns.some(p => p.test(relPath));
+}
+
+/** Normalize a node's file path to a POSIX repo-relative path. */
+function toRelPath(filePath: string, projectRoot: string): string {
+  let p = filePath.replace(/\\/g, '/');
+  const root = projectRoot.replace(/\\/g, '/').replace(/\/$/, '');
+  if (p.startsWith(root + '/')) p = p.slice(root.length + 1);
+  return p.replace(/^\.\//, '').replace(/^\/+/, '');
+}
+
+/** A definition occurrence emitted in the document where the symbol is defined. */
+interface ScipOccurrence {
+  range: number[];
+  symbol: string;
+  symbol_roles: number;
+}
+
+interface ScipSymbolInformation {
+  symbol: string;
+  documentation?: string[];
+  kind: number;
+}
+
+interface ScipDocument {
+  language: string;
+  relative_path: string;
+  occurrences: ScipOccurrence[];
+  symbols: ScipSymbolInformation[];
+}
+
+/**
+ * Build a deterministic SCIP `index.scip` payload from a serialized call graph.
+ * Returns the encoded protobuf bytes.
+ */
+export function exportScip(graph: SerializedCallGraph, options: ExportScipOptions): Buffer {
+  const report: ExportReport = options.report ?? {
+    documentCount: 0,
+    occurrenceCount: 0,
+    symbolCount: 0,
+    definitionCount: 0,
+    unspecifiedLanguageFiles: [],
+    warnings: [],
+  };
+  if (options.report) {
+    // Reset the caller-provided report so repeated calls are clean.
+    report.documentCount = 0;
+    report.occurrenceCount = 0;
+    report.symbolCount = 0;
+    report.definitionCount = 0;
+    report.unspecifiedLanguageFiles = [];
+    report.warnings = [];
+  }
+
+  const includePatterns = (options.include ?? []).map(globToRegExp);
+  const excludePatterns = (options.exclude ?? []).map(globToRegExp);
+
+  // Real (non-synthetic) nodes that survive the include/exclude filter.
+  const exportable = new Map<string, { node: FunctionNode; relPath: string }>();
+  for (const node of graph.nodes) {
+    if (node.isExternal) continue;
+    const relPath = toRelPath(node.filePath, options.projectRoot);
+    if (!relPath) continue;
+    if (includePatterns.length > 0 && !matchesAny(relPath, includePatterns)) continue;
+    if (excludePatterns.length > 0 && matchesAny(relPath, excludePatterns)) continue;
+    exportable.set(node.id, { node, relPath });
+  }
+
+  // Stable moniker per node id, computed once.
+  const monikers = new Map<string, string>();
+  for (const [id, { node, relPath }] of exportable) {
+    monikers.set(id, symbolMoniker(node, relPath, options.package));
+  }
+
+  let warnedMissingColumns = false;
+  const warnMissingColumns = (): void => {
+    if (warnedMissingColumns) return;
+    warnedMissingColumns = true;
+    report.warnings.push(
+      'Column-level ranges are unavailable in the analyzer; emitted zero-width ranges at column 0. ' +
+        'TODO(spec-04-followup): column ranges in analyzer.'
+    );
+  };
+
+  // documents keyed by relative path.
+  const docs = new Map<string, ScipDocument>();
+  const seenLanguages = new Map<string, string>(); // relPath -> openlore language
+  const docFor = (relPath: string, openloreLang: string): ScipDocument => {
+    let doc = docs.get(relPath);
+    if (!doc) {
+      const language = scipLanguageName(openloreLang);
+      if (!language) report.unspecifiedLanguageFiles.push(relPath);
+      doc = { language, relative_path: relPath, occurrences: [], symbols: [] };
+      docs.set(relPath, doc);
+      seenLanguages.set(relPath, openloreLang);
+    }
+    return doc;
+  };
+
+  // 1. Definition occurrence + SymbolInformation for every exported node.
+  for (const [, { node, relPath }] of exportable) {
+    if (node.startLine === undefined) {
+      throw new Error(
+        `SCIP export aborted: node "${node.id}" has no defining line. ` +
+          'The graph is missing a range that an SCIP consumer requires. ' +
+          'Re-run `openlore analyze` to rebuild the graph; if the problem persists the analyzer ' +
+          'did not record positions for this language.'
+      );
+    }
+    const doc = docFor(relPath, node.language);
+    const symbol = monikers.get(node.id)!;
+    const line = node.startLine - 1; // SCIP ranges are 0-based.
+    warnMissingColumns();
+    doc.occurrences.push({ range: [line, 0, 0], symbol, symbol_roles: SymbolRole.Definition });
+    doc.symbols.push({
+      symbol,
+      kind: SymbolKind_Function,
+      ...(node.docstring ? { documentation: [node.docstring] } : {}),
+    });
+  }
+
+  // 2. Reference occurrence at each call site whose callee we export.
+  for (const edge of graph.edges) {
+    const caller = exportable.get(edge.callerId);
+    const calleeSymbol = monikers.get(edge.calleeId);
+    if (!caller || !calleeSymbol) continue; // skip edges to external/filtered nodes.
+    const doc = docFor(caller.relPath, caller.node.language);
+    if (edge.line === undefined) warnMissingColumns();
+    const line = (edge.line ?? caller.node.startLine ?? 1) - 1;
+    doc.occurrences.push({ range: [line, 0, 0], symbol: calleeSymbol, symbol_roles: SymbolRole.ReadAccess });
+  }
+
+  // 3. Deterministic ordering: documents by path; occurrences by (line, col,
+  //    roles, symbol); symbols deduplicated and sorted by symbol string.
+  const sortedDocs = [...docs.values()].sort((a, b) => a.relative_path.localeCompare(b.relative_path));
+  for (const doc of sortedDocs) {
+    doc.occurrences.sort(
+      (a, b) =>
+        a.range[0] - b.range[0] ||
+        a.range[1] - b.range[1] ||
+        a.symbol_roles - b.symbol_roles ||
+        a.symbol.localeCompare(b.symbol)
+    );
+    const bySymbol = new Map<string, ScipSymbolInformation>();
+    for (const s of doc.symbols) if (!bySymbol.has(s.symbol)) bySymbol.set(s.symbol, s);
+    doc.symbols = [...bySymbol.values()].sort((a, b) => a.symbol.localeCompare(b.symbol));
+
+    report.occurrenceCount += doc.occurrences.length;
+    report.symbolCount += doc.symbols.length;
+    report.definitionCount += doc.occurrences.filter(o => o.symbol_roles === SymbolRole.Definition).length;
+  }
+  report.documentCount = sortedDocs.length;
+
+  const payload = {
+    metadata: {
+      version: 0, // UnspecifiedProtocolVersion — the only defined value.
+      tool_info: { name: 'openlore', version: options.toolVersion },
+      project_root: pathToFileUri(options.projectRoot),
+      text_document_encoding: TextEncoding_UTF8,
+    },
+    documents: sortedDocs,
+  };
+
+  const Index = scipIndexType();
+  const err = Index.verify(payload);
+  if (err) throw new Error(`SCIP export produced an invalid index: ${err}`);
+  const message = Index.create(payload);
+  return Buffer.from(Index.encode(message).finish());
+}
+
+/** Encode an absolute filesystem path as a `file://` URI for project_root. */
+function pathToFileUri(absPath: string): string {
+  const normalized = absPath.replace(/\\/g, '/');
+  const withSlash = normalized.startsWith('/') ? normalized : '/' + normalized;
+  return 'file://' + withSlash.split('/').map(encodeURIComponent).join('/');
+}

--- a/src/core/scip/moniker.ts
+++ b/src/core/scip/moniker.ts
@@ -1,0 +1,115 @@
+/**
+ * Derivation of SCIP symbol monikers and language tags from OpenLore graph
+ * nodes.
+ *
+ * SCIP symbols are formatted strings, not structured objects, per the grammar
+ * documented at https://github.com/sourcegraph/scip/blob/main/docs/scip.md.
+ * We emit global symbols of the form:
+ *
+ *   <scheme> ' ' <manager> ' ' <package-name> ' ' <version> <descriptors>
+ *
+ * where descriptors are `<repo-rel-path>/` (namespace) followed by
+ * `<qualified-name>(<arity>).` (method). Example:
+ *
+ *   openlore npm openlore 2.0.2 `src/core/scip/index.ts`/exportScip(1).
+ *
+ * Identifiers containing characters outside the SCIP "simple identifier" set
+ * are backtick-escaped (with embedded backticks doubled).
+ */
+
+import type { FunctionNode } from '../analyzer/call-graph.js';
+
+/** Package coordinates that fill the SCIP `<package>` slot of every symbol. */
+export interface PackageInfo {
+  manager: string;
+  name: string;
+  version: string;
+}
+
+const SCHEME = 'openlore';
+
+/** A simple identifier needs no escaping iff it matches this set entirely. */
+const SIMPLE_IDENTIFIER = /^[A-Za-z0-9\-+$_]+$/;
+
+/** Escape a name for use as a SCIP descriptor identifier. */
+function escapeName(name: string): string {
+  if (SIMPLE_IDENTIFIER.test(name)) return name;
+  // Escaped identifier: wrap in backticks, double any embedded backticks.
+  return '`' + name.replace(/`/g, '``') + '`';
+}
+
+/**
+ * Map an OpenLore language tag (see signature-extractor.ts) to the SCIP
+ * `Language` enum name used as `Document.language`. Returns `''` for languages
+ * SCIP has no value for (the caller records these for the export summary).
+ */
+export function scipLanguageName(openloreLanguage: string): string {
+  switch (openloreLanguage) {
+    case 'Python':
+    case 'TypeScript':
+    case 'JavaScript':
+    case 'Go':
+    case 'Rust':
+    case 'Ruby':
+    case 'Java':
+    case 'Kotlin':
+    case 'PHP':
+    case 'Swift':
+    case 'C':
+      return openloreLanguage;
+    case 'C++':
+      return 'CPP';
+    case 'C#':
+      return 'CSharp';
+    default:
+      // 'unknown' and anything SCIP lacks an enum value for.
+      return '';
+  }
+}
+
+/** Fully-qualified name within a file: `Class.method` or bare `function`. */
+export function qualifiedName(node: FunctionNode): string {
+  return node.className ? `${node.className}.${node.name}` : node.name;
+}
+
+/**
+ * Best-effort parameter count from a node's declaration `signature`. Counts
+ * top-level comma-separated parameters inside the first parenthesized group.
+ * Returns `undefined` when no signature is available (the analyzer does not
+ * persist arity directly — TODO(spec-04-followup): arity in analyzer).
+ */
+export function arityOf(node: FunctionNode): number | undefined {
+  const sig = node.signature;
+  if (!sig) return undefined;
+  const open = sig.indexOf('(');
+  if (open === -1) return undefined;
+  // Walk to the matching close paren, counting top-level commas.
+  let depth = 0;
+  let commas = 0;
+  let sawContent = false;
+  for (let i = open; i < sig.length; i++) {
+    const ch = sig[i];
+    if (ch === '(' || ch === '[' || ch === '{' || ch === '<') depth++;
+    else if (ch === ')' || ch === ']' || ch === '}' || ch === '>') {
+      depth--;
+      if (depth === 0) break;
+    } else if (ch === ',' && depth === 1) commas++;
+    else if (depth === 1 && !/\s/.test(ch)) sawContent = true;
+  }
+  if (!sawContent) return 0;
+  return commas + 1;
+}
+
+/**
+ * Build the SCIP symbol moniker string for a function node.
+ *
+ * `repoRelPath` must be the document's relative path (POSIX separators), the
+ * same value used for the node's `Document.relative_path`.
+ */
+export function symbolMoniker(node: FunctionNode, repoRelPath: string, pkg: PackageInfo): string {
+  const namespace = `${escapeName(repoRelPath)}/`;
+  const arity = arityOf(node);
+  const disambiguator = arity === undefined ? '' : String(arity);
+  const method = `${escapeName(qualifiedName(node))}(${disambiguator}).`;
+  return `${SCHEME} ${pkg.manager} ${pkg.name} ${pkg.version} ${namespace}${method}`;
+}

--- a/src/core/scip/schema.ts
+++ b/src/core/scip/schema.ts
@@ -1,0 +1,54 @@
+/**
+ * Loads the vendored SCIP protobuf schema and exposes the `scip.Index` type.
+ *
+ * The schema is vendored verbatim at `vendor/scip.proto` (pinned — see the
+ * header comment in that file). We parse it at runtime with protobufjs (pure
+ * JS, no native build) rather than committing a generated `pb.js`, which keeps
+ * the vendored artifact human-readable and trivially re-fetchable.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import protobuf from 'protobufjs';
+
+/** Resolved once and memoized — parsing the proto is cheap but not free. */
+let cachedRoot: protobuf.Root | undefined;
+
+/** Absolute path to the vendored proto, resolved relative to this module. */
+export function scipProtoPath(): string {
+  return fileURLToPath(new URL('./vendor/scip.proto', import.meta.url));
+}
+
+/** Parse the vendored proto and return the protobufjs Root. */
+export function loadScipRoot(): protobuf.Root {
+  if (cachedRoot) return cachedRoot;
+  const protoText = readFileSync(scipProtoPath(), 'utf-8');
+  cachedRoot = protobuf.parse(protoText, { keepCase: true }).root;
+  return cachedRoot;
+}
+
+/** The `scip.Index` message type, used to verify + serialize an index payload. */
+export function scipIndexType(): protobuf.Type {
+  return loadScipRoot().lookupType('scip.Index');
+}
+
+/**
+ * SCIP `SymbolRole` bitset values we use. Mirrors the enum in scip.proto.
+ * Kept as a const object (not an import) because the proto enums are not
+ * surfaced as TS values by protobufjs's runtime parse.
+ */
+export const SymbolRole = {
+  Definition: 0x1,
+  ReadAccess: 0x8,
+} as const;
+
+/**
+ * SCIP `TextEncoding.UTF8`. The index declares source files are UTF-8 on disk.
+ */
+export const TextEncoding_UTF8 = 1;
+
+/**
+ * SCIP `SymbolInformation.Kind.Function`. Every node we export is a
+ * function/method, so we tag them uniformly.
+ */
+export const SymbolKind_Function = 17;

--- a/src/core/scip/vendor/scip.proto
+++ b/src/core/scip/vendor/scip.proto
@@ -1,0 +1,910 @@
+// ============================================================================
+// VENDORED SCIP PROTOBUF SCHEMA
+//
+// Source:  https://github.com/sourcegraph/scip/blob/main/scip.proto
+// Fetched: 2026-05-27 from refs/heads/main
+// License: Apache-2.0 (Sourcegraph SCIP)
+//
+// SCIP (Source Code Intelligence Protocol) is Sourcegraph's open successor to
+// LSIF. OpenLore vendors this schema verbatim to serialize `index.scip` exports
+// (see src/core/scip/index.ts). Do NOT hand-edit the message definitions below;
+// re-fetch from the URL above to update, and bump the "Fetched" date.
+// ============================================================================
+
+// An index contains one or more pieces of information about a given piece of
+// source code or software artifact. Complementary information can be merged
+// together from multiple sources to provide a unified code intelligence
+// experience.
+//
+// Programs producing a file of this format is an "indexer" and may operate
+// somewhere on the spectrum between precision, such as indexes produced by
+// compiler-backed indexers, and heurstics, such as indexes produced by local
+// syntax-directed analysis for scope rules.
+
+syntax = "proto3";
+
+package scip;
+
+option go_package = "github.com/scip-code/scip/bindings/go/scip/";
+
+// Index represents a complete SCIP index for a workspace this is rooted at a
+// single directory. An Index message payload can have a large memory footprint
+// and it's therefore recommended to emit and consume an Index payload one field
+// value at a time. To permit streaming consumption of an Index payload, the
+// `metadata` field must appear at the start of the stream and must only appear
+// once in the stream. Other field values may appear in any order.
+message Index {
+  // Metadata about this index.
+  Metadata metadata = 1;
+  // Documents that belong to this index.
+  repeated Document documents = 2;
+  // (optional) Symbols that are referenced from this index but are defined in
+  // an external package (a separate `Index` message). Leave this field empty
+  // if you assume the external package will get indexed separately. If the
+  // external package won't get indexed for some reason then you can use this
+  // field to provide hover documentation for those external symbols.
+  repeated SymbolInformation external_symbols = 3;
+  // IMPORTANT: When adding a new field to `Index` here, add a matching
+  // function in `IndexVisitor` and update `ParseStreaming`.
+}
+
+message Metadata {
+  // Which version of this protocol was used to generate this index?
+  ProtocolVersion version = 1;
+  // Information about the tool that produced this index.
+  ToolInfo tool_info = 2;
+  // URI-encoded absolute path to the root directory of this index. All
+  // documents in this index must appear in a subdirectory of this root
+  // directory.
+  string project_root = 3;
+  // Text encoding of the source files on disk that are referenced from
+  // `Document.relative_path`. This value is unrelated to the `Document.text`
+  // field, which is a Protobuf string and hence must be UTF-8 encoded.
+  TextEncoding text_document_encoding = 4;
+}
+
+enum ProtocolVersion {
+  UnspecifiedProtocolVersion = 0;
+}
+
+enum TextEncoding {
+  UnspecifiedTextEncoding = 0;
+  UTF8 = 1;
+  UTF16 = 2;
+}
+
+message ToolInfo {
+  // Name of the indexer that produced this index.
+  string name = 1;
+  // Version of the indexer that produced this index.
+  string version = 2;
+  // Command-line arguments that were used to invoke this indexer.
+  repeated string arguments = 3;
+}
+
+// Document defines the metadata about a source file on disk.
+message Document {
+  // The string ID for the programming language this file is written in.
+  // The `Language` enum contains the names of most common programming languages.
+  // This field is typed as a string to permit any programming language, including
+  // ones that are not specified by the `Language` enum.
+  string language = 4;
+  // (Required) Unique path to the text document.
+  //
+  // 1. The path must be relative to the directory supplied in the associated
+  //    `Metadata.project_root`.
+  // 2. The path must not begin with a leading '/'.
+  // 3. The path must point to a regular file, not a symbolic link.
+  // 4. The path must use '/' as the separator, including on Windows.
+  // 5. The path must be canonical; it cannot include empty components ('//'),
+  //    or '.' or '..'.
+  string relative_path = 1;
+  // Occurrences that appear in this file.
+  repeated Occurrence occurrences = 2;
+  // Symbols that are "defined" within this document.
+  //
+  // This should include symbols which technically do not have any definition,
+  // but have a reference and are defined by some other symbol (see
+  // Relationship.is_definition).
+  repeated SymbolInformation symbols = 3;
+
+  // (optional) Text contents of this document. Indexers are not expected to
+  // include the text by default. It's preferable that clients read the text
+  // contents from the file system by resolving the absolute path from joining
+  // `Index.metadata.project_root` and `Document.relative_path`. This field
+  // can be useful for testing or when working with virtual/in-memory documents.
+  string text = 5;
+
+  // Specifies the encoding used for source ranges in this Document.
+  //
+  // Usually, this will match the type used to index the string type
+  // in the indexer's implementation language in O(1) time.
+  // - For an indexer implemented in JVM/.NET language or JavaScript/TypeScript,
+  //   use UTF16CodeUnitOffsetFromLineStart.
+  // - For an indexer implemented in Python,
+  //   use UTF32CodeUnitOffsetFromLineStart.
+  // - For an indexer implemented in Go, Rust or C++,
+  //   use UTF8ByteOffsetFromLineStart.
+  PositionEncoding position_encoding = 6;
+}
+
+// Encoding used to interpret the 'character' value in source ranges.
+enum PositionEncoding {
+  // Default value. This value should not be used by new SCIP indexers
+  // so that a consumer can process the SCIP index without ambiguity.
+  UnspecifiedPositionEncoding = 0;
+  // The 'character' value is interpreted as an offset in terms
+  // of UTF-8 code units (i.e. bytes).
+  //
+  // Example: For the string "🚀 Woo" in UTF-8, the bytes are
+  // [240, 159, 154, 128, 32, 87, 111, 111], so the offset for 'W'
+  // would be 5.
+  UTF8CodeUnitOffsetFromLineStart = 1;
+  // The 'character' value is interpreted as an offset in terms
+  // of UTF-16 code units (each is 2 bytes).
+  //
+  // Example: For the string "🚀 Woo", the UTF-16 code units are
+  // ['\ud83d', '\ude80', ' ', 'W', 'o', 'o'], so the offset for 'W'
+  // would be 3.
+  UTF16CodeUnitOffsetFromLineStart = 2;
+  // The 'character' value is interpreted as an offset in terms
+  // of UTF-32 code units (each is 4 bytes).
+  //
+  // Example: For the string "🚀 Woo", the UTF-32 code units are
+  // ['🚀', ' ', 'W', 'o', 'o'], so the offset for 'W' would be 2.
+  UTF32CodeUnitOffsetFromLineStart = 3;
+}
+
+// Symbol is similar to a URI, it identifies a class, method, or a local
+// variable. `SymbolInformation` contains rich metadata about symbols such as
+// the docstring.
+//
+// Symbol has a standardized string representation, which can be used
+// interchangeably with `Symbol`. The syntax for Symbol is the following:
+// ```
+// # (<x>)+ stands for one or more repetitions of <x>
+// # (<x>)? stands for zero or one occurrence of <x>
+// <symbol>               ::= <scheme> ' ' <package> ' ' (<descriptor>)+ | 'local ' <local-id>
+// <package>              ::= <manager> ' ' <package-name> ' ' <version>
+// <scheme>               ::= any UTF-8, escape spaces with double space. Must not be empty nor start with 'local'
+// <manager>              ::= any UTF-8, escape spaces with double space. Use the placeholder '.' to indicate an empty value
+// <package-name>         ::= same as above
+// <version>              ::= same as above
+// <descriptor>           ::= <namespace> | <type> | <term> | <method> | <type-parameter> | <parameter> | <meta> | <macro>
+// <namespace>            ::= <name> '/'
+// <type>                 ::= <name> '#'
+// <term>                 ::= <name> '.'
+// <meta>                 ::= <name> ':'
+// <macro>                ::= <name> '!'
+// <method>               ::= <name> '(' (<method-disambiguator>)? ').'
+// <type-parameter>       ::= '[' <name> ']'
+// <parameter>            ::= '(' <name> ')'
+// <name>                 ::= <identifier>
+// <method-disambiguator> ::= <simple-identifier>
+// <identifier>           ::= <simple-identifier> | <escaped-identifier>
+// <simple-identifier>    ::= (<identifier-character>)+
+// <identifier-character> ::= '_' | '+' | '-' | '$' | ASCII letter or digit
+// <escaped-identifier>   ::= '`' (<escaped-character>)+ '`', must contain at least one non-<identifier-character>
+// <escaped-characters>   ::= any UTF-8, escape backticks with double backtick.
+// <local-id>             ::= <simple-identifier>
+// ```
+//
+// The list of descriptors for a symbol should together form a fully
+// qualified name for the symbol. That is, it should serve as a unique
+// identifier across the package. Typically, it will include one descriptor
+// for every node in the AST (along the ancestry path) between the root of
+// the file and the node corresponding to the symbol.
+//
+// Local symbols MUST only be used for entities which are local to a Document,
+// and cannot be accessed from outside the Document.
+message Symbol {
+  string scheme = 1;
+  Package package = 2;
+  repeated Descriptor descriptors = 3;
+}
+
+// Unit of packaging and distribution.
+//
+// NOTE: This corresponds to a module in Go and JVM languages.
+message Package {
+  string manager = 1;
+  string name = 2;
+  string version = 3;
+}
+
+message Descriptor {
+  enum Suffix {
+    option allow_alias = true;
+    UnspecifiedSuffix = 0;
+    // Unit of code abstraction and/or namespacing.
+    //
+    // NOTE: This corresponds to a package in Go and JVM languages.
+    Namespace = 1;
+    // Use Namespace instead.
+    Package = 1 [deprecated = true];
+    Type = 2;
+    Term = 3;
+    Method = 4;
+    TypeParameter = 5;
+    Parameter = 6;
+    // Can be used for any purpose.
+    Meta = 7;
+    Local = 8;
+    Macro = 9;
+  }
+  string name = 1;
+  string disambiguator = 2;
+  Suffix suffix = 3;
+  // NOTE: If you add new fields here, make sure to update the prepareSlot()
+  // function responsible for parsing symbols.
+}
+
+// Signature represents the signature of a symbol as it's displayed in API
+// documentation or hover tooltips. It uses a subset of Document's fields with
+// the same field numbers for wire compatibility with older indexes that encoded
+// signatures using the Document message type.
+message Signature {
+  // The language of the signature, e.g. "java", "go", "python".
+  string language = 4;
+  // The text content of the signature, e.g. "void add(int a, int b)".
+  string text = 5;
+  // (optional) Occurrences within the signature text that reference other
+  // symbols, enabling hyperlinking of types in the signature. Ranges are
+  // relative to the `text` field.
+  repeated Occurrence occurrences = 2;
+
+  // Reserved field numbers from the Document message to prevent accidental
+  // reuse, which would break wire compatibility with older indexes.
+  reserved 1, 3, 6;
+}
+
+// SymbolInformation defines metadata about a symbol, such as the symbol's
+// docstring or what package it's defined it.
+message SymbolInformation {
+  // Identifier of this symbol, which can be referenced from `Occurence.symbol`.
+  // The string must be formatted according to the grammar in `Symbol`.
+  string symbol = 1;
+  // (optional, but strongly recommended) The markdown-formatted documentation
+  // for this symbol. Use `SymbolInformation.signature_documentation` to
+  // document the method/class/type signature of this symbol.
+  // Due to historical reasons, indexers may include signature documentation in
+  // this field by rendering markdown code blocks. New indexers should only
+  // include non-code documentation in this field, for example docstrings.
+  repeated string documentation = 3;
+  // (optional) Relationships to other symbols (e.g., implements, type definition).
+  repeated Relationship relationships = 4;
+  // The kind of this symbol. Use this field instead of
+  // `SymbolDescriptor.Suffix` to determine whether something is, for example, a
+  // class or a method.
+  Kind kind = 5;
+  // (optional) Kind represents the fine-grained category of a symbol, suitable for presenting
+  // information about the symbol's meaning in the language.
+  //
+  // For example:
+  // - A Java method would have the kind `Method` while a Go function would
+  //   have the kind `Function`, even if the symbols for these use the same
+  //   syntax for the descriptor `SymbolDescriptor.Suffix.Method`.
+  // - A Go struct has the symbol kind `Struct` while a Java class has
+  //   the symbol kind `Class` even if they both have the same descriptor:
+  //   `SymbolDescriptor.Suffix.Type`.
+  //
+  // Since Kind is more fine-grained than Suffix:
+  // - If two symbols have the same Kind, they should share the same Suffix.
+  // - If two symbols have different Suffixes, they should have different Kinds.
+  enum Kind {
+    UnspecifiedKind = 0;
+    // A method which may or may not have a body. For Java, Kotlin etc.
+    AbstractMethod = 66;
+    // For Ruby's attr_accessor
+    Accessor = 72;
+    Array = 1;
+    // For Alloy
+    Assertion = 2;
+    AssociatedType = 3;
+    // For C++
+    Attribute = 4;
+    // For Lean
+    Axiom = 5;
+    Boolean = 6;
+    Class = 7;
+    // For C++
+    Concept = 86;
+    Constant = 8;
+    Constructor = 9;
+    // For Solidity
+    Contract = 62;
+    // For Haskell
+    DataFamily = 10;
+    // For C# and F#
+    Delegate = 73;
+    Enum = 11;
+    EnumMember = 12;
+    Error = 63;
+    Event = 13;
+    // For Dart
+    Extension = 84;
+    // For Alloy
+    Fact = 14;
+    Field = 15;
+    File = 16;
+    Function = 17;
+    // For 'get' in Swift, 'attr_reader' in Ruby
+    Getter = 18;
+    // For Raku
+    Grammar = 19;
+    // For Purescript and Lean
+    Instance = 20;
+    Interface = 21;
+    Key = 22;
+    // For Racket
+    Lang = 23;
+    // For Lean
+    Lemma = 24;
+    // For solidity
+    Library = 64;
+    Macro = 25;
+    Method = 26;
+    // For Ruby
+    MethodAlias = 74;
+    // Analogous to 'ThisParameter' and 'SelfParameter', but for languages
+    // like Go where the receiver doesn't have a conventional name.
+    MethodReceiver = 27;
+    // Analogous to 'AbstractMethod', for Go.
+    MethodSpecification = 67;
+    // For Protobuf
+    Message = 28;
+    // For Dart
+    Mixin = 85;
+    // For Solidity
+    Modifier = 65;
+    Module = 29;
+    Namespace = 30;
+    Null = 31;
+    Number = 32;
+    Object = 33;
+    Operator = 34;
+    Package = 35;
+    PackageObject = 36;
+    Parameter = 37;
+    ParameterLabel = 38;
+    // For Haskell's PatternSynonyms
+    Pattern = 39;
+    // For Alloy
+    Predicate = 40;
+    Property = 41;
+    // Analogous to 'Trait' and 'TypeClass', for Swift and Objective-C
+    Protocol = 42;
+    // Analogous to 'AbstractMethod', for Swift and Objective-C.
+    ProtocolMethod = 68;
+    // Analogous to 'AbstractMethod', for C++.
+    PureVirtualMethod = 69;
+    // For Haskell
+    Quasiquoter = 43;
+    // 'self' in Python, Rust, Swift etc.
+    SelfParameter = 44;
+    // For 'set' in Swift, 'attr_writer' in Ruby
+    Setter = 45;
+    // For Alloy, analogous to 'Struct'.
+    Signature = 46;
+    // For Ruby
+    SingletonClass = 75;
+    // Analogous to 'StaticMethod', for Ruby.
+    SingletonMethod = 76;
+    // Analogous to 'StaticField', for C++
+    StaticDataMember = 77;
+    // For C#
+    StaticEvent = 78;
+    // For C#
+    StaticField = 79;
+    // For Java, C#, C++ etc.
+    StaticMethod = 80;
+    // For C#, TypeScript etc.
+    StaticProperty = 81;
+    // For C, C++
+    StaticVariable = 82;
+    String = 48;
+    Struct = 49;
+    // For Swift
+    Subscript = 47;
+    // For Lean
+    Tactic = 50;
+    // For Lean
+    Theorem = 51;
+    // Method receiver for languages
+    // 'this' in JavaScript, C++, Java etc.
+    ThisParameter = 52;
+    // Analogous to 'Protocol' and 'TypeClass', for Rust, Scala etc.
+    Trait = 53;
+    // Analogous to 'AbstractMethod', for Rust, Scala etc.
+    TraitMethod = 70;
+    // Data type definition for languages like OCaml which use `type`
+    // rather than separate keywords like `struct` and `enum`.
+    Type = 54;
+    TypeAlias = 55;
+    // Analogous to 'Trait' and 'Protocol', for Haskell, Purescript etc.
+    TypeClass = 56;
+    // Analogous to 'AbstractMethod', for Haskell, Purescript etc.
+    TypeClassMethod = 71;
+    // For Haskell
+    TypeFamily = 57;
+    TypeParameter = 58;
+    // For C, C++, Capn Proto
+    Union = 59;
+    Value = 60;
+    Variable = 61;
+    // Next = 87;
+    // Feel free to open a PR proposing new language-specific kinds.
+  }
+  // (optional) The name of this symbol as it should be displayed to the user.
+  // For example, the symbol "com/example/MyClass#myMethod(+1)." should have the
+  // display name "myMethod". The `symbol` field is not a reliable source of
+  // the display name for several reasons:
+  //
+  // - Local symbols don't encode the name.
+  // - Some languages have case-insensitive names, so the symbol is all-lowercase.
+  // - The symbol may encode names with special characters that should not be
+  //   displayed to the user.
+  string display_name = 6;
+  // (optional) The signature of this symbol as it's displayed in API
+  // documentation or in hover tooltips. For example, a Java method that adds
+  // two numbers would have `Signature.language = "java"` and
+  // `Signature.text = "void add(int a, int b)"`. The `language` and `text`
+  // fields are required while `occurrences` can be optionally included to
+  // support hyperlinking referenced symbols in the signature.
+  Signature signature_documentation = 7;
+  // (optional) The enclosing symbol if this is a local symbol.  For non-local
+  // symbols, the enclosing symbol should be parsed from the `symbol` field
+  // using the `Descriptor` grammar.
+  //
+  // The primary use-case for this field is to allow local symbol to be displayed
+  // in a symbol hierarchy for API documentation. It's OK to leave this field
+  // empty for local variables since local variables usually don't belong in API
+  // documentation. However, in the situation that you wish to include a local
+  // symbol in the hierarchy, then you can use `enclosing_symbol` to locate the
+  // "parent" or "owner" of this local symbol. For example, a Java indexer may
+  // choose to use local symbols for private class fields while providing an
+  // `enclosing_symbol` to reference the enclosing class to allow the field to
+  // be part of the class documentation hierarchy. From the perspective of an
+  // author of an indexer, the decision to use a local symbol or global symbol
+  // should exclusively be determined whether the local symbol is accessible
+  // outside the document, not by the capability to find the enclosing
+  // symbol.
+  string enclosing_symbol = 8;
+}
+
+message Relationship {
+  string symbol = 1;
+  // When resolving "Find references", this field documents what other symbols
+  // should be included together with this symbol. For example, consider the
+  // following TypeScript code that defines two symbols `Animal#sound()` and
+  // `Dog#sound()`:
+  // ```ts
+  // interface Animal {
+  //           ^^^^^^ definition Animal#
+  //   sound(): string
+  //   ^^^^^ definition Animal#sound()
+  // }
+  // class Dog implements Animal {
+  //       ^^^ definition Dog#, relationships = [{symbol: "Animal#", is_implementation: true}]
+  //   public sound(): string { return "woof" }
+  //          ^^^^^ definition Dog#sound(), references_symbols = Animal#sound(), relationships = [{symbol: "Animal#sound()", is_implementation:true, is_reference: true}]
+  // }
+  // const animal: Animal = new Dog()
+  //               ^^^^^^ reference Animal#
+  // console.log(animal.sound())
+  //                    ^^^^^ reference Animal#sound()
+  // ```
+  // Doing "Find references" on the symbol `Animal#sound()` should return
+  // references to the `Dog#sound()` method as well. Vice-versa, doing "Find
+  // references" on the `Dog#sound()` method should include references to the
+  // `Animal#sound()` method as well.
+  bool is_reference = 2;
+  // Similar to `is_reference` but for "Find implementations".
+  // It's common for `is_implementation` and `is_reference` to both be true but
+  // it's not always the case.
+  // In the TypeScript example above, observe that `Dog#` has an
+  // `is_implementation` relationship with `"Animal#"` but not `is_reference`.
+  // This is because "Find references" on the "Animal#" symbol should not return
+  // "Dog#". We only want "Dog#" to return as a result for "Find
+  // implementations" on the "Animal#" symbol.
+  bool is_implementation = 3;
+  // Similar to `references_symbols` but for "Go to type definition".
+  bool is_type_definition = 4;
+  // Allows overriding the behavior of "Go to definition" and "Find references"
+  // for symbols which do not have a definition of their own or could
+  // potentially have multiple definitions.
+  //
+  // For example, in a language with single inheritance and no field overriding,
+  // inherited fields can reuse the same symbol as the ancestor which declares
+  // the field. In such a situation, is_definition is not needed.
+  //
+  // On the other hand, in languages with single inheritance and some form
+  // of mixins, you can use is_definition to relate the symbol to the
+  // matching symbol in ancestor classes, and is_reference to relate the
+  // symbol to the matching symbol in mixins.
+  bool is_definition = 5;
+  // Update registerInverseRelationships on adding a new field here.
+}
+
+// SymbolRole declares what "role" a symbol has in an occurrence. A role is
+// encoded as a bitset where each bit represents a different role. For example,
+// to determine if the `Import` role is set, test whether the second bit of the
+// enum value is defined. In pseudocode, this can be implemented with the
+// logic: `const isImportRole = (role.value & SymbolRole.Import.value) > 0`.
+enum SymbolRole {
+  // This case is not meant to be used; it only exists to avoid an error
+  // from the Protobuf code generator.
+  UnspecifiedSymbolRole = 0;
+  // Is the symbol defined here? If not, then this is a symbol reference.
+  Definition = 0x1;
+  // Is the symbol imported here?
+  Import = 0x2;
+  // Is the symbol written here?
+  WriteAccess = 0x4;
+  // Is the symbol read here?
+  ReadAccess = 0x8;
+  // Is the symbol in generated code?
+  Generated = 0x10;
+  // Is the symbol in test code?
+  Test = 0x20;
+  // Is this a signature for a symbol that is defined elsewhere?
+  //
+  // Applies to forward declarations for languages like C, C++
+  // and Objective-C, as well as `val` declarations in interface
+  // files in languages like SML and OCaml.
+  ForwardDefinition = 0x40;
+}
+
+enum SyntaxKind {
+  option allow_alias = true;
+
+  UnspecifiedSyntaxKind = 0;
+
+  // Comment, including comment markers and text
+  Comment = 1;
+
+  // `;` `.` `,`
+  PunctuationDelimiter = 2;
+  // (), {}, [] when used syntactically
+  PunctuationBracket = 3;
+
+  // `if`, `else`, `return`, `class`, etc.
+  Keyword = 4;
+  IdentifierKeyword = 4 [deprecated = true];
+
+  // `+`, `*`, etc.
+  IdentifierOperator = 5;
+
+  // non-specific catch-all for any identifier not better described elsewhere
+  Identifier = 6;
+  // Identifiers builtin to the language: `min`, `print` in Python.
+  IdentifierBuiltin = 7;
+  // Identifiers representing `null`-like values: `None` in Python, `nil` in Go.
+  IdentifierNull = 8;
+  // `xyz` in `const xyz = "hello"`
+  IdentifierConstant = 9;
+  // `var X = "hello"` in Go
+  IdentifierMutableGlobal = 10;
+  // Parameter definition and references
+  IdentifierParameter = 11;
+  // Identifiers for variable definitions and references within a local scope
+  IdentifierLocal = 12;
+  // Identifiers that shadow other identifiers in an outer scope
+  IdentifierShadowed = 13;
+  // Identifier representing a unit of code abstraction and/or namespacing.
+  //
+  // NOTE: This corresponds to a package in Go and JVM languages,
+  // and a module in languages like Python and JavaScript.
+  IdentifierNamespace = 14;
+  IdentifierModule = 14 [deprecated = true];
+
+  // Function references, including calls
+  IdentifierFunction = 15;
+  // Function definition only
+  IdentifierFunctionDefinition = 16;
+
+  // Macro references, including invocations
+  IdentifierMacro = 17;
+  // Macro definition only
+  IdentifierMacroDefinition = 18;
+
+  // non-builtin types
+  IdentifierType = 19;
+  // builtin types only, such as `str` for Python or `int` in Go
+  IdentifierBuiltinType = 20;
+
+  // Python decorators, c-like __attribute__
+  IdentifierAttribute = 21;
+
+  // `\b`
+  RegexEscape = 22;
+  // `*`, `+`
+  RegexRepeated = 23;
+  // `.`
+  RegexWildcard = 24;
+  // `(`, `)`, `[`, `]`
+  RegexDelimiter = 25;
+  // `|`, `-`
+  RegexJoin = 26;
+
+  // Literal strings: "Hello, world!"
+  StringLiteral = 27;
+  // non-regex escapes: "\t", "\n"
+  StringLiteralEscape = 28;
+  // datetimes within strings, special words within a string, `{}` in format strings
+  StringLiteralSpecial = 29;
+  // "key" in { "key": "value" }, useful for example in JSON
+  StringLiteralKey = 30;
+  // 'c' or similar, in languages that differentiate strings and characters
+  CharacterLiteral = 31;
+  // Literal numbers, both floats and integers
+  NumericLiteral = 32;
+  // `true`, `false`
+  BooleanLiteral = 33;
+
+  // Used for XML-like tags
+  Tag = 34;
+  // Attribute name in XML-like tags
+  TagAttribute = 35;
+  // Delimiters for XML-like tags
+  TagDelimiter = 36;
+}
+
+// Occurrence associates a source position with a symbol and/or highlighting
+// information.
+//
+// If possible, indexers should try to bundle logically related information
+// across occurrences into a single occurrence to reduce payload sizes.
+message Occurrence {
+  // Half-open [start, end) range of this occurrence. Must be exactly three or four
+  // elements:
+  //
+  // - Four elements: `[startLine, startCharacter, endLine, endCharacter]`
+  // - Three elements: `[startLine, startCharacter, endCharacter]`. The end line
+  //   is inferred to have the same value as the start line.
+  //
+  // It is allowed for the range to be empty (i.e. start==end).
+  //
+  // Line numbers and characters are always 0-based. Make sure to increment the
+  // line/character values before displaying them in an editor-like UI because
+  // editors conventionally use 1-based numbers.
+  //
+  // The 'character' value is interpreted based on the PositionEncoding for
+  // the Document.
+  //
+  // Historical note: the original draft of this schema had a `Range` message
+  // type with `start` and `end` fields of type `Position`, mirroring LSP.
+  // Benchmarks revealed that this encoding was inefficient and that we could
+  // reduce the total payload size of an index by 50% by using `repeated int32`
+  // instead. The `repeated int32` encoding is admittedly more embarrassing to
+  // work with in some programming languages but we hope the performance
+  // improvements make up for it.
+  repeated int32 range = 1;
+  // (optional) The symbol that appears at this position. See
+  // `SymbolInformation.symbol` for how to format symbols as strings.
+  string symbol = 2;
+  // (optional) Bitset containing `SymbolRole`s in this occurrence.
+  // See `SymbolRole`'s documentation for how to read and write this field.
+  int32 symbol_roles = 3;
+  // (optional) CommonMark-formatted documentation for this specific range. If
+  // empty, the `Symbol.documentation` field is used instead. One example
+  // where this field might be useful is when the symbol represents a generic
+  // function (with abstract type parameters such as `List<T>`) and at this
+  // occurrence we know the exact values (such as `List<String>`).
+  //
+  // This field can also be used for dynamically or gradually typed languages,
+  // which commonly allow for type-changing assignment.
+  repeated string override_documentation = 4;
+  // (optional) What syntax highlighting class should be used for this range?
+  SyntaxKind syntax_kind = 5;
+  // (optional) Diagnostics that have been reported for this specific range.
+  repeated Diagnostic diagnostics = 6;
+  // (optional) Using the same encoding as the sibling `range` field, half-open
+  // source range of the nearest non-trivial enclosing AST node. This range must
+  // enclose the `range` field. Example applications that make use of the
+  // enclosing_range field:
+  //
+  // - Call hierarchies: to determine what symbols are references from the body
+  //   of a function
+  // - Symbol outline: to display breadcrumbs from the cursor position to the
+  //   root of the file
+  // - Expand selection: to select the nearest enclosing AST node.
+  // - Highlight range: to indicate the AST expression that is associated with a
+  //   hover popover
+  //
+  // For definition occurrences, the enclosing range should indicate the
+  // start/end bounds of the entire definition AST node, including
+  // documentation.
+  // ```
+  // const n = 3
+  //       ^ range
+  // ^^^^^^^^^^^ enclosing_range
+  //
+  // /** Parses the string into something */
+  // ^ enclosing_range start --------------------------------------|
+  // function parse(input string): string {                        |
+  //          ^^^^^ range                                          |
+  //     return input.slice(n)                                     |
+  // }                                                             |
+  // ^ enclosing_range end <---------------------------------------|
+  // ```
+  //
+  // Any attributes/decorators/attached macros should also be part of the
+  // enclosing range.
+  //
+  // ```python
+  // @cache
+  // ^ enclosing_range start---------------------|
+  // def factorial(n):                           |
+  //     return n * factorial(n-1) if n else 1   |
+  // < enclosing_range end-----------------------|
+  //
+  // ```
+  //
+  // For reference occurrences, the enclosing range should indicate the start/end
+  // bounds of the parent expression.
+  // ```
+  // const a = a.b
+  //             ^ range
+  //           ^^^ enclosing_range
+  // const b = a.b(41).f(42).g(43)
+  //                   ^ range
+  //           ^^^^^^^^^^^^^ enclosing_range
+  // ```
+  repeated int32 enclosing_range = 7;
+}
+
+// Represents a diagnostic, such as a compiler error or warning, which should be
+// reported for a document.
+message Diagnostic {
+  // Should this diagnostic be reported as an error, warning, info, or hint?
+  Severity severity = 1;
+  // (optional) Code of this diagnostic, which might appear in the user interface.
+  string code = 2;
+  // Message of this diagnostic.
+  string message = 3;
+  // (optional) Human-readable string describing the source of this diagnostic, e.g.
+  // 'typescript' or 'super lint'.
+  string source = 4;
+  repeated DiagnosticTag tags = 5;
+}
+
+enum Severity {
+  UnspecifiedSeverity = 0;
+  Error = 1;
+  Warning = 2;
+  Information = 3;
+  Hint = 4;
+}
+
+enum DiagnosticTag {
+  UnspecifiedDiagnosticTag = 0;
+  Unnecessary = 1;
+  Deprecated = 2;
+}
+
+// Language standardises names of common programming languages that can be used
+// for the `Document.language` field. The primary purpose of this enum is to
+// prevent a situation where we have a single programming language ends up with
+// multiple string representations. For example, the C++ language uses the name
+// "CPP" in this enum and other names such as "cpp" are incompatible.
+// Feel free to send a pull-request to add missing programming languages.
+enum Language {
+  UnspecifiedLanguage = 0;
+  ABAP = 60;
+  Apex = 96;
+  APL = 49;
+  Ada = 39;
+  Agda = 45;
+  AsciiDoc = 86;
+  Assembly = 58;
+  Awk = 66;
+  Bat = 68;
+  BibTeX = 81;
+  C = 34;
+  COBOL = 59;
+  CPP = 35; // C++ (the name "CPP" was chosen for consistency with LSP)
+  CSS = 26;
+  CSharp = 1;
+  Clojure = 8;
+  Coffeescript = 21;
+  CommonLisp = 9;
+  Coq = 47;
+  CUDA = 97;
+  Dart = 3;
+  Delphi = 57;
+  Diff = 88;
+  Dockerfile = 80;
+  Dyalog = 50;
+  Elixir = 17;
+  Erlang = 18;
+  FSharp = 42;
+  Fish = 65;
+  Flow = 24;
+  Fortran = 56;
+  Git_Commit = 91;
+  Git_Config = 89;
+  Git_Rebase = 92;
+  Go = 33;
+  GraphQL = 98;
+  Groovy = 7;
+  HTML = 30;
+  Hack = 20;
+  Handlebars = 90;
+  Haskell = 44;
+  Idris = 46;
+  Ini = 72;
+  J = 51;
+  JSON = 75;
+  Java = 6;
+  JavaScript = 22;
+  JavaScriptReact = 93;
+  Jsonnet = 76;
+  Julia = 55;
+  Justfile = 109;
+  Kotlin = 4;
+  LaTeX = 83;
+  Lean = 48;
+  Less = 27;
+  Lua = 12;
+  Luau = 108;
+  Makefile = 79;
+  Markdown = 84;
+  Matlab = 52;
+  Nickel = 110; // https://nickel-lang.org/
+  Nix = 77;
+  OCaml = 41;
+  Objective_C = 36;
+  Objective_CPP = 37;
+  Pascal = 99;
+  PHP = 19;
+  PLSQL = 70;
+  Perl = 13;
+  PowerShell = 67;
+  Prolog = 71;
+  Protobuf = 100;
+  Python = 15;
+  R = 54;
+  Racket = 11;
+  Raku = 14;
+  Razor = 62;
+  Repro = 102; // Internal language for testing SCIP
+  ReST = 85;
+  Ruby = 16;
+  Rust = 40;
+  SAS = 61;
+  SCSS = 29;
+  SML = 43;
+  SQL = 69;
+  Sass = 28;
+  Scala = 5;
+  Scheme = 10;
+  ShellScript = 64; // Bash
+  Skylark = 78;
+  Slang = 107;
+  Solidity = 95;
+  Svelte = 106;
+  Swift = 2;
+  Tcl = 101;
+  TOML = 73;
+  TeX = 82;
+  Thrift = 103;
+  TypeScript = 23;
+  TypeScriptReact = 94;
+  Verilog = 104;
+  VHDL = 105;
+  VisualBasic = 63;
+  Vue = 25;
+  Wolfram = 53;
+  XML = 31;
+  XSL = 32;
+  YAML = 74;
+  Zig = 38;
+  // NextLanguage = 111;
+  // Steps add a new language:
+  // 1. Copy-paste the "NextLanguage = N" line above
+  // 2. Increment "NextLanguage = N" to "NextLanguage = N+1"
+  // 3. Replace "NextLanguage = N" with the name of the new language.
+  // 4. Move the new language to the correct line above using alphabetical order
+  // 5. (optional) Add a brief comment behind the language if the name is not self-explanatory
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     "baseUrl": "."
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "test", "src/viewer/**/*", "!src/viewer/**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "test", "src/viewer/**/*", "!src/viewer/**/*.test.ts", "src/core/scip/fixtures/**/*"]
 }


### PR DESCRIPTION
Implements [docs/specs/openlore-spec-04-scip-export.md](docs/specs/openlore-spec-04-scip-export.md): a one-way SCIP export so OpenLore is consumable by the wider symbolic-code-graph ecosystem (Sourcegraph code nav, GitHub stack graphs, Glean importers, any SCIP-aware tool). The SQLite/JSON graph remains canonical.

## What's in it
- `openlore export scip [--out <path>] [--project-root <path>] [--include <glob>...] [--exclude <glob>...]`
- `src/core/scip/exportScip(graph, options): Buffer` — functions → SCIP symbols (stable monikers), call edges → `Definition`/`ReadAccess` occurrences, one `Document` per file. Deterministic ordering → byte-identical re-runs.
- Vendored, pinned SCIP proto loaded at runtime; `docs/scip-export.md` + README "Interop" section.

## Upstream SCIP spec & pinned proto
- Spec / schema: https://github.com/sourcegraph/scip/blob/main/scip.proto
- Vendored verbatim at `src/core/scip/vendor/scip.proto`, pinned to `refs/heads/main` fetched 2026-05-27 (33,659 bytes). Re-fetch + bump the header date to update.

## New runtime dependency: `protobufjs`
- Used to parse the vendored `.proto` and serialize the index. **Pure JS, zero native build** (`gypfile: false`, no compilation in install/postinstall; only runtime dep is `long`). ~3.4 MB installed.
- Chosen over vendoring a generated `pb.js` to keep the vendored artifact human-readable and trivially re-fetchable. The pre-existing `brace-expansion` Dependabot alert is unrelated (transitive via `glob`/`eslint`), not introduced here.

## `wc -l` of generated output (this repo's graph, as a stand-in for a large fixture)
```
$ openlore export scip --out index.scip
documents: 150  symbols: 1193  occurrences: 2750  definitions: 1193
$ wc -l index.scip
1546 index.scip      # binary protobuf, 410,886 bytes
```
The tiny-repo unit fixture locks exact counts: 3 documents / 4 symbols / 8 occurrences / 4 definitions.

## Scope notes / follow-ups
- `TODO(spec-04-followup): column ranges in analyzer` — the analyzer records lines but not columns; occurrences are zero-width at column 0 with a one-time warning. If a node lacks even a defining line, the export **fails loudly** rather than emitting a malformed index.
- `TODO(spec-04-followup): scip import` — export-only shipped, per the spec.
- Tests live under `src/core/scip/` (co-located) because `test/` is gitignored in this repo; the spec's suggested `test/core/scip/` path would never run in CI.

## Verification
`npm run lint`, `npm run typecheck`, `npm run test:run` (2789 pass), `npm run build` (proto copied to dist; built CLI verified) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)