### PR TITLE
qa: harden new-language support + release prep (v2.0.4)

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -66,8 +66,11 @@ no native build compatible with the pinned host `tree-sitter` binding (they ship
 only ABI-15 builds), so they load a **portable WASM grammar** (`tree-sitter-wasms`)
 through `web-tree-sitter` instead — pure JS/WASM, no native compile, works on
 every platform. The graph output is identical regardless of backend; the choice
-is invisible to every downstream tool. If even the WASM backend is unavailable,
-both still degrade gracefully (detection + search indexing, no graph).
+is invisible to every downstream tool. Each WASM grammar loads in its own module
+instance, so a repo using both Lua and Dart graphs both correctly (a shared
+web-tree-sitter runtime would otherwise let one grammar corrupt the other). If
+even the WASM backend is unavailable, both still degrade gracefully (detection +
+search indexing, no graph).
 
 ## Out of scope
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.1",
@@ -39,9 +39,9 @@
         "tree-sitter-rust": "^0.24.0",
         "tree-sitter-scala": "^0.24.0",
         "tree-sitter-typescript": "^0.23.2",
-        "tree-sitter-wasms": "^0.1.13",
+        "tree-sitter-wasms": "0.1.13",
         "vite": "^7.1.3",
-        "web-tree-sitter": "^0.25.0",
+        "web-tree-sitter": "0.25.0",
         "yaml": "^2.6.1"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Reverse-engineer OpenSpec specifications from existing codebases",
   "type": "module",
   "main": "dist/api/index.js",
@@ -112,9 +112,9 @@
     "tree-sitter-rust": "^0.24.0",
     "tree-sitter-scala": "^0.24.0",
     "tree-sitter-typescript": "^0.23.2",
-    "tree-sitter-wasms": "^0.1.13",
+    "tree-sitter-wasms": "0.1.13",
     "vite": "^7.1.3",
-    "web-tree-sitter": "^0.25.0",
+    "web-tree-sitter": "0.25.0",
     "yaml": "^2.6.1"
   },
   "optionalDependencies": {

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -1519,7 +1519,6 @@ interface GrammarHandle {
 }
 
 const _grammarHandleCache = new Map<string, GrammarHandle | null>();
-let _wtsInit: Promise<unknown> | undefined;
 
 function warnUnavailable(language: string, err: unknown): null {
   if (!_warnedUnavailable.has(language)) {
@@ -1583,16 +1582,21 @@ async function loadWasmGrammarSoft(
     // Load the wasm bytes ourselves and hand web-tree-sitter a Uint8Array, so it
     // never does its own `require("fs/promises")` (which breaks under ESM/vitest).
     const wasmBytes = new Uint8Array(await readFile(wasmPath));
-    const TS = (await import('web-tree-sitter')) as unknown as Record<string, unknown>;
+    // CRITICAL: each WASM grammar gets its OWN web-tree-sitter module instance.
+    // web-tree-sitter is a singleton emscripten module with a shared heap; loading
+    // two different grammars into one instance corrupts parsing (a Dart parse
+    // silently breaks subsequent Lua parses). Busting the require cache before each
+    // grammar yields an isolated runtime + heap per grammar, so they never interfere.
+    for (const k of Object.keys(req.cache)) {
+      if (k.includes('web-tree-sitter')) delete req.cache[k];
+    }
+    const TS = req('web-tree-sitter') as Record<string, unknown>;
     const ParserCtor = (TS.default ?? TS.Parser ?? TS) as {
       new (): { setLanguage(l: unknown): void; parse(s: string): { rootNode: TsNodeLike } };
       init?: () => Promise<void>;
       Language?: { load(p: Uint8Array): Promise<{ query(src: string): { matches(root: TsNodeLike): TsMatch[] } }> };
     };
-    if (typeof ParserCtor.init === 'function') {
-      _wtsInit ??= ParserCtor.init();
-      await _wtsInit;
-    }
+    if (typeof ParserCtor.init === 'function') await ParserCtor.init();
     const LanguageNs = (TS.Language ?? ParserCtor.Language) as { load(p: Uint8Array): Promise<{ query(src: string): { matches(root: TsNodeLike): TsMatch[] } }> };
     const lang = await LanguageNs.load(wasmBytes) as {
       query(src: string): { matches(root: TsNodeLike): TsMatch[]; delete?: () => void };
@@ -1848,14 +1852,15 @@ const QUERY_LANG_SPECS: Record<string, QueryLangSpec> = {
   'Scala': SCALA_SPEC, 'Lua': LUA_SPEC, 'Bash': BASH_SPEC,
 };
 
-// ── Dart (via shipped WASM + web-tree-sitter) ────────────────────────────────
+// ── Dart (via portable WASM + web-tree-sitter) ───────────────────────────────
 //
-// No ABI-compatible native tree-sitter-dart build exists for the pinned host
-// binding, but the grammar ships a portable `.wasm`. We load it through
-// web-tree-sitter (ABI-agnostic, pure JS/WASM, builds on every platform) so
-// Dart graphs everywhere. Dart's grammar places the `function_body` as a
-// SIBLING of `function_signature` (not a child), so a generic query extractor
-// would attribute no calls — hence a custom walk that spans signature+body.
+// No ABI-compatible native Dart grammar exists for the pinned host binding, so
+// Dart loads the portable `tree-sitter-wasms` WASM through web-tree-sitter
+// (ABI-agnostic, pure JS/WASM, builds on every platform) — each WASM grammar in
+// its own module instance (see loadWasmGrammarSoft). Dart's grammar places the
+// `function_body` as a SIBLING of `function_signature` (not a child), so a
+// generic query extractor would attribute no calls — hence a custom walk that
+// spans signature+body.
 
 const DART_CLASS_TYPES = new Set(['class_definition', 'mixin_declaration', 'extension_declaration', 'enum_declaration']);
 

--- a/src/core/analyzer/wasm-multigrammar.test.ts
+++ b/src/core/analyzer/wasm-multigrammar.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { CallGraphBuilder, serializeCallGraph, type SerializedCallGraph } from './call-graph.js';
+
+const dir = join(__dirname, 'fixtures');
+const load = (rel: string, language: string) => ({ path: rel, content: readFileSync(join(dir, rel), 'utf-8'), language });
+const fnNames = (g: SerializedCallGraph, lang: string) => g.nodes.filter(n => n.language === lang && !n.isExternal).map(n => n.name).sort();
+const edge = (g: SerializedCallGraph, caller: string, callee: string) => {
+  const c = g.nodes.find(n => n.name === caller); const d = g.nodes.find(n => n.name === callee && !n.isExternal);
+  return !!c && !!d && g.edges.some(e => e.callerId === c.id && e.calleeId === d.id);
+};
+
+// Regression: two WASM-backed grammars (Dart + Lua) in ONE build() must each
+// produce a COMPLETE graph. web-tree-sitter is a singleton emscripten module
+// with a shared heap; loading both grammars into one instance silently corrupts
+// the second grammar's parses (Lua lost half its functions). Each grammar must
+// load in its own module instance. Order both ways to be safe.
+describe('spec-08 WASM multi-grammar isolation (Dart + Lua together)', () => {
+  it('both Dart and Lua graph fully when analyzed in the same run', async () => {
+    const g = serializeCallGraph(await new CallGraphBuilder().build([
+      load('dart/app.dart', 'Dart'),
+      load('lua/app.lua', 'Lua'),
+    ]));
+    if (fnNames(g, 'Dart').length === 0 && fnNames(g, 'Lua').length === 0) return; // WASM unavailable
+    expect(fnNames(g, 'Dart')).toEqual(['helper', 'main', 'run']);
+    expect(fnNames(g, 'Lua')).toEqual(['boot', 'helper', 'run']);
+    expect(edge(g, 'run', 'helper')).toBe(true); // resolves within each
+  });
+
+  it('is order-independent (Lua before Dart)', async () => {
+    const g = serializeCallGraph(await new CallGraphBuilder().build([
+      load('lua/app.lua', 'Lua'),
+      load('dart/app.dart', 'Dart'),
+    ]));
+    if (fnNames(g, 'Dart').length === 0 && fnNames(g, 'Lua').length === 0) return;
+    expect(fnNames(g, 'Lua')).toEqual(['boot', 'helper', 'run']);
+    expect(fnNames(g, 'Dart')).toEqual(['helper', 'main', 'run']);
+  });
+});


### PR DESCRIPTION
## Summary

QA / release-readiness pass over the new-language work (spec-07 Infrastructure-as-Code and spec-08 general-purpose languages) ahead of tagging a release.

**Production bug found via real end-to-end testing (not caught by unit tests):**
Running the actual `openlore analyze` CLI on a polyglot repo revealed that
`web-tree-sitter` is a **singleton emscripten module with a shared heap** — loading
both WASM-backed grammars (Dart + Lua) into one instance silently **corrupted the
second grammar's parses**. A polyglot Lua+Dart repo lost half its Lua functions
(2 → 1), producing a confidently-wrong graph.

**Fix:** load each WASM grammar in its **own module instance** (bust the require
cache per grammar) → isolated runtime + heap per grammar, so they never interfere.
Verified end-to-end: all ten new languages now graph fully and deterministically
in a single analyze run, and `search_code`/`orient` surface them via the MCP layer.

## Changes
- Per-grammar WASM module isolation in `loadWasmGrammarSoft` (the fix).
- New regression test `wasm-multigrammar.test.ts` (Dart + Lua in one build, both orders).
- Pin ABI-sensitive deps exactly: `web-tree-sitter@0.25.0`, `tree-sitter-wasms@0.1.13` (a fresh install can't drift the WASM ABI match).
- Version 2.0.3 → 2.0.4.
- Docs: document per-grammar WASM isolation in `docs/languages.md`; refresh Dart comment.

## Verification
- [x] lint / typecheck / **2907 tests** / build all green
- [x] Real CLI `openlore analyze` on a 10-language polyglot repo: every language produces complete nodes + edges
- [x] `search_code` (spans 8 languages, language filter works) and `orient` verified via MCP handlers
- [x] Self-analyze on the OpenLore repo itself (1517 fns / 1370 edges) runs clean
- [x] Determinism: byte-identical graph across two full analyze runs (incl. WASM path)
- [x] README languages section + "45 MCP tools" claim confirmed accurate
- [x] Grammar deps confirmed runtime `dependencies` (ship to consumers); release workflow on node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)