### PR TITLE
fix: ship orient CLI subcommand + build BM25 index under --no-embed

### DIFF
--- a/.claude/commands/first-run-hardening.md
+++ b/.claude/commands/first-run-hardening.md
@@ -1,0 +1,84 @@
+---
+description: Find and fix bugs that break OpenLore's first-run experience by dogfooding the real install flow on a clean repo (the method that found the orient-CLI, --no-embed, watcher-EMFILE, and install-index bugs).
+---
+
+# OpenLore first-run hardening pass
+
+You are working in the OpenLore repo, a published npm CLI (`openlore`) that gives coding
+agents persistent architectural memory via static analysis + an MCP server. Your job: find
+and fix the bugs that break a NEW USER's first-run experience — the way earlier passes found
+"unknown command 'orient'", "--no-embed kills BM25", "watcher EMFILE on target/", and
+"install never builds the index".
+
+If the user named a target repo or a specific area in their message ($ARGUMENTS), focus there;
+otherwise pick a clean repo as described below.
+
+## Method — dogfood, don't just unit-test
+
+1. BUILD FIRST so you test current code, not the published version:
+   `npm run build` → drive `node dist/cli/index.js`, never bare `openlore`/`npx openlore`
+   (those resolve the OLD published version). When comparing to published behavior, do it
+   explicitly with `npx --yes openlore@latest` and label it.
+
+2. Pick a CLEAN sibling repo under the parent of this repo that does NOT already have openlore
+   (check: no `.openlore`, no `openspec/`, no OpenLore block in `CLAUDE.md`). Prefer variety
+   across runs — a Rust repo (huge `target/`), a big monorepo, a Python repo, a repo with a
+   pre-existing `.claude/settings.json`. proxilion (Rust) and vaulytica (TS) are known-good.
+
+3. Run the REAL first-run flow as a user would, end to end, checking exit codes AND actual
+   output of each step:
+     openlore install                 # the one-command path
+     # then simulate the first agent session: run the SessionStart hook command verbatim
+     # from .claude/settings.json, plus a real `orient --task` query
+   Also exercise: init → analyze → analyze --no-embed → analyze --force →
+   orient (no task / with task / bad --limit) → install --no-analyze → install --dry-run →
+   install --uninstall → mcp server over stdio (initialize → tools/call orient).
+
+4. Stress the edges that break in the field, not just happy paths:
+   - Large/non-TS repos (build dirs: target/, node_modules/, dist/, .venv/, vendor/) → EMFILE,
+     ENOSPC, multi-minute hangs, watching the wrong tree.
+   - `--json` output must be PURE parseable JSON on stdout; all diagnostics/logs go to stderr.
+     (Pipe `2>/dev/null` and JSON.parse it.)
+   - Idempotency / re-runs: running install or analyze twice must be a clean no-op, not a
+     duplicate or a clobber.
+   - Pre-existing user files (.claude/settings.json, CLAUDE.md, .gitignore): MERGE, never
+     clobber. Verify with a repo that already has them.
+   - process.cwd() vs explicit-dir handling; commander singletons leaking option state
+     between parseAsync calls in tests.
+   - Wrapper/skill paths (orient.sh, orient.ps1, orient-via-mcp.mjs) and graceful degradation
+     against OLDER openlore versions that lack new flags.
+
+## Rules
+
+- ROOT-CAUSE every bug before fixing. Reproduce with a concrete command and capture real
+  output. Distinguish "code bug" from "test pollution" (e.g. commander option-state leaking
+  across parseAsync — fix the test) from "environment quirk". Don't theorize when you can run it.
+- Prefer ROBUST fixes over patches. (The watcher fix matched ignored dirs by root-relative
+  path SEGMENT so the dir itself is pruned — not a bigger substring list that still FD-storms.)
+- Match existing code style; surgical changes only; no speculative features.
+- Every fix gets a regression test that FAILS before and PASSES after. Where it matters, use a
+  real-dependency test (e.g. real chokidar on a real temp tree), not just a mock.
+- Treat other people's repos as READ-ONLY fixtures: after each dogfood run, remove ALL openlore
+  artifacts (.openlore, openspec/, CLAUDE.md, ARCHITECTURE.md) and `git checkout` any modified
+  .gitignore / settings.json. Verify the repo is clean (`git status`) before moving on. Never
+  commit to a test repo.
+- Verify honestly: run `npm run typecheck` and `npm run test:run` and report the REAL counts.
+  Never fabricate a passing count. If something's red, say so with the output.
+
+## Git / PR discipline
+
+- NEVER commit to or push `main`. Work on a feature branch; confirm with
+  `git rev-list --left-right --count origin/main...main` (want `0 0`) before and after.
+- If the user points you at an open clean-up PR, commit there; otherwise create a feature
+  branch + PR against main with `gh pr create`. Use `--force-with-lease` for a stale remote
+  branch, and verify `gh pr view <n> --json baseRefName` is `main`.
+- Commit messages: accurate, no fabricated test counts; end with the Co-Authored-By trailer.
+- Branch pruning: only delete branches already merged into origin/main (verify with
+  `git branch -r --merged origin/main`); never touch cross-repo PR branches (forks — check
+  `gh pr view <n> --json isCrossRepository`).
+
+## Deliverable
+
+For each issue: a one-line repro, the root cause, the fix (file:line), and the regression
+test. End with: full suite result (real numbers), what you verified by dogfooding on which
+repo, and the PR link. Call out anything that ships to users only on the next npm publish.

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ Thumbs.db
 *.swo
 *~
 #*#
-.claude
+.claude/*
+!.claude/commands
 .openlore/
 .mcp.json
 .cursor/

--- a/README.md
+++ b/README.md
@@ -58,18 +58,27 @@ Traditional coding agents reconstruct architecture from repeated file reads ever
 
 ## 5-Minute Quickstart
 
-> **Minimum to see value — no API key needed:**
+> **One command, no API key needed:**
 
 ```bash
 npm install -g openlore
 cd /path/to/your-project
 
-openlore analyze          # build call graph, clusters, CODEBASE.md
-openlore install          # auto-configure your agent (Claude Code, Cursor, …)
-openlore mcp              # start MCP server
+openlore install          # detect your agent, wire it up, AND build the index
 ```
 
-`openlore install` auto-detects which agent surfaces are present (Claude Code, Cursor, Cline, Continue, AGENTS.md) and wires each one to call `orient()` automatically — no manual `CLAUDE.md` editing needed. See [docs/install.md](docs/install.md).
+That single command:
+
+1. **Auto-detects** which agent surfaces are present (Claude Code, Cursor, Cline, Continue, AGENTS.md) and wires each one to call `orient()` — no manual `CLAUDE.md` editing.
+2. **Registers the MCP server** so it starts automatically when your agent launches (you don't run `openlore mcp` yourself).
+3. **Builds the index** (`init` + `analyze` → a keyword/BM25 graph, no network needed) so `orient()` returns real results in your very first session — no separate `analyze` step.
+
+```bash
+openlore install --no-analyze   # wire surfaces only; build the index later
+openlore install --dry-run      # preview every change without writing
+```
+
+See [docs/install.md](docs/install.md). The MCP server keeps the index fresh as you edit (file watcher on by default — large build dirs like `target/`, `node_modules/`, `dist/` are pruned automatically; disable entirely with `openlore mcp --no-watch-auto`).
 
 Then ask your agent: **`orient("add a new payment method")`**
 
@@ -329,7 +338,7 @@ The manifest captures the public API surface, HTTP routes, stats, dependencies, 
 
 ## Known Limitations
 
-- **Incremental call graph updates are depth-1 only**: `--watch-auto` re-indexes signatures and edges on save for the changed file and its direct callers. Transitive callers (A→B→C, C changes, A stays stale) are only refreshed by the next `analyze --force`. For hub files with 100+ callerFiles, re-parse may take several seconds.
+- **Incremental call graph updates are depth-1 only**: the MCP file watcher (`--watch-auto`, on by default) re-indexes signatures and edges on save for the changed file and its direct callers. Transitive callers (A→B→C, C changes, A stays stale) are only refreshed by the next `analyze --force`. For hub files with 100+ callerFiles, re-parse may take several seconds. The watcher prunes build/dependency directories (`target/`, `node_modules/`, `dist/`, `.venv/`, `vendor/`, …) so it stays light even on large repos; turn it off entirely with `openlore mcp --no-watch-auto`.
 - **Static analysis only**: dynamic dispatch, runtime metaprogramming, and `eval`-based patterns are not captured in the call graph.
 - **LLM spec quality varies**: generated specs reflect the model's understanding. Review sections covering complex business logic before treating them as authoritative.
 - **Embedding is optional**: plain `openlore analyze` (no `--embed`, no `EMBED_*`) builds a keyword (BM25) search index out of the box, so `orient`, `search_code`, `suggest_insertion_points`, and `search_specs` work immediately. Configure an embedding endpoint (`EMBED_BASE_URL`/`EMBED_MODEL` or an `embedding` block in `.openlore/config.json`) to upgrade to hybrid dense+BM25 search, which is more accurate for semantic queries.
@@ -361,7 +370,7 @@ The manifest captures the public API surface, HTTP routes, stats, dependencies, 
 ```bash
 npm install
 npm run build
-npm test          # 2660+ unit tests
+npm test          # 2900+ unit tests
 npm run typecheck
 ```
 

--- a/skills/openlore-orient/README.md
+++ b/skills/openlore-orient/README.md
@@ -45,7 +45,7 @@ Once OpenLore spec-01's `openlore install --agent claude-code` is shipped on npm
 
 ## Known limitations
 
-The `openlore orient --json --task "..."` CLI subcommand is not yet shipped on npm — `orient` is currently exposed only as an MCP tool. The shell wrappers transparently fall back to driving `openlore mcp` over stdio JSON-RPC via the bundled [`scripts/orient-via-mcp.mjs`](scripts/orient-via-mcp.mjs) helper, so they work today. A follow-up spec will add the CLI subcommand; once it ships, the wrappers will pick it up automatically and the MCP fallback becomes a no-op.
+The `openlore orient --json --task "..."` CLI subcommand is shipped, and `orient` is also exposed as an MCP tool. The shell wrappers prefer the CLI subcommand and transparently fall back to driving `openlore mcp` over stdio JSON-RPC via the bundled [`scripts/orient-via-mcp.mjs`](scripts/orient-via-mcp.mjs) helper on older openlore versions that predate the subcommand.
 
 See `TODO(spec-02-followup)` markers in `SKILL.md` and the wrappers.
 

--- a/skills/openlore-orient/SKILL.md
+++ b/skills/openlore-orient/SKILL.md
@@ -35,7 +35,7 @@ bash scripts/orient.sh "<task description>"
 
 (On Windows: `powershell -File scripts/orient.ps1 "<task description>"`)
 
-The wrapper tries the direct CLI subcommand first (`npx --yes openlore orient --json --task "<task>"`) and falls back to driving the `openlore mcp` server over stdio JSON-RPC via the sibling `orient-via-mcp.mjs` helper when the CLI subcommand isn't shipped yet. Either path produces real orient JSON on stdout. Parse these arrays from the result:
+The wrapper tries the direct CLI subcommand first (`npx --yes openlore orient --json --task "<task>"`) and falls back to driving the `openlore mcp` server over stdio JSON-RPC via the sibling `orient-via-mcp.mjs` helper on older openlore versions that predate the CLI subcommand. Either path produces real orient JSON on stdout. Parse these arrays from the result:
 
 - **`relevant_functions`** — top scored functions for the task, with file/line, role classification, and a short reason.
 - **`callers`** — depth-1 caller neighbourhood for each top function. This is where "who breaks if I change this" lives.
@@ -44,7 +44,7 @@ The wrapper tries the direct CLI subcommand first (`npx --yes openlore orient --
 
 Always start by reading **`spec_sections`**, then **`callers`**, then jump into source only at the **`insertion_points`** you actually plan to edit.
 
-> **TODO(spec-02-followup):** the `openlore orient` CLI subcommand (with `--task`) is not yet shipped on the npm package — the wrappers reach the `orient` tool through the MCP server as a fallback. A future spec will add the CLI subcommand and the wrappers will pick it up automatically.
+> **Note:** the `openlore orient --json --task` CLI subcommand is available, so the wrappers use it directly. The MCP fallback in the wrappers only kicks in on older openlore versions that predate the subcommand.
 
 ## What NOT to do
 

--- a/skills/openlore-orient/scripts/orient-via-mcp.mjs
+++ b/skills/openlore-orient/scripts/orient-via-mcp.mjs
@@ -11,7 +11,7 @@
  * prints the result, and exits.
  */
 
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { createInterface } from 'node:readline';
 
 const task = process.argv[2];
@@ -22,7 +22,25 @@ if (!task) {
   process.exit(2);
 }
 
-const child = spawn('npx', ['--yes', 'openlore', 'mcp'], {
+// This is a one-shot call (initialize → orient → exit), so the MCP server must
+// NOT start its file watcher: auto-watch recursively watches the whole repo —
+// including huge build dirs like Rust's target/ — and EMFILEs before we ever
+// get a response. Pass --no-watch-auto, but only if this openlore build
+// supports it: older versions error on unknown options. Detect via `mcp --help`.
+const mcpArgs = ['--yes', 'openlore', 'mcp'];
+try {
+  const help = spawnSync('npx', ['--yes', 'openlore', 'mcp', '--help'], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  if ((help.stdout ?? '').includes('--no-watch-auto')) {
+    mcpArgs.push('--no-watch-auto');
+  }
+} catch {
+  // If detection fails, fall through without the flag (safe default).
+}
+
+const child = spawn('npx', mcpArgs, {
   stdio: ['pipe', 'pipe', 'inherit'],
 });
 

--- a/skills/openlore-orient/scripts/orient.ps1
+++ b/skills/openlore-orient/scripts/orient.ps1
@@ -3,14 +3,10 @@
 #
 # Strategy (in order):
 #   1. `npx --yes openlore orient --json --task "<task>"` — preferred path,
-#      activates as soon as the orient CLI subcommand is shipped (TODO below).
+#      uses the orient CLI subcommand.
 #   2. Drive the existing `openlore mcp` server over stdio JSON-RPC via the
-#      sibling orient-via-mcp.mjs helper — works today against the current
-#      shipped surface.
-#
-# TODO(spec-02-followup): once the `openlore orient --json --task` CLI
-# subcommand lands on the npm package, path #2 becomes unnecessary. The
-# wrapper picks #1 automatically.
+#      sibling orient-via-mcp.mjs helper — fallback for older openlore versions
+#      that predate the CLI subcommand.
 
 param(
   [Parameter(Mandatory=$false, Position=0)]

--- a/skills/openlore-orient/scripts/orient.sh
+++ b/skills/openlore-orient/scripts/orient.sh
@@ -4,14 +4,10 @@
 #
 # Strategy (in order):
 #   1. `npx --yes openlore orient --json --task "<task>"` — preferred path,
-#      activates as soon as the orient CLI subcommand is shipped (TODO below).
+#      uses the orient CLI subcommand.
 #   2. Drive the existing `openlore mcp` server over stdio JSON-RPC via the
-#      sibling orient-via-mcp.mjs helper — works today against the current
-#      shipped surface.
-#
-# TODO(spec-02-followup): once the `openlore orient --json --task` CLI
-# subcommand lands on the npm package, path #2 becomes unnecessary. The
-# wrapper picks #1 automatically.
+#      sibling orient-via-mcp.mjs helper — fallback for older openlore versions
+#      that predate the CLI subcommand.
 set -eu
 TASK="${1:-}"
 if [ -z "$TASK" ]; then

--- a/src/cli/commands/analyze-no-embed.test.ts
+++ b/src/cli/commands/analyze-no-embed.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Regression test for the `--no-embed` flag.
+ *
+ * Bug: `analyze --no-embed` used to skip the entire index-building step, which
+ * meant no BM25 keyword index was written and orient() later failed with
+ * "No analysis found". `--no-embed` must build a keyword-only (BM25) index
+ * (null embedder), not skip indexing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Hoisted so the vi.mock factories below (which are hoisted to the top of the
+// module) can safely reference these spies.
+const { buildMock, fromEnvMock, fromConfigMock } = vi.hoisted(() => ({
+  buildMock: vi.fn(),
+  fromEnvMock: vi.fn(),
+  fromConfigMock: vi.fn(),
+}));
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    section: vi.fn(), info: vi.fn(), warning: vi.fn(), error: vi.fn(),
+    success: vi.fn(), discovery: vi.fn(), analysis: vi.fn(), blank: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    access:    vi.fn().mockResolvedValue(undefined),
+    stat:      vi.fn().mockResolvedValue({ mtime: new Date() }),
+    mkdir:     vi.fn().mockResolvedValue(undefined),
+    readFile:  vi.fn().mockResolvedValue('{}'),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// fileExists(false) → getAnalysisAge null (fresh analysis) AND spec indexing skipped.
+vi.mock('../../utils/command-helpers.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/command-helpers.js')>();
+  return {
+    ...actual,
+    fileExists: vi.fn().mockResolvedValue(false),
+    getAnalysisAge: vi.fn().mockResolvedValue(null),
+  };
+});
+
+vi.mock('../../core/analyzer/repository-mapper.js', () => ({
+  RepositoryMapper: vi.fn().mockImplementation(function (this: unknown) {
+    Object.assign(this as object, {
+      map: vi.fn().mockResolvedValue({
+        allFiles: [], highValueFiles: [], metadata: { projectName: 'proj' },
+        summary: { totalFiles: 1, analyzedFiles: 1, skippedFiles: 0, languages: [] },
+      }),
+    });
+  }),
+}));
+
+vi.mock('../../core/analyzer/dependency-graph.js', () => ({
+  DependencyGraphBuilder: vi.fn().mockImplementation(function (this: unknown) {
+    Object.assign(this as object, {
+      build: vi.fn().mockResolvedValue({
+        statistics: { nodeCount: 2, edgeCount: 1, clusterCount: 0, cycleCount: 0, avgDegree: 1 },
+      }),
+    });
+  }),
+}));
+
+// callGraph WITH nodes so runEmbedStep reaches VectorIndex.build.
+const CALL_GRAPH = {
+  nodes: [{ id: 'a.ts::f', name: 'f', filePath: 'a.ts', line: 1, kind: 'function', calls: [] }],
+  hubFunctions: [], entryPoints: [],
+  stats: { totalNodes: 1, totalEdges: 0 },
+};
+
+vi.mock('../../core/analyzer/artifact-generator.js', () => ({
+  AnalysisArtifactGenerator: vi.fn().mockImplementation(function (this: unknown) {
+    Object.assign(this as object, {
+      generateAndSave: vi.fn().mockResolvedValue({
+        repoStructure: {
+          architecture: { pattern: 'unknown' }, domains: [], uiComponents: [],
+          schemas: [], routeInventory: { total: 0, byMethod: {}, byFramework: {}, routes: [] },
+          middleware: [], envVars: [],
+        },
+        llmContext: { callGraph: CALL_GRAPH, signatures: [] },
+      }),
+    });
+  }),
+  repoStructureToRepoMap: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('../../core/analyzer/architecture-writer.js', () => ({
+  buildArchitectureOverview: vi.fn().mockReturnValue({}),
+  writeArchitectureMd: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../core/analyzer/codebase-digest.js', () => ({
+  generateCodebaseDigest: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../../core/analyzer/ui-component-extractor.js', () => ({ extractUIComponents: vi.fn().mockResolvedValue([]) }));
+vi.mock('../../core/analyzer/schema-extractor.js', () => ({ extractSchemas: vi.fn().mockResolvedValue([]) }));
+vi.mock('../../core/analyzer/http-route-parser.js', () => ({
+  buildRouteInventory: vi.fn().mockResolvedValue({ total: 0, byMethod: {}, byFramework: {}, routes: [] }),
+  extractAllHttpEdges: vi.fn().mockResolvedValue({ calls: [], routes: [], edges: [] }),
+}));
+vi.mock('../../core/analyzer/middleware-extractor.js', () => ({ extractMiddleware: vi.fn().mockResolvedValue([]) }));
+vi.mock('../../core/analyzer/env-extractor.js', () => ({ extractEnvVars: vi.fn().mockResolvedValue([]) }));
+vi.mock('../../core/analyzer/ai-config-generator.js', () => ({
+  generateAiConfigs: vi.fn().mockResolvedValue([]), AI_TOOL_TARGETS: [],
+}));
+
+vi.mock('../../core/services/config-manager.js', () => ({ readOpenLoreConfig: vi.fn() }));
+
+vi.mock('../../core/analyzer/vector-index.js', () => ({
+  VectorIndex: { build: buildMock, exists: vi.fn().mockReturnValue(false) },
+}));
+
+vi.mock('../../core/analyzer/embedding-service.js', () => ({
+  EmbeddingService: { fromEnv: fromEnvMock, fromConfig: fromConfigMock },
+}));
+
+vi.mock('../../core/analyzer/spec-vector-index.js', () => ({
+  SpecVectorIndex: { build: vi.fn().mockResolvedValue({ recordCount: 0, hasEmbeddings: false }), exists: vi.fn().mockReturnValue(false) },
+}));
+
+import { analyzeCommand } from './analyze.js';
+
+const FAKE_CONFIG = {
+  version: '1.0.0', projectType: 'nodejs' as const, openspecPath: './openspec',
+  analysis: { maxFiles: 100000, includePatterns: [], excludePatterns: [] },
+  generation: { provider: 'openai' as const, model: 'gpt-4', domains: 'auto' as const },
+  createdAt: new Date().toISOString(), lastRun: null,
+};
+
+describe('analyze --no-embed builds a keyword (BM25) index', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    buildMock.mockReset().mockResolvedValue({ hasEmbeddings: false, total: 1, reused: 0, embedded: 0 });
+    fromEnvMock.mockReset().mockImplementation(() => { throw new Error('no embedder'); });
+    fromConfigMock.mockReset().mockReturnValue(null);
+    const cfgMod = await import('../../core/services/config-manager.js');
+    vi.mocked(cfgMod.readOpenLoreConfig).mockResolvedValue(FAKE_CONFIG);
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/fake/root');
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    process.exitCode = undefined;
+    // analyzeCommand is a module-level singleton; commander retains --embed
+    // between parseAsync() calls, so a prior --no-embed test would leave
+    // embed=false and pollute the default-path test. Reset to the declared
+    // default (true).
+    analyzeCommand.setOptionValue('embed', true);
+  });
+
+  afterEach(() => {
+    cwdSpy.mockRestore();
+    consoleSpy.mockRestore();
+    process.exitCode = undefined;
+  });
+
+  it('still calls VectorIndex.build (does NOT skip indexing) with --no-embed', async () => {
+    await analyzeCommand.parseAsync(['--no-embed'], { from: 'user' });
+    expect(buildMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('builds with a null embedder under --no-embed (keyword-only, no embedding attempt)', async () => {
+    await analyzeCommand.parseAsync(['--no-embed'], { from: 'user' });
+    // 6th positional arg (index 5) is the embedding service — must be null.
+    expect(buildMock.mock.calls[0][5]).toBeNull();
+    // --no-embed must not even attempt to resolve an embedder.
+    expect(fromEnvMock).not.toHaveBeenCalled();
+    expect(fromConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('also builds the index by default (no flag), falling back to BM25 when no embedder', async () => {
+    await analyzeCommand.parseAsync([], { from: 'user' });
+    expect(buildMock).toHaveBeenCalledTimes(1);
+    // Default path DOES attempt to resolve an embedder (then falls back).
+    expect(fromEnvMock).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -234,7 +234,7 @@ export const analyzeCommand = new Command('analyze')
   )
   .option(
     '--no-embed',
-    'Skip vector index build (overrides default --embed)'
+    'Build a keyword-only (BM25) index instead of semantic embeddings — orient still works, just without semantic search'
   )
   .option(
     '--reindex-specs',
@@ -260,7 +260,7 @@ Examples:
   $ openlore analyze --output ./my-analysis
                                      Custom output location
   $ openlore analyze --force         Force re-analysis
-  $ openlore analyze --no-embed      Skip vector index build
+  $ openlore analyze --no-embed      Build keyword-only (BM25) index, no embeddings
   $ openlore analyze --reindex-specs Re-index specs only (no full re-analysis)
 
 Output files:
@@ -315,13 +315,9 @@ After analysis, run 'openlore generate' to create OpenSpec files.
         return;
       }
 
-      // Auto-enable --embed when embedding is configured but flag wasn't passed explicitly.
-      if (!options.embed) {
-        const embedConfigured =
-          !!process.env.EMBED_BASE_URL ||
-          !!EmbeddingService.fromConfig(openloreConfig);
-        if (embedConfigured) opts.embed = true;
-      }
+      // The index is ALWAYS built (so orient works); opts.embed only controls
+      // whether we attempt semantic embeddings. --no-embed → keyword-only BM25.
+      const keywordOnly = options.embed === false;
 
       logger.info('Project', openloreConfig.projectType);
       logger.info('Output', opts.output);
@@ -371,10 +367,9 @@ After analysis, run 'openlore generate' to create OpenSpec files.
             logger.info('Architecture', repoStructure.architecture.pattern);
             logger.blank();
 
-            // If embed is requested, run the embed step (incremental: only re-embeds changed functions)
-            if (opts.embed) {
-              await runEmbedStep(rootPath, outputPath, openloreConfig, opts.force ?? false, null);
-            }
+            // Always (re)build the search index — incremental, so it only
+            // re-embeds changed functions. keywordOnly forces a BM25 index.
+            await runEmbedStep(rootPath, outputPath, openloreConfig, opts.force ?? false, null, keywordOnly);
 
             // If --ai-configs is requested, generate them even from cached analysis
             if (opts.aiConfigs) {
@@ -713,11 +708,11 @@ After analysis, run 'openlore generate' to create OpenSpec files.
       console.log('');
 
       // ========================================================================
-      // PHASE 5 (optional): BUILD VECTOR INDEX
+      // PHASE 5: BUILD SEARCH INDEX
       // ========================================================================
-      if (opts.embed) {
-        await runEmbedStep(rootPath, outputPath, openloreConfig, opts.force ?? false, result.artifacts.llmContext);
-      }
+      // Always build an index so orient() works. With embeddings when available,
+      // otherwise (or with --no-embed) a keyword-only BM25 index.
+      await runEmbedStep(rootPath, outputPath, openloreConfig, opts.force ?? false, result.artifacts.llmContext, keywordOnly);
 
       // Duration
       const totalDuration = Date.now() - startTime;
@@ -752,20 +747,24 @@ async function runEmbedStep(
   openloreConfig: OpenLoreConfig | null,
   force: boolean,
   llmContext: import('../../core/analyzer/artifact-generator.js').LLMContext | null,
+  keywordOnly = false,
 ): Promise<void> {
-  console.log('  Building semantic vector index...');
+  console.log(keywordOnly ? '  Building keyword (BM25) search index...' : '  Building semantic vector index...');
   try {
     const { EmbeddingService } = await import('../../core/analyzer/embedding-service.js');
     const { VectorIndex } = await import('../../core/analyzer/vector-index.js');
 
-    // Resolve embedding service — best-effort. When none is configured we build
-    // a keyword-only (BM25) index rather than aborting the whole index build.
+    // Resolve embedding service — best-effort. When --no-embed was passed
+    // (keywordOnly) or none is configured we build a keyword-only (BM25) index
+    // rather than aborting the whole index build.
     let embedSvc: InstanceType<typeof EmbeddingService> | null = null;
-    try {
-      embedSvc = EmbeddingService.fromEnv();
-    } catch {
-      const cfg = openloreConfig ?? await readOpenLoreConfig(rootPath);
-      embedSvc = cfg ? EmbeddingService.fromConfig(cfg) : null;
+    if (!keywordOnly) {
+      try {
+        embedSvc = EmbeddingService.fromEnv();
+      } catch {
+        const cfg = openloreConfig ?? await readOpenLoreConfig(rootPath);
+        embedSvc = cfg ? EmbeddingService.fromConfig(cfg) : null;
+      }
     }
 
     // Load context from disk if not provided (cache hit path)
@@ -827,7 +826,7 @@ async function runEmbedStep(
     }
 
     // Also index specs if they exist
-    await runSpecIndexing(rootPath, outputPath, openloreConfig);
+    await runSpecIndexing(rootPath, outputPath, openloreConfig, keywordOnly);
   } catch (embedErr) {
     console.log(`    ✗ Vector index failed: ${(embedErr as Error).message}`);
   }
@@ -846,20 +845,24 @@ async function runEmbedStep(
 async function runSpecIndexing(
   rootPath: string,
   outputPath: string,
-  openloreConfig: OpenLoreConfig | null
+  openloreConfig: OpenLoreConfig | null,
+  keywordOnly = false
 ): Promise<void> {
   const { join: pathJoin } = await import('node:path');
   const { SpecVectorIndex } = await import('../../core/analyzer/spec-vector-index.js');
   const { readOpenLoreConfig } = await import('../../core/services/config-manager.js');
 
-  // Resolve embedding service — best-effort. When none is configured we build
-  // a keyword-only (BM25) spec index rather than skipping spec search entirely.
+  // Resolve embedding service — best-effort. When --no-embed was passed
+  // (keywordOnly) or none is configured we build a keyword-only (BM25) spec
+  // index rather than skipping spec search entirely.
   let embedSvc: InstanceType<typeof EmbeddingService> | null = null;
-  try {
-    embedSvc = EmbeddingService.fromEnv();
-  } catch {
-    const cfg = openloreConfig ?? await readOpenLoreConfig(rootPath);
-    embedSvc = cfg ? EmbeddingService.fromConfig(cfg) : null;
+  if (!keywordOnly) {
+    try {
+      embedSvc = EmbeddingService.fromEnv();
+    } catch {
+      const cfg = openloreConfig ?? await readOpenLoreConfig(rootPath);
+      embedSvc = cfg ? EmbeddingService.fromConfig(cfg) : null;
+    }
   }
 
   // Locate specs directory

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1608,6 +1608,7 @@ export const mcpCommand = new Command('mcp')
   .description('Start openlore as an MCP server (stdio transport, for Cline/Claude Code)')
   .option('--watch <directory>', 'Watch a project directory and incrementally re-index signatures on file changes')
   .option('--watch-auto', 'Auto-detect the project directory from the first tool call and start watching', true)
+  .option('--no-watch-auto', 'Disable auto-watch (use for one-shot tool calls, e.g. the orient skill wrapper)')
   .option('--watch-debounce <ms>', 'Debounce delay in ms before re-indexing after a file change (default: 400)', '400')
   .option('--minimal', 'Expose only core 5 tools (orient, search_code, record_decision, detect_changes, check_spec_drift). Pair with alwaysLoad: true in Claude Code for always-visible core tools.')
   .action((options: McpServerOptions) => startMcpServer(options));

--- a/src/cli/commands/orient.test.ts
+++ b/src/cli/commands/orient.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the `openlore orient` CLI command.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: {
+    error: vi.fn(), info: vi.fn(), section: vi.fn(), success: vi.fn(),
+    warning: vi.fn(), discovery: vi.fn(), blank: vi.fn(), debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../core/services/mcp-handlers/orient.js', () => ({
+  handleOrient: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return { ...actual, existsSync: vi.fn().mockReturnValue(false) };
+});
+
+import { orientCommand } from './orient.js';
+import { handleOrient } from '../../core/services/mcp-handlers/orient.js';
+import { existsSync } from 'node:fs';
+
+const mockHandleOrient = vi.mocked(handleOrient);
+const mockExistsSync = vi.mocked(existsSync);
+
+describe('orient command', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let cwdSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockHandleOrient.mockReset();
+    mockExistsSync.mockReset().mockReturnValue(false);
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/fake/proj');
+    process.exitCode = undefined;
+    // orientCommand is a module-level singleton; commander retains option
+    // values between parseAsync() calls, so reset them so one test's flags
+    // (e.g. --limit 0) don't bleed into the next.
+    for (const opt of ['task', 'directory', 'limit', 'json']) {
+      orientCommand.setOptionValue(opt, undefined);
+    }
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    cwdSpy.mockRestore();
+    process.exitCode = undefined;
+  });
+
+  function output(): string {
+    return consoleSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
+  }
+
+  describe('command configuration', () => {
+    it('has correct name and description', () => {
+      expect(orientCommand.name()).toBe('orient');
+      expect(orientCommand.description().toLowerCase()).toContain('insertion');
+    });
+
+    it('exposes --task, --json, --directory and --limit options', () => {
+      const longs = orientCommand.options.map(o => o.long);
+      expect(longs).toContain('--task');
+      expect(longs).toContain('--json');
+      expect(longs).toContain('--directory');
+      expect(longs).toContain('--limit');
+    });
+  });
+
+  describe('no-task primer (used by the install SessionStart hook)', () => {
+    it('prints a primer and does NOT call handleOrient when no task is given', async () => {
+      await orientCommand.parseAsync([], { from: 'user' });
+      expect(mockHandleOrient).not.toHaveBeenCalled();
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('--json primer emits parseable JSON with openlore status', async () => {
+      mockExistsSync.mockReturnValue(false);
+      await orientCommand.parseAsync(['--json'], { from: 'user' });
+      const parsed = JSON.parse(output());
+      expect(parsed.openlore).toBe('no-analysis');
+    });
+
+    it('--json primer reports "ready" when analysis exists', async () => {
+      mockExistsSync.mockReturnValue(true);
+      await orientCommand.parseAsync(['--json'], { from: 'user' });
+      const parsed = JSON.parse(output());
+      expect(parsed.openlore).toBe('ready');
+    });
+  });
+
+  describe('with a task', () => {
+    it('passes task, directory and limit through to handleOrient', async () => {
+      mockHandleOrient.mockResolvedValue({ task: 't', searchMode: 'bm25_fallback', relevantFunctions: [] });
+      await orientCommand.parseAsync(['--task', 'add rate limiting', '--limit', '7'], { from: 'user' });
+      expect(mockHandleOrient).toHaveBeenCalledWith('/fake/proj', 'add rate limiting', 7);
+    });
+
+    it('--json emits the full result object as JSON', async () => {
+      mockHandleOrient.mockResolvedValue({ task: 'x', searchMode: 'hybrid', relevantFunctions: [] });
+      await orientCommand.parseAsync(['--json', '--task', 'x'], { from: 'user' });
+      const parsed = JSON.parse(output());
+      expect(parsed.searchMode).toBe('hybrid');
+    });
+
+    it('rejects a non-positive --limit', async () => {
+      await orientCommand.parseAsync(['--task', 'x', '--limit', '0'], { from: 'user' });
+      expect(process.exitCode).toBe(1);
+      expect(mockHandleOrient).not.toHaveBeenCalled();
+    });
+
+    it('sets exitCode=1 and emits JSON error when handleOrient throws (--json)', async () => {
+      mockHandleOrient.mockRejectedValue(new Error('boom'));
+      await orientCommand.parseAsync(['--json', '--task', 'x'], { from: 'user' });
+      expect(process.exitCode).toBe(1);
+      const parsed = JSON.parse(output());
+      expect(parsed.error).toBe('boom');
+    });
+
+    it('--json keeps stdout pure JSON even when the handler logs to stdout', async () => {
+      // handleOrient → validateDirectory writes "[ok] Successfully validated…"
+      // to stdout via console.log. In --json mode that must be routed away so
+      // wrapper scripts get parseable JSON. Simulate the stray write.
+      mockHandleOrient.mockImplementation(async () => {
+        console.log('[ok] Successfully validated directory: /fake/proj');
+        return { task: 'x', searchMode: 'bm25_fallback', relevantFunctions: [] };
+      });
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await orientCommand.parseAsync(['--json', '--task', 'x'], { from: 'user' });
+      // The stray line must NOT be on the captured console.log stdout…
+      expect(output()).not.toContain('Successfully validated');
+      // …and what IS on stdout must be valid JSON.
+      const parsed = JSON.parse(output());
+      expect(parsed.searchMode).toBe('bm25_fallback');
+      // The stray line was redirected to stderr instead.
+      const stderrText = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(stderrText).toContain('Successfully validated');
+      stderrSpy.mockRestore();
+    });
+  });
+});

--- a/src/cli/commands/orient.ts
+++ b/src/cli/commands/orient.ts
@@ -1,0 +1,175 @@
+/**
+ * openlore orient command
+ *
+ * CLI surface for the orient tool (also exposed through the MCP server). Given
+ * a task, returns the relevant functions, callers, spec sections, and insertion
+ * points — as JSON (for tooling) or a human-readable summary.
+ *
+ * With no task it prints a short session-start primer instead of erroring, so
+ * the SessionStart hook written by `openlore install`
+ * (`npx --yes openlore orient --json`) is a no-op that injects useful context
+ * rather than failing on every session start.
+ */
+
+import { Command } from 'commander';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { logger } from '../../utils/logger.js';
+import { handleOrient } from '../../core/services/mcp-handlers/orient.js';
+import { OPENLORE_ANALYSIS_REL_PATH } from '../../constants.js';
+
+interface OrientCliOptions {
+  task?: string;
+  directory?: string;
+  limit?: string;
+  json?: boolean;
+}
+
+/** True once `openlore analyze` has produced an llm-context artifact. */
+function hasAnalysis(directory: string): boolean {
+  return existsSync(join(directory, OPENLORE_ANALYSIS_REL_PATH, 'llm-context.json'));
+}
+
+/** Session-start primer printed when orient is invoked without a task. */
+function printPrimer(directory: string, asJson: boolean): void {
+  const ready = hasAnalysis(directory);
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          openlore: ready ? 'ready' : 'no-analysis',
+          message: ready
+            ? 'OpenLore architectural memory is active. Call orient with a task before reading source files.'
+            : 'OpenLore is installed but no analysis was found. Run "openlore analyze" to build the graph.',
+          usage: 'openlore orient --json --task "<task description>"',
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+  if (ready) {
+    console.log('OpenLore architectural memory is active.');
+    console.log('Call orient with a task before reading source files:');
+    console.log('  openlore orient --task "<task description>"');
+  } else {
+    console.log('OpenLore is installed but no analysis was found.');
+    console.log('Run "openlore analyze" to build the graph, then:');
+    console.log('  openlore orient --task "<task description>"');
+  }
+}
+
+/**
+ * Run `fn` with console.log/info/warn redirected to stderr, then restore them.
+ * handleOrient → validateDirectory writes a "[ok] Successfully validated
+ * directory…" line to stdout via logger.success; in --json mode that would
+ * corrupt the JSON the wrappers parse. The MCP server applies the same stdout
+ * discipline (see startMcpServer). logger.error already uses stderr.
+ */
+async function withQuietStdout<T>(fn: () => Promise<T>): Promise<T> {
+  const orig = { log: console.log, info: console.info, warn: console.warn };
+  const toStderr = (...args: unknown[]): void => {
+    process.stderr.write(args.map(a => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
+  };
+  console.log = toStderr;
+  console.info = toStderr;
+  console.warn = toStderr;
+  try {
+    return await fn();
+  } finally {
+    console.log = orig.log;
+    console.info = orig.info;
+    console.warn = orig.warn;
+  }
+}
+
+/** Concise human-readable rendering of a handleOrient result. */
+function printHuman(result: Record<string, unknown>): void {
+  if (result.error) {
+    logger.error(String(result.error));
+    if (result.hint) logger.info('Hint', String(result.hint));
+    return;
+  }
+
+  const fns = (result.relevantFunctions as Array<{ name: string; filePath: string }>) ?? [];
+  const ips =
+    (result.insertionPoints as Array<{ rank: number; name: string; filePath: string; reason: string }>) ?? [];
+  const next = (result.nextSteps as string[]) ?? [];
+
+  console.log(`Task: ${result.task}`);
+  console.log(`Search mode: ${result.searchMode}`);
+
+  if (fns.length > 0) {
+    console.log('\nRelevant functions:');
+    for (const f of fns) console.log(`  ${f.name}  (${f.filePath})`);
+  }
+  if (ips.length > 0) {
+    console.log('\nInsertion points:');
+    for (const ip of ips) console.log(`  ${ip.rank}. ${ip.name}  (${ip.filePath}) — ${ip.reason}`);
+  }
+  if (next.length > 0) {
+    console.log('\nNext steps:');
+    for (const s of next) console.log(`  - ${s}`);
+  }
+}
+
+export const orientCommand = new Command('orient')
+  .description('Get the relevant functions, callers, specs, and insertion points for a task')
+  .option('--task <task>', 'Natural-language task description (e.g. "add rate limiting to the API")')
+  .option('--directory <path>', 'Project directory to orient in (default: current directory)')
+  .option('--limit <n>', 'Number of relevant functions to return (default: 5)')
+  .option('--json', 'Emit the full result as JSON instead of a human-readable summary', false)
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ openlore orient --task "add a new CLI command"
+  $ openlore orient --json --task "fix the analyze cache"
+  $ openlore orient --json --task "auth flow" --limit 10
+
+Requires "openlore analyze" to have been run at least once. With no --task,
+prints a short session-start primer (used by the install SessionStart hook).
+`
+  )
+  .action(async (opts: OrientCliOptions) => {
+    const directory = opts.directory ?? process.cwd();
+    const asJson = opts.json ?? false;
+    const task = opts.task?.trim();
+
+    // No task → session-start primer (keeps the install hook from erroring).
+    if (!task) {
+      printPrimer(directory, asJson);
+      return;
+    }
+
+    const limit = opts.limit ? parseInt(opts.limit, 10) : 5;
+    if (Number.isNaN(limit) || limit < 1) {
+      logger.error('--limit must be a positive integer');
+      process.exitCode = 1;
+      return;
+    }
+
+    try {
+      // In --json mode keep stdout clean (validateDirectory logs to stdout);
+      // in human mode let diagnostics through normally.
+      const result = (asJson
+        ? await withQuietStdout(() => handleOrient(directory, task, limit))
+        : await handleOrient(directory, task, limit)) as Record<string, unknown>;
+      // Always emit structured results (including the "no analysis" error object)
+      // on stdout so wrapper scripts can parse them — mirroring the MCP tool.
+      if (asJson) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        printHuman(result);
+      }
+    } catch (err) {
+      const message = (err as Error).message;
+      if (asJson) {
+        console.log(JSON.stringify({ error: message }, null, 2));
+      } else {
+        logger.error(`orient failed: ${message}`);
+      }
+      process.exitCode = 1;
+    }
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,6 +11,7 @@ import { Command } from 'commander';
 import { createRequire } from 'node:module';
 import { initCommand } from './commands/init.js';
 import { analyzeCommand } from './commands/analyze.js';
+import { orientCommand } from './commands/orient.js';
 import { generateCommand } from './commands/generate.js';
 import { verifyCommand } from './commands/verify.js';
 import { driftCommand } from './commands/drift.js';
@@ -127,6 +128,7 @@ Learn more: https://github.com/Fission-AI/OpenSpec
 // Register subcommands
 program.addCommand(initCommand);
 program.addCommand(analyzeCommand);
+program.addCommand(orientCommand);
 program.addCommand(generateCommand);
 program.addCommand(verifyCommand);
 program.addCommand(driftCommand);

--- a/src/cli/install/index.ts
+++ b/src/cli/install/index.ts
@@ -54,6 +54,57 @@ export interface InstallOptions {
   force?: boolean;
   uninstall?: boolean;
   cwd?: string;
+  /**
+   * After configuring agent surfaces, build the index so orient() works on the
+   * very first session (init if needed, then analyze). Default true; set false
+   * via `--no-analyze`. Skipped for --dry-run and --uninstall.
+   */
+  analyze?: boolean;
+}
+
+/**
+ * Build the openlore index so the freshly-wired orient() returns results on the
+ * user's first session instead of "No analysis found".
+ *
+ * Drives the real `init` and `analyze` CLI commands (not the programmatic API):
+ * the searchable BM25 index that orient depends on is built by analyze's embed
+ * step, which only the CLI command runs. Both commands read process.cwd(), so
+ * we chdir into the target for the duration. Failures are non-fatal — the
+ * surfaces are already wired, so we warn and tell the user to run analyze
+ * themselves rather than failing the whole install.
+ */
+async function buildIndex(cwd: string): Promise<void> {
+  const prevCwd = process.cwd();
+  // init/analyze print their own multi-line CLI output ("Next step: run
+  // generate", etc.) via console.log — noise inside install. Capture it to
+  // stderr so install shows its own concise summary; logger.error still surfaces.
+  const origLog = console.log;
+  const toStderr = (...args: unknown[]): void => {
+    process.stderr.write(args.map(a => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
+  };
+  try {
+    process.chdir(cwd);
+    const { initCommand } = await import('../commands/init.js');
+    const { analyzeCommand } = await import('../commands/analyze.js');
+
+    logger.discovery('Building search index (BM25; no network required)…');
+    console.log = toStderr;
+    // init is idempotent (skips if config already exists); analyze builds the
+    // BM25 index orient() reads — no embedding endpoint needed.
+    await initCommand.parseAsync([], { from: 'user' });
+    await analyzeCommand.parseAsync([], { from: 'user' });
+    console.log = origLog;
+    logger.success('Index built — orient() will return results in your next session.');
+  } catch (err) {
+    console.log = origLog;
+    logger.warning(
+      `Could not build the index automatically: ${(err as Error).message}`
+    );
+    logger.info('Next step', 'Run "openlore analyze" so orient() works in your next session');
+  } finally {
+    console.log = origLog;
+    process.chdir(prevCwd);
+  }
 }
 
 export async function runInstall(opts: InstallOptions): Promise<number> {
@@ -106,6 +157,16 @@ export async function runInstall(opts: InstallOptions): Promise<number> {
     );
     return 1;
   }
+
+  // One-command setup: build the index so orient() works on the first session.
+  // Opt out with --no-analyze; never runs for dry-run or uninstall.
+  const shouldAnalyze = opts.analyze !== false && !opts.dryRun && !opts.uninstall;
+  if (shouldAnalyze) {
+    await buildIndex(cwd);
+  } else if (!opts.dryRun && !opts.uninstall) {
+    logger.info('Next step', 'Run "openlore analyze" so orient() works in your next session');
+  }
+
   return 0;
 }
 
@@ -146,11 +207,31 @@ function printSummary(
 }
 
 export const installCommand = new Command('install')
-  .description('Auto-configure agent surfaces to call orient() (Claude Code, Cursor, Cline, Continue, AGENTS.md).')
+  .description(
+    'One-command setup: configure agent surfaces (Claude Code, Cursor, Cline, Continue, AGENTS.md) ' +
+    'to call orient(), then build the index so orient works on your first session.'
+  )
   .option('--agent <name>', 'Install only for a specific surface (claude-code, cursor, cline, continue, agents-md)')
   .option('--dry-run', 'Print the planned changes without writing any files', false)
   .option('--force', 'Overwrite OpenLore-managed blocks even if hand-edited', false)
   .option('--uninstall', 'Remove OpenLore-managed blocks and entries', false)
+  .option('--analyze', 'Build the index after configuring surfaces (default: true)', true)
+  .option('--no-analyze', 'Configure surfaces only; do not run init/analyze (run "openlore analyze" yourself later)')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ openlore install                 Detect agents, wire them up, build the index
+  $ openlore install --agent claude-code
+  $ openlore install --no-analyze    Wire up surfaces only (skip index build)
+  $ openlore install --dry-run       Preview changes without writing
+  $ openlore install --uninstall     Remove OpenLore-managed entries
+
+After install, orient() is available immediately — the configured MCP server
+(\`openlore mcp\`) starts automatically when your agent launches, and the index
+stays fresh as you edit (disable the file watcher with \`openlore mcp --no-watch-auto\`).
+`
+  )
   .action(async (opts: InstallOptions) => {
     const code = await runInstall(opts);
     if (code !== 0) process.exit(code);

--- a/src/cli/install/index.ts
+++ b/src/cli/install/index.ts
@@ -66,32 +66,35 @@ export interface InstallOptions {
  * Build the openlore index so the freshly-wired orient() returns results on the
  * user's first session instead of "No analysis found".
  *
- * Drives the real `init` and `analyze` CLI commands (not the programmatic API):
- * the searchable BM25 index that orient depends on is built by analyze's embed
- * step, which only the CLI command runs. Both commands read process.cwd(), so
- * we chdir into the target for the duration. Failures are non-fatal — the
- * surfaces are already wired, so we warn and tell the user to run analyze
- * themselves rather than failing the whole install.
+ * - init: use the programmatic API (openloreInit), which is silent and returns
+ *   created:false when config already exists. The init CLI command instead logs
+ *   a scary "[error] Configuration exists. Use --force" on re-runs, which is
+ *   misleading inside install where re-running is a clean no-op.
+ * - analyze: drive the real CLI command — the searchable BM25 index orient reads
+ *   is built by analyze's embed step, which only the CLI command runs. It reads
+ *   process.cwd(), so we chdir into the target for the duration.
+ *
+ * Failures are non-fatal: the surfaces are already wired, so we warn and tell
+ * the user to run analyze themselves rather than failing the whole install.
  */
 async function buildIndex(cwd: string): Promise<void> {
   const prevCwd = process.cwd();
-  // init/analyze print their own multi-line CLI output ("Next step: run
-  // generate", etc.) via console.log — noise inside install. Capture it to
-  // stderr so install shows its own concise summary; logger.error still surfaces.
+  // analyze prints its own multi-line CLI output ("Next step: run generate",
+  // etc.) via console.log — noise inside install. Capture it to stderr so
+  // install shows its own concise summary; logger.error still surfaces.
   const origLog = console.log;
   const toStderr = (...args: unknown[]): void => {
     process.stderr.write(args.map(a => (typeof a === 'string' ? a : String(a))).join(' ') + '\n');
   };
   try {
-    process.chdir(cwd);
-    const { initCommand } = await import('../commands/init.js');
-    const { analyzeCommand } = await import('../commands/analyze.js');
+    const { openloreInit } = await import('../../api/init.js');
+    // Silent + idempotent: creates config if absent, no-ops (created:false) if present.
+    await openloreInit({ rootPath: cwd });
 
+    process.chdir(cwd);
+    const { analyzeCommand } = await import('../commands/analyze.js');
     logger.discovery('Building search index (BM25; no network required)…');
     console.log = toStderr;
-    // init is idempotent (skips if config already exists); analyze builds the
-    // BM25 index orient() reads — no embedding endpoint needed.
-    await initCommand.parseAsync([], { from: 'user' });
     await analyzeCommand.parseAsync([], { from: 'user' });
     console.log = origLog;
     logger.success('Index built — orient() will return results in your next session.');

--- a/src/cli/install/install-analyze.test.ts
+++ b/src/cli/install/install-analyze.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for `openlore install`'s one-command setup: after wiring agent surfaces
+ * it should build the index (init + analyze) so orient() works on the first
+ * session, unless --no-analyze (analyze: false) is passed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, mkdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runInstall } from './index.js';
+
+async function exists(p: string): Promise<boolean> {
+  try { await stat(p); return true; } catch { return false; }
+}
+
+describe('openlore install — auto index build', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'openlore-install-analyze-'));
+    // A minimal but real TS project so analyze has something to index.
+    await writeFile(join(dir, 'package.json'), JSON.stringify({ name: 'tmp', version: '1.0.0' }));
+    await mkdir(join(dir, 'src'), { recursive: true });
+    await writeFile(
+      join(dir, 'src', 'index.ts'),
+      'export function greet(name: string): string {\n  return `hi ${name}`;\n}\n'
+    );
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('default install builds the index (.openlore + vector-index) so orient works immediately', async () => {
+    const code = await runInstall({ cwd: dir, agent: 'claude-code' });
+    expect(code).toBe(0);
+    // Surfaces wired…
+    expect(await exists(join(dir, '.claude/settings.json'))).toBe(true);
+    // …AND the index was built (init created config; analyze wrote the index).
+    expect(await exists(join(dir, '.openlore/config.json'))).toBe(true);
+    expect(await exists(join(dir, '.openlore/analysis/vector-index'))).toBe(true);
+  }, 30_000);
+
+  it('--no-analyze (analyze:false) configures surfaces but does NOT build the index', async () => {
+    const code = await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
+    expect(code).toBe(0);
+    expect(await exists(join(dir, '.claude/settings.json'))).toBe(true);
+    // No analysis artifacts produced.
+    expect(await exists(join(dir, '.openlore/analysis/vector-index'))).toBe(false);
+  });
+
+  it('dry-run never builds the index', async () => {
+    const code = await runInstall({ cwd: dir, agent: 'claude-code', dryRun: true });
+    expect(code).toBe(0);
+    expect(await exists(join(dir, '.openlore'))).toBe(false);
+  });
+});

--- a/src/cli/install/install.test.ts
+++ b/src/cli/install/install.test.ts
@@ -53,7 +53,7 @@ describe('openlore install (end-to-end)', () => {
   });
 
   it('agent-md install creates AGENTS.md with managed block', async () => {
-    const code = await runInstall({ cwd: dir, agent: 'agents-md' });
+    const code = await runInstall({ cwd: dir, agent: 'agents-md', analyze: false });
     expect(code).toBe(0);
     const md = await readFile(join(dir, 'AGENTS.md'), 'utf8');
     expect(md).toContain('BEGIN OPENLORE');
@@ -62,7 +62,7 @@ describe('openlore install (end-to-end)', () => {
 
   it('claude-code install creates settings.json with SessionStart + mcpServers', async () => {
     await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
-    const code = await runInstall({ cwd: dir, agent: 'claude-code' });
+    const code = await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
     expect(code).toBe(0);
     const settings = JSON.parse(await readFile(join(dir, '.claude/settings.json'), 'utf8'));
     expect(settings.mcpServers.openlore).toEqual({
@@ -77,34 +77,34 @@ describe('openlore install (end-to-end)', () => {
 
   it('re-running install is a no-op (no writes, exit 0)', async () => {
     await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
-    await runInstall({ cwd: dir, agent: 'claude-code' });
+    await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
     const mdBefore = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
     const settingsBefore = await readFile(join(dir, '.claude/settings.json'), 'utf8');
 
-    const code = await runInstall({ cwd: dir, agent: 'claude-code' });
+    const code = await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
     expect(code).toBe(0);
     expect(await readFile(join(dir, 'CLAUDE.md'), 'utf8')).toBe(mdBefore);
     expect(await readFile(join(dir, '.claude/settings.json'), 'utf8')).toBe(settingsBefore);
   });
 
   it('refuses to overwrite hand-edited block without --force', async () => {
-    await runInstall({ cwd: dir, agent: 'agents-md' });
+    await runInstall({ cwd: dir, agent: 'agents-md', analyze: false });
     const md = await readFile(join(dir, 'AGENTS.md'), 'utf8');
     const tampered = md.replace('orient()', 'OOPS-EDITED');
     await writeFile(join(dir, 'AGENTS.md'), tampered, 'utf8');
 
-    const code = await runInstall({ cwd: dir, agent: 'agents-md' });
+    const code = await runInstall({ cwd: dir, agent: 'agents-md', analyze: false });
     expect(code).toBe(1);
     expect(await readFile(join(dir, 'AGENTS.md'), 'utf8')).toBe(tampered);
   });
 
   it('--force overwrites hand-edited block', async () => {
-    await runInstall({ cwd: dir, agent: 'agents-md' });
+    await runInstall({ cwd: dir, agent: 'agents-md', analyze: false });
     const md = await readFile(join(dir, 'AGENTS.md'), 'utf8');
     const tampered = md.replace('orient()', 'OOPS-EDITED');
     await writeFile(join(dir, 'AGENTS.md'), tampered, 'utf8');
 
-    const code = await runInstall({ cwd: dir, agent: 'agents-md', force: true });
+    const code = await runInstall({ cwd: dir, agent: 'agents-md', force: true, analyze: false });
     expect(code).toBe(0);
     const after = await readFile(join(dir, 'AGENTS.md'), 'utf8');
     expect(after).not.toContain('OOPS-EDITED');
@@ -114,7 +114,7 @@ describe('openlore install (end-to-end)', () => {
   it('--uninstall restores a pre-existing CLAUDE.md byte-for-byte', async () => {
     const original = '# my project\n\nsome notes\n';
     await writeFile(join(dir, 'CLAUDE.md'), original);
-    await runInstall({ cwd: dir, agent: 'claude-code' });
+    await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
     expect(await readFile(join(dir, 'CLAUDE.md'), 'utf8')).not.toBe(original);
 
     const code = await runInstall({ cwd: dir, agent: 'claude-code', uninstall: true });
@@ -125,7 +125,7 @@ describe('openlore install (end-to-end)', () => {
   });
 
   it('--uninstall removes AGENTS.md when it was OpenLore-only', async () => {
-    await runInstall({ cwd: dir, agent: 'agents-md' });
+    await runInstall({ cwd: dir, agent: 'agents-md', analyze: false });
     expect(await exists(join(dir, 'AGENTS.md'))).toBe(true);
     await runInstall({ cwd: dir, agent: 'agents-md', uninstall: true });
     expect(await exists(join(dir, 'AGENTS.md'))).toBe(false);
@@ -144,7 +144,7 @@ describe('openlore install (end-to-end)', () => {
       'utf8'
     );
 
-    const code = await runInstall({ cwd: dir, agent: 'claude-code' });
+    const code = await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
     expect(code).toBe(0);
     const settings = JSON.parse(await readFile(join(dir, '.claude/settings.json'), 'utf8'));
     expect(settings.hooks.SessionStart).toHaveLength(2);
@@ -163,7 +163,7 @@ describe('openlore install (end-to-end)', () => {
 
   it('cursor install writes .cursor/mcp.json with mcpServers.openlore', async () => {
     await mkdir(join(dir, '.cursor'), { recursive: true });
-    const code = await runInstall({ cwd: dir, agent: 'cursor' });
+    const code = await runInstall({ cwd: dir, agent: 'cursor', analyze: false });
     expect(code).toBe(0);
     const mcp = JSON.parse(await readFile(join(dir, '.cursor/mcp.json'), 'utf8'));
     expect(mcp.mcpServers.openlore).toEqual({
@@ -182,7 +182,7 @@ describe('openlore install (end-to-end)', () => {
     const existing = { mcpServers: { other: { command: 'foo' } } };
     await writeFile(join(dir, '.cursor/mcp.json'), JSON.stringify(existing, null, 2));
 
-    await runInstall({ cwd: dir, agent: 'cursor' });
+    await runInstall({ cwd: dir, agent: 'cursor', analyze: false });
     const merged = JSON.parse(await readFile(join(dir, '.cursor/mcp.json'), 'utf8'));
     expect(merged.mcpServers.other).toEqual({ command: 'foo' });
     expect(merged.mcpServers.openlore.command).toBe('npx');
@@ -196,7 +196,7 @@ describe('openlore install (end-to-end)', () => {
   it('auto-detects multiple surfaces when no --agent passed', async () => {
     await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
     await mkdir(join(dir, '.cursor'), { recursive: true });
-    const code = await runInstall({ cwd: dir });
+    const code = await runInstall({ cwd: dir, analyze: false });
     expect(code).toBe(0);
     expect(await exists(join(dir, '.claude/settings.json'))).toBe(true);
     expect(await exists(join(dir, '.cursor/rules/openlore.mdc'))).toBe(true);

--- a/src/core/services/mcp-watcher.test.ts
+++ b/src/core/services/mcp-watcher.test.ts
@@ -544,3 +544,53 @@ describe('McpWatcher start/stop', () => {
     await expect(watcher.stop()).resolves.not.toThrow();
   });
 });
+
+describe('isIgnoredPath — build/dependency dirs are never watched (EMFILE guard)', () => {
+  // These dirs can hold hundreds of thousands of files; watching them recursively
+  // EMFILEs on the first tool call. Regression guard for the proxilion (Rust,
+  // 75GB target/) first-run failure.
+  const ignored = [
+    '/repo/target/debug/build/foo.rs',          // Rust
+    '/repo/node_modules/pkg/index.js',          // JS deps
+    '/repo/dist/bundle.js',                     // JS build
+    '/repo/build/output.js',
+    '/repo/.next/server/page.js',               // Next.js
+    '/repo/coverage/lcov.info',
+    '/repo/.venv/lib/python3.12/site.py',       // Python venv
+    '/repo/__pycache__/mod.cpython-312.pyc',
+    '/repo/.mypy_cache/x.json',
+    '/repo/vendor/golang.org/x/net/http.go',    // Go vendored
+    '/repo/.gradle/caches/x.jar',               // JVM
+    '/repo/obj/Debug/app.dll',                  // .NET
+    '/repo/.git/objects/ab/cdef',               // VCS
+    '/repo/.openlore/analysis/llm-context.json',
+  ];
+
+  const watched = [
+    '/repo/src/main.rs',
+    '/repo/crates/proxy/src/forwarder/siem.rs',
+    '/repo/src/index.ts',
+    '/repo/lib/handler.py',
+    '/repo/pkg/server.go',
+  ];
+
+  it('ignores known build/dependency/cache/VCS directories', async () => {
+    const { isIgnoredPath } = await import('./mcp-watcher.js');
+    for (const p of ignored) {
+      expect(isIgnoredPath(p), `${p} should be ignored`).toBe(true);
+    }
+  });
+
+  it('still watches genuine source files', async () => {
+    const { isIgnoredPath } = await import('./mcp-watcher.js');
+    for (const p of watched) {
+      expect(isIgnoredPath(p), `${p} should be watched`).toBe(false);
+    }
+  });
+
+  it('ignores test-file suffixes', async () => {
+    const { isIgnoredPath } = await import('./mcp-watcher.js');
+    expect(isIgnoredPath('/repo/src/foo.test.ts')).toBe(true);
+    expect(isIgnoredPath('/repo/src/foo.spec.js')).toBe(true);
+  });
+});

--- a/src/core/services/mcp-watcher.test.ts
+++ b/src/core/services/mcp-watcher.test.ts
@@ -545,52 +545,104 @@ describe('McpWatcher start/stop', () => {
   });
 });
 
-describe('isIgnoredPath — build/dependency dirs are never watched (EMFILE guard)', () => {
+describe('isIgnoredRelPath — build/dependency dirs are never watched (EMFILE guard)', () => {
   // These dirs can hold hundreds of thousands of files; watching them recursively
   // EMFILEs on the first tool call. Regression guard for the proxilion (Rust,
-  // 75GB target/) first-run failure.
+  // 75GB target/) first-run failure. Paths are RELATIVE to the watch root.
   const ignored = [
-    '/repo/target/debug/build/foo.rs',          // Rust
-    '/repo/node_modules/pkg/index.js',          // JS deps
-    '/repo/dist/bundle.js',                     // JS build
-    '/repo/build/output.js',
-    '/repo/.next/server/page.js',               // Next.js
-    '/repo/coverage/lcov.info',
-    '/repo/.venv/lib/python3.12/site.py',       // Python venv
-    '/repo/__pycache__/mod.cpython-312.pyc',
-    '/repo/.mypy_cache/x.json',
-    '/repo/vendor/golang.org/x/net/http.go',    // Go vendored
-    '/repo/.gradle/caches/x.jar',               // JVM
-    '/repo/obj/Debug/app.dll',                  // .NET
-    '/repo/.git/objects/ab/cdef',               // VCS
-    '/repo/.openlore/analysis/llm-context.json',
+    'target',                                   // the dir itself must match
+    'target/debug/build/foo.rs',                // Rust
+    'node_modules/pkg/index.js',                // JS deps
+    'dist/bundle.js',                           // JS build
+    'build/output.js',
+    '.next/server/page.js',                     // Next.js
+    'coverage/lcov.info',
+    '.venv/lib/python3.12/site.py',             // Python venv
+    '__pycache__/mod.cpython-312.pyc',
+    '.mypy_cache/x.json',
+    'vendor/golang.org/x/net/http.go',          // Go vendored
+    '.gradle/caches/x.jar',                      // JVM
+    'obj/Debug/app.dll',                        // .NET
+    '.git/objects/ab/cdef',                     // VCS
+    '.openlore/analysis/llm-context.json',
+    'crates/proxy/target/debug/x.rs',           // nested target/ deep in the tree
   ];
 
   const watched = [
-    '/repo/src/main.rs',
-    '/repo/crates/proxy/src/forwarder/siem.rs',
-    '/repo/src/index.ts',
-    '/repo/lib/handler.py',
-    '/repo/pkg/server.go',
+    'src/main.rs',
+    'crates/proxy/src/forwarder/siem.rs',
+    'src/index.ts',
+    'lib/handler.py',
+    'pkg/server.go',
+    'src/my-target-helper.rs',                  // 'target' as a substring, not a segment
+    'src/build-config.ts',                      // 'build' as a substring, not a segment
   ];
 
-  it('ignores known build/dependency/cache/VCS directories', async () => {
-    const { isIgnoredPath } = await import('./mcp-watcher.js');
+  it('ignores known build/dependency/cache/VCS directories (incl. the dir itself + nested)', async () => {
+    const { isIgnoredRelPath } = await import('./mcp-watcher.js');
     for (const p of ignored) {
-      expect(isIgnoredPath(p), `${p} should be ignored`).toBe(true);
+      expect(isIgnoredRelPath(p), `${p} should be ignored`).toBe(true);
     }
   });
 
-  it('still watches genuine source files', async () => {
-    const { isIgnoredPath } = await import('./mcp-watcher.js');
+  it('still watches genuine source files (no substring false-positives)', async () => {
+    const { isIgnoredRelPath } = await import('./mcp-watcher.js');
     for (const p of watched) {
-      expect(isIgnoredPath(p), `${p} should be watched`).toBe(false);
+      expect(isIgnoredRelPath(p), `${p} should be watched`).toBe(false);
     }
+    // The watch root itself ('' or '.') must not be ignored.
+    expect(isIgnoredRelPath('')).toBe(false);
+    expect(isIgnoredRelPath('.')).toBe(false);
   });
 
   it('ignores test-file suffixes', async () => {
-    const { isIgnoredPath } = await import('./mcp-watcher.js');
-    expect(isIgnoredPath('/repo/src/foo.test.ts')).toBe(true);
-    expect(isIgnoredPath('/repo/src/foo.spec.js')).toBe(true);
+    const { isIgnoredRelPath } = await import('./mcp-watcher.js');
+    expect(isIgnoredRelPath('src/foo.test.ts')).toBe(true);
+    expect(isIgnoredRelPath('src/foo.spec.js')).toBe(true);
+  });
+
+  it('handles windows-style separators', async () => {
+    const { isIgnoredRelPath } = await import('./mcp-watcher.js');
+    expect(isIgnoredRelPath('target\\debug\\x.rs')).toBe(true);
+    expect(isIgnoredRelPath('src\\main.rs')).toBe(false);
+  });
+});
+
+describe('McpWatcher — real chokidar prunes build dirs (does not FD-storm target/)', () => {
+  // The real EMFILE fix: chokidar must PRUNE an ignored directory subtree, not
+  // descend into it and open FDs for every file before pruning. Uses the real
+  // chokidar (not the module mock above) via a fresh dynamic import in an
+  // isolated module registry.
+  it('watches source but never opens target/ children', async () => {
+    const { mkdtemp, writeFile, mkdir } = await import('node:fs/promises');
+    const { tmpdir } = await import('node:os');
+    const { join: pjoin } = await import('node:path');
+
+    const root = await mkdtemp(pjoin(tmpdir(), 'mcp-prune-'));
+    await mkdir(pjoin(root, 'src'), { recursive: true });
+    await mkdir(pjoin(root, 'target', 'debug', 'deps'), { recursive: true });
+    await writeFile(pjoin(root, 'src', 'main.rs'), 'fn main() {}');
+    for (let i = 0; i < 40; i++) {
+      await writeFile(pjoin(root, 'target', 'debug', 'deps', `f${i}.rs`), '// gen');
+    }
+
+    // Use the real chokidar + the real ignore predicate, not the vi.mock.
+    const chokidarMod = await vi.importActual<typeof import('chokidar')>('chokidar');
+    const chokidar = chokidarMod.default;
+    const { isIgnoredRelPath } = await import('./mcp-watcher.js');
+    const { relative: prel, sep } = await import('node:path');
+
+    const seen: string[] = [];
+    const w = chokidar.watch(root, {
+      ignored: (p: string) => isIgnoredRelPath(prel(root, p)),
+      ignoreInitial: false,
+      persistent: true,
+    });
+    w.on('add', (p: string) => seen.push(p));
+    await new Promise<void>((res) => w.on('ready', () => res()));
+    await w.close();
+
+    expect(seen.some((p) => p.endsWith('main.rs'))).toBe(true);
+    expect(seen.some((p) => p.includes(`${sep}target${sep}`))).toBe(false);
   });
 });

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -45,11 +45,38 @@ export interface McpWatcherOptions {
 const SOURCE_EXTENSIONS = /\.(ts|tsx|js|jsx|py|go|rs|rb|java|kt|php|cs|cpp|cc|cxx|h|hpp|c|swift)$/;
 
 // String-segment checks evaluated before kqueue/inotify FDs are opened — avoids
-// EMFILE on macOS when chokidar opens FDs for all directories before applying globs.
-const IGNORED_SEGMENTS = ['/node_modules/', '/.openlore/', '/dist/', '/.git/'];
+// EMFILE on macOS when chokidar opens FDs for all directories before applying
+// globs. Build-output and dependency directories can hold hundreds of thousands
+// of files (e.g. a Rust `target/` is routinely tens of GB), so watching them is
+// both wasteful and a hard EMFILE/ENOSPC trigger on the first tool call.
+const IGNORED_SEGMENTS = [
+  // VCS / openlore
+  '/.git/', '/.hg/', '/.svn/', '/.openlore/',
+  // JS/TS
+  '/node_modules/', '/dist/', '/build/', '/.next/', '/.nuxt/', '/.svelte-kit/',
+  '/.turbo/', '/.parcel-cache/', '/.cache/', '/coverage/', '/.vite/',
+  // Rust
+  '/target/',
+  // Python
+  '/.venv/', '/venv/', '/__pycache__/', '/.mypy_cache/', '/.pytest_cache/',
+  '/.tox/', '/.ruff_cache/',
+  // Go / vendored deps
+  '/vendor/',
+  // JVM
+  '/.gradle/',
+  // .NET
+  '/obj/',
+  // Editor metadata
+  '/.idea/',
+];
 const IGNORED_SUFFIXES = ['.test.ts', '.test.js', '.spec.ts', '.spec.js'];
 
-function isIgnoredPath(filePath: string): boolean {
+/**
+ * True if a path should never be watched. Evaluated as a cheap string-segment
+ * check before any FD is opened, so it must stay allocation-light. Exported for
+ * testing.
+ */
+export function isIgnoredPath(filePath: string): boolean {
   for (const seg of IGNORED_SEGMENTS) {
     if (filePath.includes(seg)) return true;
   }

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -44,44 +44,57 @@ export interface McpWatcherOptions {
 
 const SOURCE_EXTENSIONS = /\.(ts|tsx|js|jsx|py|go|rs|rb|java|kt|php|cs|cpp|cc|cxx|h|hpp|c|swift)$/;
 
-// String-segment checks evaluated before kqueue/inotify FDs are opened — avoids
-// EMFILE on macOS when chokidar opens FDs for all directories before applying
-// globs. Build-output and dependency directories can hold hundreds of thousands
-// of files (e.g. a Rust `target/` is routinely tens of GB), so watching them is
-// both wasteful and a hard EMFILE/ENOSPC trigger on the first tool call.
-const IGNORED_SEGMENTS = [
+// Directory NAMES that must never be watched. Build-output and dependency
+// directories can hold hundreds of thousands of files (a Rust `target/` is
+// routinely tens of GB), so watching them is both wasteful and a hard EMFILE
+// trigger on the first tool call.
+//
+// Matched against root-RELATIVE path segments (see isIgnoredRelPath), which is
+// what makes this robust:
+//   • The ignored directory ITSELF matches (not just its children), so chokidar
+//     prunes the whole subtree and never opens FDs inside it — the actual EMFILE
+//     fix. A naive `path.includes('/target/')` check only matches descendants,
+//     so chokidar still descends into target/ and readdir-storms before pruning.
+//   • Only segments BELOW the watch root are considered, so a repo that happens
+//     to live under e.g. /home/user/dist/myapp is not wrongly ignored.
+const IGNORED_DIR_NAMES = new Set([
   // VCS / openlore
-  '/.git/', '/.hg/', '/.svn/', '/.openlore/',
-  // JS/TS
-  '/node_modules/', '/dist/', '/build/', '/.next/', '/.nuxt/', '/.svelte-kit/',
-  '/.turbo/', '/.parcel-cache/', '/.cache/', '/coverage/', '/.vite/',
+  '.git', '.hg', '.svn', '.openlore',
+  // JS / TS
+  'node_modules', 'dist', 'build', '.next', '.nuxt', '.svelte-kit',
+  '.turbo', '.parcel-cache', '.cache', 'coverage', '.vite',
   // Rust
-  '/target/',
+  'target',
   // Python
-  '/.venv/', '/venv/', '/__pycache__/', '/.mypy_cache/', '/.pytest_cache/',
-  '/.tox/', '/.ruff_cache/',
+  '.venv', 'venv', '__pycache__', '.mypy_cache', '.pytest_cache',
+  '.tox', '.ruff_cache',
   // Go / vendored deps
-  '/vendor/',
+  'vendor',
   // JVM
-  '/.gradle/',
+  '.gradle',
   // .NET
-  '/obj/',
+  'obj',
   // Editor metadata
-  '/.idea/',
-];
+  '.idea',
+]);
 const IGNORED_SUFFIXES = ['.test.ts', '.test.js', '.spec.ts', '.spec.js'];
 
 /**
- * True if a path should never be watched. Evaluated as a cheap string-segment
- * check before any FD is opened, so it must stay allocation-light. Exported for
- * testing.
+ * True if a root-relative path should never be watched. Evaluated as a cheap
+ * segment scan before any FD is opened, so it stays allocation-light. A path is
+ * ignored if ANY of its segments is a known build/dependency/VCS directory
+ * name, or it has a test-file suffix. Exported for testing.
+ *
+ * @param relPath path relative to the watch root (forward- or back-slashed)
  */
-export function isIgnoredPath(filePath: string): boolean {
-  for (const seg of IGNORED_SEGMENTS) {
-    if (filePath.includes(seg)) return true;
+export function isIgnoredRelPath(relPath: string): boolean {
+  if (!relPath || relPath === '.') return false;
+  const segments = relPath.split(/[/\\]/);
+  for (const seg of segments) {
+    if (IGNORED_DIR_NAMES.has(seg)) return true;
   }
   for (const suf of IGNORED_SUFFIXES) {
-    if (filePath.endsWith(suf)) return true;
+    if (relPath.endsWith(suf)) return true;
   }
   return false;
 }
@@ -111,10 +124,16 @@ export class McpWatcher {
   async start(): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       const extraIgnore = this.extraIgnore;
-      this.fsWatcher = chokidar.watch(this.rootPath, {
-        ignored: (filePath: string) =>
-          isIgnoredPath(filePath) ||
-          extraIgnore.some((p) => filePath.includes(p)),
+      const rootPath = this.rootPath;
+      this.fsWatcher = chokidar.watch(rootPath, {
+        // Resolve each candidate to a root-relative path first, then prune by
+        // directory name. This prunes the ignored directory itself (chokidar
+        // never opens FDs inside it — the EMFILE fix) without false-matching on
+        // parent path components above the watch root.
+        ignored: (filePath: string) => {
+          const rel = relative(rootPath, filePath);
+          return isIgnoredRelPath(rel) || extraIgnore.some((p) => rel.includes(p));
+        },
         persistent: true,
         ignoreInitial: true,
         followSymlinks: false,


### PR DESCRIPTION
## Summary

A clean-up PR to unblock everyone: make openlore **dead-simple to install** and fix the bugs that broke first-run setup. Started from field feedback on `openlore@2.0.4`; a full first-run dogfood on clean repos surfaced the rest. **Targets `main` via this branch — not a direct push to main.**

### 1. `openlore install` wrote a broken SessionStart hook
The hook ran `npx --yes openlore orient --json`, but no `orient` CLI subcommand existed → `error: unknown command 'orient'` on every session start.

**Fix:** ship the `orient` CLI subcommand (`src/cli/commands/orient.ts`) wrapping the existing `handleOrient` MCP handler. Flags `--task/--json/--directory/--limit`; with no task it prints a session-start primer (exit 0) so the hook is a useful no-op. `--json` keeps stdout pure JSON (diagnostic `validateDirectory` output routed to stderr) so wrappers can parse it.

### 2. `analyze --no-embed` skipped the BM25 index entirely
The whole index build was gated on `--embed`, so `--no-embed` left orient reporting "No analysis found".

**Fix:** the index is now always built; `--no-embed` only disables the semantic-embedding attempt (keyword-only BM25). Removed a contradictory auto-enable block; fixed the help text.

### 3. MCP watcher EMFILE on large repos
Dogfooding on a Rust repo (75GB `target/`, ~294k files) crashed the MCP server's auto-watcher with `EMFILE: too many open files` on the first tool call — breaking both the orient skill's MCP fallback and Claude Code's long-lived MCP server.

**Fix (robust, not just a bigger list):** match ignored dirs by **root-relative path segment**, which prunes the ignored directory *itself* so chokidar never opens FDs inside it (a substring `includes('/target/')` only matches descendants, so chokidar still descends and FD-storms first). Also eliminates false-positives for repos under paths like `/home/user/dist/app`. Broadened the ignore set across ecosystems (Rust/JS/Python/Go/JVM/.NET/VCS). Added a `--no-watch-auto` flag for one-shot callers; the `orient-via-mcp.mjs` helper detects and uses it. Real-chokidar test proves `target/` is pruned, not stormed.

### 4. One-command setup (the "dead simple" goal)
`openlore install` previously only wired surfaces — so a new user's first `orient()` still returned "No analysis found" until they manually ran `analyze`.

**Fix:** `install` now also builds the index (runs `init` if needed, then the real `analyze` so the BM25 index orient reads actually gets built). orient works in the **first session, from one command**. Opt out with `--no-analyze`; skipped for `--dry-run`/`--uninstall`. Sub-command chatter is captured so install prints its own concise progress.

**On MCP auto-start:** the MCP server is launched by the agent (Claude Code spawns `npx openlore mcp` from `settings.json`), so `install` already wires auto-start — there's no daemon for openlore to start itself. The file watcher (now safe on large repos) stays on by default; `openlore mcp --no-watch-auto` disables it.

### 5. Docs
- Dropped the stale "orient CLI not yet shipped / TODO(spec-02-followup)" language from `SKILL.md`, the skill `README.md`, and the wrappers.
- Rewrote the project `README.md` Quickstart around the single `openlore install` command; documented MCP auto-start and the watcher's build-dir pruning / `--no-watch-auto`.

## First-run verification (clean repos, via PR build)
- **Rust (proxilion):** `init` → `analyze` (BM25, 4359 fns) → `install` → hook returns `{"openlore":"ready"}` → `orient --task` returns results; MCP server watches the 75GB repo with **no EMFILE**.
- **TS (vaulytica):** a single `openlore install` wires the surface, builds the index (1889 fns), and `orient` returns real results immediately — no manual analyze step. Confirmed published 2.0.4 errors (`unknown command 'orient'`) while the PR build returns clean JSON. Both repos left exactly as found.

## Tests
- `orient.test.ts`, `analyze-no-embed.test.ts`, `install-analyze.test.ts` (one-command setup builds the index; `--no-analyze`/dry-run don't), `mcp-watcher.test.ts` (`isIgnoredRelPath` + real-chokidar pruning).
- Full suite: **2928 passing, 2 skipped**; typecheck clean; build succeeds; `openlore orient --help` lists the command.

Note: dependabot advisory #43 on the default branch is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)