### PR TITLE
docs: new feature specifications (specs 13–23)

### DIFF
--- a/docs/specs/openlore-spec-13-context-substrate.md
+++ b/docs/specs/openlore-spec-13-context-substrate.md
@@ -1,0 +1,280 @@
+# OpenLore Spec 13 — The Context Substrate (True North)
+
+> This is a **strategy + architecture** spec, not a single-PR prompt. It defines the
+> direction every subsequent spec should serve, and seeds the concrete next specs
+> (14+) that implement it incrementally. Read it before proposing any large feature.
+
+---
+
+## Progress
+
+Branch: `openlore-spec-13-context-substrate`. Vision locked; roadmap defined; implementation specs to follow.
+
+- [x] Strategic direction chosen by owner (2026-05-29): **substrate/plumbing**, not breadth-product
+- [x] Competitive landscape mapped (Glean, Onyx, MCP connector zoo, coding-context maps, protocol precedents)
+- [x] Core thesis stated and stress-tested: the *deterministic substrate* bet
+- [x] Compounding roadmap defined (git/co-change → forge → tracker → docs → comms → semantic)
+- [x] Scope discipline written (what OpenLore must NEVER become)
+- [ ] `TODO(spec-14)`: Git / co-change layer — no OAuth, no LLM, ships to every coding agent
+- [ ] `TODO(spec-15)`: Connector write-contract v1 — the ~50-line plugin shape
+- [ ] `TODO(spec-16)`: Cross-source deterministic resolver (ID/URL/email join)
+- [ ] `TODO(spec-17)`: `orient()` over the merged graph — token-budgeted subgraph response
+- [ ] `TODO(future)`: Forge / tracker / docs / comms connectors (each rides existing MCP servers)
+
+---
+
+## Context for you (the agent / the maintainer)
+
+OpenLore today is a **deterministic, local-first, token-cheap context engine for code**:
+tree-sitter call graph + clusters + McCabe (no API key), an optional LLM spec/decision
+layer, and a 45-tool MCP runtime fronted by `orient()`. Its measured value is replacing
+15,000–50,000 tokens of file-by-file rediscovery with a ~1–3k targeted orientation pass.
+
+The question this spec answers: **what does OpenLore become next, and what does it
+refuse to become?**
+
+The space is crowded and well-funded:
+
+- **Glean** — enterprise knowledge graph; the real moat is **real-time ACL mirroring**
+  across 100+ connectors, sold to IT. That mirroring is both its moat and its tarpit.
+- **Onyx (ex-Danswer)** — the OSS Glean: MIT, self-hostable, 40+ connectors, hybrid
+  vector+keyword RAG. But it is a **chat-over-your-docs product**, not an agent context layer.
+- **The MCP connector zoo** — Atlassian (official), Notion (official), Google Workspace,
+  Gmail. OAuth + fetching is **already solved**. But these are **dumb pipes**: query-time
+  tools that dump raw pages into the agent's context. Nobody *structures across them*.
+- **Coding-context maps** — Cursor's index, Sourcegraph (Cody/Amp + **SCIP/LSIF**),
+  Augment, Continue, Aider's repo-map. Most are embeddings-over-text or closed/cloud.
+- **Protocol precedents** — **tree-sitter, LSP, SCIP, LSIF, Kythe, GraphRAG.** The
+  durable winners in this space won by being a **contract**, not an app.
+
+### The decision
+
+> **OpenLore is plumbing, not a product.** Its job is to be the deterministic context
+> *substrate* that any agent or tool builds on — the "tree-sitter / SCIP for agent
+> context" — not a Glean-style breadth product with 40 connectors and a chat UI.
+
+This single decision cascades and resolves two otherwise-hard forks for free:
+
+1. **Whose permissions?** → Substrate + local-first ⟹ **token-scoped, not org-wide.**
+   The agent sees what *your* OAuth token sees. No ACL-mirroring engine to build, no
+   security-review nightmare to own. We deliberately cede Glean's enterprise-ACL moat
+   because it is also its tarpit; our user is the *developer and their agent*, not IT.
+2. **Build connectors or ride MCP?** → Substrate ⟹ **ride the existing MCP connectors.**
+   Official Atlassian/Notion/Google MCP servers already solved OAuth + fetch. OpenLore
+   sits **above** them as the layer that builds the deterministic, cross-joined graph.
+   We do not re-implement OAuth twelve times. We do not enter the connector graveyard.
+
+---
+
+## The core thesis (the load-bearing bet)
+
+> **There is a large DETERMINISTIC substrate inside org data that competitors needlessly
+> pay an LLM / embeddings to rediscover.**
+
+Glean and Onyx treat everything as text → embed → retrieve. But an enormous amount of
+structure is **explicitly stated** and needs no inference:
+
+| Source | Deterministic structure (no LLM) |
+|--------|----------------------------------|
+| Jira / Linear | epics→stories→subtasks, blocks/blocked-by, assignees, sprints, status transitions |
+| Confluence / Notion | page trees, backlinks, @mentions, spaces |
+| Google Drive | folder tree, sharing/ownership edges, doc-to-doc links |
+| Gmail / Slack | thread structure (`References`/`In-Reply-To`), sender/recipient graph |
+| GitHub / forge | PR ↔ issue ↔ commit ↔ file, reviews, cross-refs |
+| Code (today) | call graph, imports, clusters — already OpenLore's core |
+
+And the gold nobody mines: **these systems cross-reference each other.** A Jira ticket
+pastes a Confluence URL that links a Google Doc implemented in a GitHub PR discussed in
+an email thread. **Every one of those edges is a deterministic join on an ID, URL, or
+email address** — no embeddings, no hallucinated relationships, fully auditable, offline.
+
+This is *exactly* OpenLore's existing philosophy (Layer 1 = deterministic; Layers 2/3 =
+optional semantic) applied to the org instead of the repo. Embeddings are reserved only
+for the genuinely fuzzy edge — "these two docs are *about* the same thing even though
+neither links the other" — which becomes an **optional** layer on top, same as for code.
+
+### The unique unlock — the join no competitor has
+
+OpenLore already owns the **code graph**. Glean and Onyx index code as *text*; they are
+blind to call topology. Coding-context maps own the code graph but have no org context.
+**Nobody joins the two.** Wire the call graph into the org graph in one structure and you
+get an edge chain that is genuine white space:
+
+```
+function exportToCsv()
+   → implements   → JIRA-412
+   → specced-in   → Confluence "Export v2"
+   → designed-in  → Drive design doc
+   → discussed-in → email thread
+```
+
+When an agent says *"implement OAuth for the export feature,"* one `orient()` call returns
+that whole subgraph — ranked, with ~200-token summaries and stable IDs — instead of six
+MCP calls dumping 50k tokens of raw pages. The agent then lazy-fetches only the one or two
+leaves it actually needs. **That is the token-saving, context-management story, and it is
+just `orient()` extended past the repo boundary.**
+
+---
+
+## What "be plumbing" actually means
+
+The precedent to copy is **tree-sitter / SCIP / LSP**: adopted because they are a
+*contract*, not an app. OpenLore-the-binary becomes the **reference implementation** of a
+contract that others can emit into, query, or reimplement. Three things must be nailed:
+
+### 1. The format (the actual deliverable)
+
+A versioned, **on-disk, git-diffable** node/edge schema with **provenance**. Deterministic
+means inspectable: you can `cat` the graph and see exactly *why* an edge exists — which URL,
+which ID, which commit produced it. No black-box embedding silently deciding a relationship.
+
+This already has seeds in-repo: **Spec 04 (SCIP export)** makes the code graph consumable by
+the SCIP/Glean ecosystem; **Spec 05 (federation manifest, `.well-known/openlore.json`)** is
+the "SBOM-of-cognition" self-description. Spec 13 generalizes these: the context graph is the
+union of code symbols + org nodes + the deterministic edges between them, persisted locally.
+
+Minimal node/edge contract (v1 sketch — to be pinned in Spec 15/16):
+
+```jsonc
+// Node — anything addressable across any source
+{
+  "id": "openlore://github/clay-good/openlore/pr/95",  // stable, source-qualified URI
+  "type": "pull_request",          // function | file | issue | doc | page | email | person | commit | pr ...
+  "source": "github",
+  "title": "fix: quiet install re-runs",
+  "ts": "2026-05-28T14:02:00Z",
+  "perms": "token-scoped",         // visible because YOUR token saw it; no ACL mirror
+  "summary": null                  // optional, lazily filled; NOT raw content
+}
+
+// Edge — every edge carries provenance so it is auditable
+{
+  "from": "openlore://github/.../pr/95",
+  "to":   "openlore://jira/PROJ/issue/412",
+  "type": "references",            // implements | references | mentions | parent_of | authored_by | co_changes_with | specced_in ...
+  "deterministic": true,
+  "provenance": { "kind": "url_in_body", "evidence": "https://.../browse/PROJ-412" }
+}
+```
+
+### 2. The read interface
+
+`orient()` over MCP — already shipped for code; extended to traverse the merged graph.
+"Go-to-definition" for *context*. Stable verb, agent-agnostic.
+
+### 3. The write contract
+
+A connector so small (~50 lines: "emit these nodes, these edges") that the community
+actually writes them. Heaviness is what killed prior connector ecosystems. Where possible,
+a connector is a **thin adapter over an existing MCP server**, not a fresh OAuth client.
+
+---
+
+## The compounding roadmap (the part that adds up)
+
+Every new source is the **same move**: ingest → extract its native deterministic graph →
+join to the existing graph on shared IDs/URLs/emails. Each join makes *every prior source
+more valuable*, because edges compose into multi-hop chains. Sequenced cheapest-and-highest-
+trust first:
+
+1. **Git / co-change layer — `TODO(spec-14)`.** *No OAuth, no LLM, already local.* Blame,
+   history, and the killer signal AST cannot see: **co-change edges** ("these files/functions
+   change together"). Bridges code → people → intent before touching a single connector.
+   Ships value to **every** coding agent on day one. **This is the wedge.**
+2. **Forge layer (your token).** PR ↔ issue ↔ commit ↔ file ↔ review. Explicit links =
+   deterministic. Code gets its first layer of *why*. Reuses Spec 04/05 plumbing.
+3. **Tracker layer (Jira / Linear via MCP).** Issue/epic graph + its explicit PR links.
+   code → PR → issue → epic.
+4. **Docs layer (Confluence / Notion / Drive via MCP).** Page trees, backlinks, and the
+   cross-source URLs that link docs to issues. The cross-source join lights up here.
+5. **Comms layer (Gmail / Slack).** Thread graph + the URLs inside messages. The
+   "discussed-in" edges that close the loop back to code.
+6. **Semantic layer (optional, last).** Embeddings *only* for the fuzzy "about the same
+   thing" edges the deterministic layers cannot produce. Exactly today's Layer-1/Layer-2 split.
+
+By step 5, a single `orient()` traverses `function → PR → issue → doc → email` in one chain
+no competitor can produce — reached by adding edge *types* to one graph, never rebuilding.
+
+### Cross-cutting concerns each step inherits
+
+- **Identity resolution.** Stitch "Clay in Jira" = "clay-good on GitHub" = "hi@claygood.com"
+  deterministically on email/handle where possible; a small fuzzy layer only for the residual.
+  Persisted as `person` nodes with `same_as` edges carrying provenance.
+- **Freshness.** Today's file-watcher does incremental code sync. The analog is webhook/delta
+  pull per source. Real-time is *not* required for v1 — a manual/periodic refresh is fine; the
+  graph records `ts` so staleness is visible. Do not over-build sync before the graph is proven.
+- **Token-scoped permissions.** No ACL mirror. Every node is in the graph because *your* token
+  fetched it. This is a feature (zero security engine), documented as an explicit non-goal of
+  enterprise multi-tenant indexing.
+
+---
+
+## Scope contract — what OpenLore must NEVER become
+
+To stay plumbing and not drift into a product:
+
+- **No chat UI.** We do not answer questions; we serve a graph the agent reasons over.
+- **No LLM hosting / no embedding service.** Semantic layer is optional and BYO (see Spec 06,
+  BM25-without-embeddings — deterministic retrieval must always work with zero network).
+- **No org-wide ACL mirroring / multi-tenant index.** Token-scoped only. Ceded to Glean on purpose.
+- **No re-implementing OAuth per service.** Ride existing MCP connectors; thin adapters only.
+- **No mirroring of raw content.** Store the **graph** (IDs, links, titles, small summaries,
+  provenance) and **lazy-fetch** content on demand. Token savings come from never pulling a full
+  doc until the agent picks it.
+- **No required network, ever, for the deterministic core.** Offline-first is identity, not a feature.
+
+The test, inherited from the project's surgical-change ethos: **every feature must make the
+graph more queryable or more deterministic. If it adds a surface the agent talks *to* instead
+of a graph the agent reasons *over*, it does not belong in OpenLore.**
+
+---
+
+## Positioning
+
+> **OpenLore: the deterministic context graph for AI agents — tree-sitter for your org,
+> not just your code.**
+
+Local-first. Token-cheap. Auditable edges. Rides the MCP ecosystem it sits above.
+
+---
+
+## Risks and kill signals
+
+| Risk | Earliest signal the bet is wrong |
+|------|----------------------------------|
+| **Redundancy with coding-context maps** (Cursor/SCIP/Augment already "good enough") | Spec 14 (co-change) lands and no agent workflow measurably improves over plain file reads |
+| **Deterministic substrate is too thin** — the useful edges turn out to need LLM inference after all | In the forge/tracker layers, >50% of valuable edges require fuzzy matching, not ID/URL joins |
+| **Connector contract too heavy** — community doesn't write connectors | After Spec 15, no external contributor ships a connector in <1 day |
+| **MCP servers can't bulk-crawl** — query-time tools won't enumerate for graph construction | Tracker/docs layers stall because official MCP servers expose no listing; forces direct-API fallback (raises maintenance back toward connector-graveyard levels) |
+| **No distribution** — substrate with no consumers | After 6 months, OpenLore is not the default context layer under any agent it didn't ship itself |
+
+The single biggest risk is **redundancy**: if the coding-context incumbents are already
+good enough that the *deterministic + cross-domain join* doesn't change agent outcomes, the
+substrate has no reason to exist. The co-change layer (Spec 14) is deliberately first because
+it is the cheapest possible test of that risk — it needs no auth, no LLM, and either visibly
+improves orientation or it doesn't.
+
+---
+
+## Relationship to existing specs
+
+- **Spec 04 (SCIP export)** — interop format; the code half of the substrate, already shippable.
+- **Spec 05 (federation manifest)** — cross-repo self-description; the "SBOM of cognition." The
+  context graph is the natural superset (org nodes + cross-source edges added to the same idea).
+- **Spec 06 (BM25 without embeddings)** — guarantees deterministic retrieval with zero network;
+  the floor the semantic layer sits on top of, never replaces.
+
+Specs 14–17 (git/co-change, connector contract, cross-source resolver, merged `orient()`) are
+the concrete first implementations of this true north and should be written next.
+
+---
+
+## Appendix — the reasoning trail (brainstorm of 2026-05-29)
+
+This spec is the durable output of a brainstorming session. The reasoning, the rejected
+alternatives, and the multi-agent stress-test synthesis are appended below so a future
+session can re-derive *why* without repeating the exploration.
+
+> The multi-agent "true north" workflow synthesis is appended in a follow-up commit to this
+> same PR (research of coding-context-map competitors, protocol-precedent lessons, adversarial
+> stress-tests of the three core theses, and the judged candidate true-norths).

--- a/docs/specs/openlore-spec-13-context-substrate.md
+++ b/docs/specs/openlore-spec-13-context-substrate.md
@@ -1,7 +1,14 @@
-# OpenLore Spec 13 — The Context Substrate (True North)
+# OpenLore Spec 13 — Product Direction: A Deterministic Structural Context Substrate for AI Coding Agents
 
 > This is a **strategy + architecture** spec, not a single-PR prompt. It defines the
 > direction every subsequent spec should serve.
+>
+> **Prime directive (read first):** OpenLore is, and remains, a tool for **AI coding agents**.
+> Everything in this document is **additive**. Nothing here removes, replaces, or repositions
+> the current product. We grow *up* (deeper, better-proven code intelligence) and *out*
+> (adjacent developer context — infra, decisions, provenance), never *away* from the coding
+> agent. Every new capability must make the existing coding-agent use case more useful, or it
+> does not ship. See "Compatibility & scope guarantee" below.
 >
 > **Revision note (2026-05-30):** the first draft of this spec overstated several things
 > (a built "code↔org join," "bidirectional SCIP," a published token-savings benchmark, a
@@ -19,12 +26,12 @@ Branch: `openlore-spec-13-context-substrate`. Direction locked; claims verified;
 - [x] Competitive + market reality verified against primary sources (2026-05-30)
 - [x] Repo ground-truth established (what actually ships vs. what was claimed)
 - [x] Theses adversarially stress-tested; positioning corrected to survive the strongest attack
-- [ ] `TODO(spec-14)`: **WITH-vs-WITHOUT token-savings benchmark** — the bleeding wound; do this FIRST
-- [ ] `TODO(spec-15)`: Dogfood the decision/drift governance in OpenLore's own repo
-- [ ] `TODO(spec-16)`: Promote `Decision` to a first-class graph node with `affects` edges
-- [ ] `TODO(spec-17)`: Cross-domain impact query (code → infra) as a headline `orient` capability
-- [ ] `TODO(spec-18)`: Local org-artifact join (git/PR metadata via local `gh`) — no OAuth
-- [ ] `TODO(horizon-3, optional, may never ship)`: cloud OAuth connectors as a fire-walled plugin
+- [ ] **Spec 14** — Agent Token-Efficiency Benchmark Harness (WITH vs WITHOUT). *Do this first.* → [openlore-spec-14-agent-benchmark-harness.md](openlore-spec-14-agent-benchmark-harness.md)
+- [ ] **Spec 15** — Decision & Drift Governance Dogfooding (turn the gate on in our own repo). → [openlore-spec-15-governance-dogfooding.md](openlore-spec-15-governance-dogfooding.md)
+- [ ] **Spec 16** — Architectural Decisions as First-Class Graph Nodes (`affects` edges). → [openlore-spec-16-decisions-as-graph-nodes.md](openlore-spec-16-decisions-as-graph-nodes.md)
+- [ ] **Spec 17** — Cross-Domain Impact Analysis (Code ↔ Infrastructure). → [openlore-spec-17-cross-domain-impact.md](openlore-spec-17-cross-domain-impact.md)
+- [ ] **Spec 18** — Local Provenance Edges (Git & PR metadata, no OAuth). → [openlore-spec-18-local-provenance-edges.md](openlore-spec-18-local-provenance-edges.md)
+- [ ] **Horizon 3 (optional, may never ship)** — cloud OAuth connectors as a fire-walled plugin. Deliberately *not* a numbered spec until 14–18 land and prove the local-first thesis.
 
 ---
 
@@ -44,6 +51,52 @@ tree-sitter / SCIP / LSP), not the Glean-style breadth product. That single choi
 
 The rest of this spec is about getting the *positioning* right, because the lens alone does
 not survive contact with the 2026 market without a sharper claim.
+
+---
+
+## Compatibility & scope guarantee (the prime constraint)
+
+OpenLore's installed product is: `openlore analyze` → `CODEBASE.md` + `orient()` over MCP for
+coding agents, with optional specs/decisions/drift. **That contract is frozen. This direction
+adds to it; it does not change or break it.** Concretely:
+
+- **The CLI surface is preserved.** `analyze`, `generate`, `drift`, `decisions`, `export scip`,
+  `manifest`, `install`, `mcp` continue to behave as today. New work adds new subcommands/flags,
+  never repurposes existing ones.
+- **`orient()`'s response shape is treated as a public API.** New fields are additive and
+  optional; existing fields keep their meaning. A 2.x agent integration must not break.
+- **No API key remains required for the core.** Layer-1 determinism (graph, `orient`,
+  `CODEBASE.md`) stays offline and key-free. Everything network/LLM stays optional, as today.
+- **Graph schema changes are safe by construction.** The edge store is keyed on `SCHEMA_VERSION`
+  and rebuilds from source on a version bump ([edge-store.ts](../../src/core/services/edge-store.ts)).
+  The graph is *derived*, never hand-authored, so a schema addition costs users one re-analyze —
+  not a migration, not data loss.
+- **Every new capability serves the coding agent.** Code↔infra impact, decision/provenance edges,
+  and the benchmark are all things a coding agent uses *while working on code*. The one item that
+  drifts toward non-coding context — cloud org connectors — is fenced to an optional Horizon-3
+  plugin that is never installed by default and never on the core path.
+
+**The test for any future PR under this spec:** *does it make today's coding-agent workflow
+strictly better or strictly broader, while leaving every current behavior intact?* If not, it
+does not belong here.
+
+## How the shape of the product changes
+
+This is growth along the axis OpenLore already chose, not a turn onto a new one:
+
+| | Today | After specs 14–18 (still local, still key-free, still coding-first) |
+|---|---|---|
+| **Core artifact** | Deterministic code call graph | Same graph, now spanning code **+ infrastructure + decisions** on one primitive |
+| **What `orient()` answers** | who-calls / what-breaks / call-path / insertion points / spec matches | + code→infra blast radius; + "who last changed this, under which PR/decision" |
+| **Decisions** | LLM-extracted, stored in a side-file, surfaced by a string filter | First-class graph nodes with `affects` edges, traversable by `analyze_impact` |
+| **Evidence** | "saves 15–50k tokens" (unmeasured claim) | A reproducible WITH-vs-WITHOUT benchmark, published |
+| **Audience** | Coding agents | **Unchanged** — coding agents |
+| **Network** | Optional (specs/LLM only) | **Unchanged** — core stays offline; cloud is opt-in Horizon-3 only |
+
+The product goes from *"a map of your code"* to *"the always-fresh structural and governance
+memory of your code, the infra it deploys to, and the decisions that shaped it"* — a wider view
+of **the same developer's world**, for **the same audience**, with **the same local-first,
+deterministic guarantees**. That is "grow up and out," not pivot.
 
 ---
 

--- a/docs/specs/openlore-spec-13-context-substrate.md
+++ b/docs/specs/openlore-spec-13-context-substrate.md
@@ -152,7 +152,7 @@ third-party blog tagline / per-repo best, not its headline average — do not mi
 **The redundancy risk is therefore the #1 risk, and it lands hardest in the narrow lane.**
 If OpenLore ships "another local code-graph MCP," it loses a knife fight on traction and
 published evidence. The only escape is to compete where these tools **do not play at all**
-(see "True North" below) and to publish our own benchmark (see roadmap step 1).
+(see "Recommended Direction" below) and to publish our own benchmark (see roadmap step 1).
 
 ---
 
@@ -206,7 +206,7 @@ on 2026-05-30.
 
 ---
 
-## The True North
+## Recommended Direction
 
 > **OpenLore is the always-fresh, deterministic *structural substrate beneath* agentic search —
 > it answers who-calls / what-breaks / call-path in one sub-millisecond MCP call against a typed
@@ -353,6 +353,6 @@ Repo facts: file:line references inline above, verified 2026-05-30.
 ## Appendix — the reasoning trail
 
 This spec is the durable output of a brainstorming session plus two multi-agent research
-workflows (landscape + candidate true-norths; then verification + adversarial stress-test +
+workflows (landscape + candidate directions; then verification + adversarial stress-test +
 synthesis). The verification pass is what corrected the first draft's overstatements. A future
 session can re-run the same shape to re-validate as the market moves.

--- a/docs/specs/openlore-spec-13-context-substrate.md
+++ b/docs/specs/openlore-spec-13-context-substrate.md
@@ -31,7 +31,12 @@ Branch: `openlore-spec-13-context-substrate`. Direction locked; claims verified;
 - [ ] **Spec 16** — Architectural Decisions as First-Class Graph Nodes (`affects` edges). → [openlore-spec-16-decisions-as-graph-nodes.md](openlore-spec-16-decisions-as-graph-nodes.md)
 - [ ] **Spec 17** — Cross-Domain Impact Analysis (Code ↔ Infrastructure). → [openlore-spec-17-cross-domain-impact.md](openlore-spec-17-cross-domain-impact.md)
 - [ ] **Spec 18** — Local Provenance Edges (Git & PR metadata, no OAuth). → [openlore-spec-18-local-provenance-edges.md](openlore-spec-18-local-provenance-edges.md)
-- [ ] **Horizon 3 (optional, may never ship)** — cloud OAuth connectors as a fire-walled plugin. Deliberately *not* a numbered spec until 14–18 land and prove the local-first thesis.
+- [ ] **Spec 19** — Deterministic Test Impact Selection (headline Layer-3 instrument). → [openlore-spec-19-test-impact-selection.md](openlore-spec-19-test-impact-selection.md)
+- [ ] **Spec 20** — Reachability & Dead-Code Analysis. → [openlore-spec-20-reachability-dead-code.md](openlore-spec-20-reachability-dead-code.md)
+- [ ] **Spec 21** — Structural Change Analysis (graph diff). → [openlore-spec-21-structural-change-analysis.md](openlore-spec-21-structural-change-analysis.md)
+- [ ] **Spec 22** — Change-Coupling & Volatility Analysis. → [openlore-spec-22-change-coupling-volatility.md](openlore-spec-22-change-coupling-volatility.md)
+- [ ] **Spec 23** — Architecture Invariant Guardrails. → [openlore-spec-23-architecture-invariants.md](openlore-spec-23-architecture-invariants.md)
+- [ ] **Horizon 3 (optional, may never ship)** — cloud OAuth connectors as a fire-walled plugin. Deliberately *not* a numbered spec until 14–23 land and prove the local-first thesis.
 
 ---
 
@@ -84,19 +89,21 @@ does not belong here.
 
 This is growth along the axis OpenLore already chose, not a turn onto a new one:
 
-| | Today | After specs 14–18 (still local, still key-free, still coding-first) |
+| | Today | After specs 14–23 (still local, still key-free, still coding-first) |
 |---|---|---|
 | **Core artifact** | Deterministic code call graph | Same graph, now spanning code **+ infrastructure + decisions** on one primitive |
 | **What `orient()` answers** | who-calls / what-breaks / call-path / insertion points / spec matches | + code→infra blast radius; + "who last changed this, under which PR/decision" |
+| **What it can *compute* (Layer 3)** | shallow callers / direct impact | + which tests to run, reachability/dead-code, structural diff of a change, change-coupling, invariant checks |
 | **Decisions** | LLM-extracted, stored in a side-file, surfaced by a string filter | First-class graph nodes with `affects` edges, traversable by `analyze_impact` |
 | **Evidence** | "saves 15–50k tokens" (unmeasured claim) | A reproducible WITH-vs-WITHOUT benchmark, published |
 | **Audience** | Coding agents | **Unchanged** — coding agents |
 | **Network** | Optional (specs/LLM only) | **Unchanged** — core stays offline; cloud is opt-in Horizon-3 only |
 
-The product goes from *"a map of your code"* to *"the always-fresh structural and governance
-memory of your code, the infra it deploys to, and the decisions that shaped it"* — a wider view
-of **the same developer's world**, for **the same audience**, with **the same local-first,
-deterministic guarantees**. That is "grow up and out," not pivot.
+The product goes from *"a map of your code"* to *"the always-fresh map of your code — the infra
+it deploys to and the decisions that shaped it — plus the deterministic analysis (impact, tests,
+coupling, invariants) computed over it"* — a wider view of **the same developer's world**, for
+**the same audience**, with **the same local-first, deterministic guarantees**. That is "grow up
+and out," not pivot.
 
 ---
 
@@ -208,23 +215,82 @@ on 2026-05-30.
 
 ## Recommended Direction
 
-> **OpenLore is the always-fresh, deterministic *structural substrate beneath* agentic search —
-> it answers who-calls / what-breaks / call-path in one sub-millisecond MCP call against a typed
-> code graph that also spans infrastructure, and it uniquely pairs that graph with a governance
-> layer (recorded decisions + a spec-drift gate) that no navigation competitor ships.**
+> **OpenLore is the deterministic *analysis layer* for AI coding agents: a local, always-fresh
+> graph of the code — and the infrastructure and decisions around it — over which it *computes*
+> the facts a model cannot cheaply derive by reading. What breaks if I change this? Which tests
+> cover it? What is it coupled to? What rule would this violate? One MCP call, computed not
+> guessed. It *complements* agentic search (retrieval); it does not compete with it.**
 
-The substrate is the **credibility proof**, not the pitch. The pitch is the two things the
-crowded cohort does not have: **cross-domain (code↔infra) impact** and **decision/drift
-governance coupled to the graph.**
+This is an *evolution* of the existing product, not a replacement. The map (Layer 1) and the
+why-layer (Layer 2) remain exactly as they are; the analysis (Layer 3) is computed on top of
+them. See "The analysis layer" immediately below for the full framing.
 
-**Defense against the strongest attack** — the marginal-value / "Cherny killed the index"
-objection: Anthropic moved Claude Code off a *semantic RAG embeddings* index, a like-for-like
-substitution where lexical grep genuinely won. OpenLore is not a semantic retriever; it is a
-**typed relational graph** answering reverse-edge and transitive-impact queries that iterative
-grep+read can only reconstruct through many round-trips. The staleness tax Cherny rejected was a
-*batch re-index*; OpenLore answers it with **incremental** watcher updates, so the staleness
-surface is small. This survives — but only once the benchmark (step 1) proves the round-trip
-savings are real. Until then it is a hypothesis, not a result.
+**Why this is the durable bet.** The frontier labs are commoditizing *retrieval* — agentic
+search, larger context windows, and smarter models are turning "find the relevant code" into
+something the model does for itself. They are **not** building *analysis* (facts computed by
+graph algorithms): the model is structurally poor at it, it is expensive to do in-context, and a
+free, local, cross-language analysis engine is nobody's business model. The retrieval-MCP cohort
+(CodeGraph, Serena, tokensave) also stops at navigation. Analysis is open white space — and it is
+exactly what a deterministic graph is *for*.
+
+**Defense against the strongest attack** — the "Cherny killed the index" objection: Anthropic
+moved Claude Code off a *semantic RAG embeddings* index, a like-for-like substitution where
+lexical grep genuinely won. OpenLore is not a semantic retriever; it computes *relational and
+transitive facts* (impact, reachability, test coverage, coupling, invariants) that iterative
+grep+read can only reconstruct over many round-trips and many tokens. The staleness tax Cherny
+rejected was a *batch re-index*; OpenLore stays fresh incrementally. This survives — but the
+public tagline only earns itself once the Spec 14 benchmark proves the savings are real. Build
+the layer now; let the numbers earn the claim.
+
+---
+
+## The analysis layer (Layer 3): retrieval vs. analysis
+
+Three layers, nothing removed, each built on the one below:
+
+- **Layer 1 — the map** *(shipping today)*: **structure.** What exists, where execution enters,
+  how calls flow. The call/IaC graph, `orient()`, `CODEBASE.md`.
+- **Layer 2 — the why** *(shipping today)*: **intent.** Living specs, recorded decisions, drift.
+- **Layer 3 — the analysis** *(the evolution)*: **consequences.** Deterministic facts *computed
+  over Layers 1–2* that no amount of reading reveals cheaply — what breaks, what to test, what is
+  coupled, what is reachable, what rule a change would violate.
+
+**The metaphor.** The agent has **eyes** (grep/read) and a **brain** (the model). The labs are
+sharpening both. Nobody is building the **instruments** — the altimeter and radar a pilot
+*computes* rather than looks at. OpenLore is the instruments. A smarter brain makes the
+instruments *more* valuable, not less — which is precisely why Layer 3 complements the labs
+instead of competing with them.
+
+**Layer 3 cannot exist without Layers 1–2,** so the current product becomes the foundation, not
+legacy: test selection reads `tested_by` + call edges; reachability is BFS over existing nodes;
+co-change reads git; invariants read the dependency graph. Every instrument makes `orient()` more
+useful. This is the literal meaning of "grow up and out without deleting anything."
+
+Specs 16–18 are already Layer-3 instruments (decisions made queryable; code↔infra impact;
+provenance). The cluster below makes the layer explicit and leads with the clearest demonstration.
+
+### Analysis instruments (the Layer-3 cluster)
+
+Each is deterministic, computed once and cached, reuses the existing graph, and answers a
+question grep cannot follow and the model is expensive at — and each stands on established
+computer science rather than novelty for its own sake.
+
+| Spec | Instrument | Prior art it stands on | Reuses |
+|---|---|---|---|
+| **19** | **Deterministic Test Impact Selection** — "you changed X; run exactly these tests" | Regression test selection (Ekstazi; RTS++ call-graph-based) | `tested_by` + call edges (already in the graph) |
+| **20** | **Reachability & Dead-Code Analysis** — reachable from any entry point? dead if I delete X? | knip / ts-prune (TS-only); mark-and-sweep from entry points | graph reachability (BFS) |
+| **21** | **Structural Change Analysis** — graph-level diff of a change: edges added/removed, stale callers | semantic / AST diff (difftastic) | diff of two graph snapshots |
+| **22** | **Change-Coupling & Volatility** — files/functions that always change together; churn hotspots | logical / change coupling (CodeScene) | git history (Spec 18's ingestion) |
+| **23** | **Architecture Invariant Guardrails** — "may I import X here?" answered *before* the edit | architecture fitness functions (ArchUnit, dependency-cruiser, import-linter) | dependency graph + Spec 16's decision machinery |
+
+**Backlog (not yet specced — captured so the intent is recorded):**
+
+- **Dependency-upgrade blast radius** — "you are bumping this library; here are the exact
+  functions of yours that call the changed APIs." External-dependency tracking × call graph.
+- **Coarse source→sink reachability** — "every path that reaches the payments/auth/DB sink." The
+  security flavor of reachability; indirect paths grep cannot follow.
+
+These layer on **after** Spec 14 proves the map pays its way. The benchmark is still the gate.
 
 ---
 
@@ -279,6 +345,11 @@ Each step ships on what exists and makes the next cheaper.
 7. **(Horizon-3, optional, may never ship) Cloud OAuth connectors** as a fire-walled, opt-in
    plugin. Only after 1–5 prove the local join is adopted. The *only* step where cloud enters.
 
+Steps 3–4 are already the first **analysis instruments** (decisions-as-graph, code↔infra impact).
+The rest of the Layer-3 cluster — **specs 19–23** (test selection, reachability/dead-code,
+structural diff, change-coupling, invariant guardrails) — layers on after step 1's benchmark.
+See "The analysis layer" above. The benchmark remains the gate for all of it.
+
 ---
 
 ## What to explicitly NOT build
@@ -302,11 +373,13 @@ Each step ships on what exists and makes the next cheaper.
 
 ## Positioning
 
-> **OpenLore is the always-fresh code graph beneath your agent: one `orient()` call gives
-> who-calls, what-breaks, and call-path that grep would burn 20 round-trips to rebuild — plus
-> the only decision-and-drift governance layer that travels with the code.**
+> **OpenLore is the deterministic analysis layer beneath your coding agent: one call tells it
+> what a change breaks, which tests to run, what's coupled, and what architectural rule it would
+> violate — facts *computed* over a local, always-fresh graph, not guessed.**
 
-Local-first. Token-scoped. Auditable edges. Code *and* infrastructure on one graph.
+Local-first. Key-free core. Auditable, deterministic edges. Code *and* infrastructure on one
+graph. *(Public tagline gated on the Spec 14 benchmark — build the instruments first, let the
+numbers earn the claim.)*
 
 ---
 

--- a/docs/specs/openlore-spec-13-context-substrate.md
+++ b/docs/specs/openlore-spec-13-context-substrate.md
@@ -1,280 +1,305 @@
 # OpenLore Spec 13 — The Context Substrate (True North)
 
 > This is a **strategy + architecture** spec, not a single-PR prompt. It defines the
-> direction every subsequent spec should serve, and seeds the concrete next specs
-> (14+) that implement it incrementally. Read it before proposing any large feature.
+> direction every subsequent spec should serve.
+>
+> **Revision note (2026-05-30):** the first draft of this spec overstated several things
+> (a built "code↔org join," "bidirectional SCIP," a published token-savings benchmark, a
+> Zed integration). A verification pass against the codebase and primary sources corrected
+> them. This revision is deliberately **honest about what exists vs. what is aspirational** —
+> because the entire bet depends on claims a reviewer can check in 60 seconds.
 
 ---
 
 ## Progress
 
-Branch: `openlore-spec-13-context-substrate`. Vision locked; roadmap defined; implementation specs to follow.
+Branch: `openlore-spec-13-context-substrate`. Direction locked; claims verified; roadmap is benchmark-first.
 
-- [x] Strategic direction chosen by owner (2026-05-29): **substrate/plumbing**, not breadth-product
-- [x] Competitive landscape mapped (Glean, Onyx, MCP connector zoo, coding-context maps, protocol precedents)
-- [x] Core thesis stated and stress-tested: the *deterministic substrate* bet
-- [x] Compounding roadmap defined (git/co-change → forge → tracker → docs → comms → semantic)
-- [x] Scope discipline written (what OpenLore must NEVER become)
-- [ ] `TODO(spec-14)`: Git / co-change layer — no OAuth, no LLM, ships to every coding agent
-- [ ] `TODO(spec-15)`: Connector write-contract v1 — the ~50-line plugin shape
-- [ ] `TODO(spec-16)`: Cross-source deterministic resolver (ID/URL/email join)
-- [ ] `TODO(spec-17)`: `orient()` over the merged graph — token-budgeted subgraph response
-- [ ] `TODO(future)`: Forge / tracker / docs / comms connectors (each rides existing MCP servers)
-
----
-
-## Context for you (the agent / the maintainer)
-
-OpenLore today is a **deterministic, local-first, token-cheap context engine for code**:
-tree-sitter call graph + clusters + McCabe (no API key), an optional LLM spec/decision
-layer, and a 45-tool MCP runtime fronted by `orient()`. Its measured value is replacing
-15,000–50,000 tokens of file-by-file rediscovery with a ~1–3k targeted orientation pass.
-
-The question this spec answers: **what does OpenLore become next, and what does it
-refuse to become?**
-
-The space is crowded and well-funded:
-
-- **Glean** — enterprise knowledge graph; the real moat is **real-time ACL mirroring**
-  across 100+ connectors, sold to IT. That mirroring is both its moat and its tarpit.
-- **Onyx (ex-Danswer)** — the OSS Glean: MIT, self-hostable, 40+ connectors, hybrid
-  vector+keyword RAG. But it is a **chat-over-your-docs product**, not an agent context layer.
-- **The MCP connector zoo** — Atlassian (official), Notion (official), Google Workspace,
-  Gmail. OAuth + fetching is **already solved**. But these are **dumb pipes**: query-time
-  tools that dump raw pages into the agent's context. Nobody *structures across them*.
-- **Coding-context maps** — Cursor's index, Sourcegraph (Cody/Amp + **SCIP/LSIF**),
-  Augment, Continue, Aider's repo-map. Most are embeddings-over-text or closed/cloud.
-- **Protocol precedents** — **tree-sitter, LSP, SCIP, LSIF, Kythe, GraphRAG.** The
-  durable winners in this space won by being a **contract**, not an app.
-
-### The decision
-
-> **OpenLore is plumbing, not a product.** Its job is to be the deterministic context
-> *substrate* that any agent or tool builds on — the "tree-sitter / SCIP for agent
-> context" — not a Glean-style breadth product with 40 connectors and a chat UI.
-
-This single decision cascades and resolves two otherwise-hard forks for free:
-
-1. **Whose permissions?** → Substrate + local-first ⟹ **token-scoped, not org-wide.**
-   The agent sees what *your* OAuth token sees. No ACL-mirroring engine to build, no
-   security-review nightmare to own. We deliberately cede Glean's enterprise-ACL moat
-   because it is also its tarpit; our user is the *developer and their agent*, not IT.
-2. **Build connectors or ride MCP?** → Substrate ⟹ **ride the existing MCP connectors.**
-   Official Atlassian/Notion/Google MCP servers already solved OAuth + fetch. OpenLore
-   sits **above** them as the layer that builds the deterministic, cross-joined graph.
-   We do not re-implement OAuth twelve times. We do not enter the connector graveyard.
+- [x] Strategic lens chosen by owner (2026-05-29): **substrate/plumbing**, not breadth-product
+- [x] Competitive + market reality verified against primary sources (2026-05-30)
+- [x] Repo ground-truth established (what actually ships vs. what was claimed)
+- [x] Theses adversarially stress-tested; positioning corrected to survive the strongest attack
+- [ ] `TODO(spec-14)`: **WITH-vs-WITHOUT token-savings benchmark** — the bleeding wound; do this FIRST
+- [ ] `TODO(spec-15)`: Dogfood the decision/drift governance in OpenLore's own repo
+- [ ] `TODO(spec-16)`: Promote `Decision` to a first-class graph node with `affects` edges
+- [ ] `TODO(spec-17)`: Cross-domain impact query (code → infra) as a headline `orient` capability
+- [ ] `TODO(spec-18)`: Local org-artifact join (git/PR metadata via local `gh`) — no OAuth
+- [ ] `TODO(horizon-3, optional, may never ship)`: cloud OAuth connectors as a fire-walled plugin
 
 ---
 
-## The core thesis (the load-bearing bet)
+## Context — the decision and what it cascades
 
-> **There is a large DETERMINISTIC substrate inside org data that competitors needlessly
-> pay an LLM / embeddings to rediscover.**
+OpenLore today is a **deterministic, local-first code context engine**: a tree-sitter call
+graph + clusters + McCabe (no API key), an optional LLM spec/decision layer, and a 45-tool
+MCP runtime fronted by `orient()`.
 
-Glean and Onyx treat everything as text → embed → retrieve. But an enormous amount of
-structure is **explicitly stated** and needs no inference:
+The owner chose the **substrate/plumbing** lens (be the layer others build on, like
+tree-sitter / SCIP / LSP), not the Glean-style breadth product. That single choice cascades:
 
-| Source | Deterministic structure (no LLM) |
-|--------|----------------------------------|
-| Jira / Linear | epics→stories→subtasks, blocks/blocked-by, assignees, sprints, status transitions |
-| Confluence / Notion | page trees, backlinks, @mentions, spaces |
-| Google Drive | folder tree, sharing/ownership edges, doc-to-doc links |
-| Gmail / Slack | thread structure (`References`/`In-Reply-To`), sender/recipient graph |
-| GitHub / forge | PR ↔ issue ↔ commit ↔ file, reviews, cross-refs |
-| Code (today) | call graph, imports, clusters — already OpenLore's core |
+1. **Whose permissions?** → local-first ⟹ **token-scoped, not org-wide.** No ACL-mirroring
+   engine (Glean's moat *and* its tarpit). Our user is the developer and their agent, not IT.
+2. **Build connectors or ride MCP?** → substrate ⟹ ride existing MCP connectors where org
+   data is ever needed; do not re-implement OAuth twelve times.
 
-And the gold nobody mines: **these systems cross-reference each other.** A Jira ticket
-pastes a Confluence URL that links a Google Doc implemented in a GitHub PR discussed in
-an email thread. **Every one of those edges is a deterministic join on an ID, URL, or
-email address** — no embeddings, no hallucinated relationships, fully auditable, offline.
-
-This is *exactly* OpenLore's existing philosophy (Layer 1 = deterministic; Layers 2/3 =
-optional semantic) applied to the org instead of the repo. Embeddings are reserved only
-for the genuinely fuzzy edge — "these two docs are *about* the same thing even though
-neither links the other" — which becomes an **optional** layer on top, same as for code.
-
-### The unique unlock — the join no competitor has
-
-OpenLore already owns the **code graph**. Glean and Onyx index code as *text*; they are
-blind to call topology. Coding-context maps own the code graph but have no org context.
-**Nobody joins the two.** Wire the call graph into the org graph in one structure and you
-get an edge chain that is genuine white space:
-
-```
-function exportToCsv()
-   → implements   → JIRA-412
-   → specced-in   → Confluence "Export v2"
-   → designed-in  → Drive design doc
-   → discussed-in → email thread
-```
-
-When an agent says *"implement OAuth for the export feature,"* one `orient()` call returns
-that whole subgraph — ranked, with ~200-token summaries and stable IDs — instead of six
-MCP calls dumping 50k tokens of raw pages. The agent then lazy-fetches only the one or two
-leaves it actually needs. **That is the token-saving, context-management story, and it is
-just `orient()` extended past the repo boundary.**
+The rest of this spec is about getting the *positioning* right, because the lens alone does
+not survive contact with the 2026 market without a sharper claim.
 
 ---
 
-## What "be plumbing" actually means
+## The verified market reality (2026)
 
-The precedent to copy is **tree-sitter / SCIP / LSP**: adopted because they are a
-*contract*, not an app. OpenLore-the-binary becomes the **reference implementation** of a
-contract that others can emit into, query, or reimplement. Three things must be nailed:
+**Several leading coding agents have de-emphasized embedding-based RAG for code *navigation*
+in favor of on-demand agentic search (grep/glob/file-reading).** This is real and primary-sourced,
+but "RAG is dead for coding agents" is commentator hype — state it precisely:
 
-### 1. The format (the actual deliverable)
+- **Confirmed (primary):** Claude Code deliberately moved *off* a local vector DB to agentic
+  search. Boris Cherny (Claude Code creator, Anthropic): *"Early versions of Claude Code used
+  RAG + a local vector db, but we found pretty quickly that agentic search generally works
+  better… It is also simpler and doesn't have the same issues around security, privacy,
+  staleness, and reliability."* and *"It outperformed everything. By a lot."* (Latent Space,
+  2025-05-07; HN item 43164253).
+- **Counter-example (do not ignore):** **Cursor invested in custom code embeddings** and reports
+  measurable gains (≈12.5% higher answer accuracy; better retention on 1,000+ file repos),
+  concluding the best results come from **grep + semantic search combined** (cursor.com/blog/semsearch,
+  2025-11-06).
+- **Consensus:** the winning pattern is **hybrid** — lexical/symbol search for source code,
+  semantic retrieval for large/unstructured corpora (Augment: *"don't throw away your retrieval
+  systems — expose them as tools"*, jxnl.co, 2025-09-11). The anti-RAG case is **scoped to
+  navigating structured source code**, not document Q&A.
 
-A versioned, **on-disk, git-diffable** node/edge schema with **provenance**. Deterministic
-means inspectable: you can `cat` the graph and see exactly *why* an edge exists — which URL,
-which ID, which commit produced it. No black-box embedding silently deciding a relationship.
-
-This already has seeds in-repo: **Spec 04 (SCIP export)** makes the code graph consumable by
-the SCIP/Glean ecosystem; **Spec 05 (federation manifest, `.well-known/openlore.json`)** is
-the "SBOM-of-cognition" self-description. Spec 13 generalizes these: the context graph is the
-union of code symbols + org nodes + the deterministic edges between them, persisted locally.
-
-Minimal node/edge contract (v1 sketch — to be pinned in Spec 15/16):
-
-```jsonc
-// Node — anything addressable across any source
-{
-  "id": "openlore://github/clay-good/openlore/pr/95",  // stable, source-qualified URI
-  "type": "pull_request",          // function | file | issue | doc | page | email | person | commit | pr ...
-  "source": "github",
-  "title": "fix: quiet install re-runs",
-  "ts": "2026-05-28T14:02:00Z",
-  "perms": "token-scoped",         // visible because YOUR token saw it; no ACL mirror
-  "summary": null                  // optional, lazily filled; NOT raw content
-}
-
-// Edge — every edge carries provenance so it is auditable
-{
-  "from": "openlore://github/.../pr/95",
-  "to":   "openlore://jira/PROJ/issue/412",
-  "type": "references",            // implements | references | mentions | parent_of | authored_by | co_changes_with | specced_in ...
-  "deterministic": true,
-  "provenance": { "kind": "url_in_body", "evidence": "https://.../browse/PROJ-412" }
-}
-```
-
-### 2. The read interface
-
-`orient()` over MCP — already shipped for code; extended to traverse the merged graph.
-"Go-to-definition" for *context*. Stable verb, agent-agnostic.
-
-### 3. The write contract
-
-A connector so small (~50 lines: "emit these nodes, these edges") that the community
-actually writes them. Heaviness is what killed prior connector ecosystems. Where possible,
-a connector is a **thin adapter over an existing MCP server**, not a fresh OAuth client.
+**Implication for OpenLore:** do not pitch a *better index*. The defensible lane is the
+**structural / relational** answer that grep is architecturally incapable of giving cheaply —
+reverse edges (callers), transitive blast radius, call paths, cross-file/infra dependency
+projection — answered in **one** MCP call instead of O(many) grep+read round-trips, and kept
+**fresh incrementally** so it never carries the staleness tax Cherny rejected.
 
 ---
 
-## The compounding roadmap (the part that adds up)
+## The competitive landscape (honest, as-of 2026-05-30)
 
-Every new source is the **same move**: ingest → extract its native deterministic graph →
-join to the existing graph on shared IDs/URLs/emails. Each join makes *every prior source
-more valuable*, because edges compose into multi-hop chains. Sequenced cheapest-and-highest-
-trust first:
+The pure "local code-graph MCP" lane is **crowded**, and two competitors have far more
+traction than OpenLore. Stated plainly so we never pretend otherwise:
 
-1. **Git / co-change layer — `TODO(spec-14)`.** *No OAuth, no LLM, already local.* Blame,
-   history, and the killer signal AST cannot see: **co-change edges** ("these files/functions
-   change together"). Bridges code → people → intent before touching a single connector.
-   Ships value to **every** coding agent on day one. **This is the wedge.**
-2. **Forge layer (your token).** PR ↔ issue ↔ commit ↔ file ↔ review. Explicit links =
-   deterministic. Code gets its first layer of *why*. Reuses Spec 04/05 plumbing.
-3. **Tracker layer (Jira / Linear via MCP).** Issue/epic graph + its explicit PR links.
-   code → PR → issue → epic.
-4. **Docs layer (Confluence / Notion / Drive via MCP).** Page trees, backlinks, and the
-   cross-source URLs that link docs to issues. The cross-source join lights up here.
-5. **Comms layer (Gmail / Slack).** Thread graph + the URLs inside messages. The
-   "discussed-in" edges that close the loop back to code.
-6. **Semantic layer (optional, last).** Embeddings *only* for the fuzzy "about the same
-   thing" edges the deterministic layers cannot produce. Exactly today's Layer-1/Layer-2 split.
+| Project | License | Tech | Stars* | Notable |
+|---------|---------|------|--------|---------|
+| **Serena** (`oraios/serena`) | MIT | **LSP-based** (not tree-sitter) | ~24,800 | Symbolic retrieval + editing; "the IDE for your agent." No published token benchmark. |
+| **CodeGraph** (`colbymchenry/codegraph`) | MIT | tree-sitter → SQLite/FTS5 | ~34,000 | ~10 MCP tools (`trace/callers/callees/impact`). **Publishes a WITH-vs-WITHOUT benchmark.** |
+| **tokensave** (`aovestdipaperino/tokensave`) | MIT | tree-sitter → libSQL/FTS5 | ~150 | 40+/48 MCP tools; self-reported "93% retrieval savings" (largely on its own repo). |
+| **code-graph-mcp** (`sdsrss/...`) | **unverifiable** (no LICENSE file) | tree-sitter | ~37 | Self-reported "5–20× fewer tokens." Low traction. |
 
-By step 5, a single `orient()` traverses `function → PR → issue → doc → email` in one chain
-no competitor can produce — reached by adding edge *types* to one graph, never rebuilding.
+\* GitHub API, 2026-05-30; stars move — cite with the as-of date.
 
-### Cross-cutting concerns each step inherits
+**CodeGraph already ships the benchmark we were claiming as our moat.** Its README reports
+(median of 4 runs, 7 OSS repos, Claude Opus 4.8 headless, with/without its MCP server):
+**"25% cheaper, 57% fewer tokens, 23% faster, 62% fewer tool calls"** (per-repo highs reach
+~70% fewer tokens / ~80% fewer tool calls). The "~35% / ~70%" figure seen elsewhere is a
+third-party blog tagline / per-repo best, not its headline average — do not misquote it.
 
-- **Identity resolution.** Stitch "Clay in Jira" = "clay-good on GitHub" = "hi@claygood.com"
-  deterministically on email/handle where possible; a small fuzzy layer only for the residual.
-  Persisted as `person` nodes with `same_as` edges carrying provenance.
-- **Freshness.** Today's file-watcher does incremental code sync. The analog is webhook/delta
-  pull per source. Real-time is *not* required for v1 — a manual/periodic refresh is fine; the
-  graph records `ts` so staleness is visible. Do not over-build sync before the graph is proven.
-- **Token-scoped permissions.** No ACL mirror. Every node is in the graph because *your* token
-  fetched it. This is a feature (zero security engine), documented as an explicit non-goal of
-  enterprise multi-tenant indexing.
+**The redundancy risk is therefore the #1 risk, and it lands hardest in the narrow lane.**
+If OpenLore ships "another local code-graph MCP," it loses a knife fight on traction and
+published evidence. The only escape is to compete where these tools **do not play at all**
+(see "True North" below) and to publish our own benchmark (see roadmap step 1).
 
 ---
 
-## Scope contract — what OpenLore must NEVER become
+## Ground truth — what OpenLore *is*, and what it is *not yet*
 
-To stay plumbing and not drift into a product:
+This section exists so no future claim outruns the code. All items verified against the repo
+on 2026-05-30.
 
-- **No chat UI.** We do not answer questions; we serve a graph the agent reasons over.
-- **No LLM hosting / no embedding service.** Semantic layer is optional and BYO (see Spec 06,
-  BM25-without-embeddings — deterministic retrieval must always work with zero network).
-- **No org-wide ACL mirroring / multi-tenant index.** Token-scoped only. Ceded to Glean on purpose.
-- **No re-implementing OAuth per service.** Ride existing MCP connectors; thin adapters only.
-- **No mirroring of raw content.** Store the **graph** (IDs, links, titles, small summaries,
-  provenance) and **lazy-fetch** content on demand. Token savings come from never pulling a full
-  doc until the agent picks it.
-- **No required network, ever, for the deterministic core.** Offline-first is identity, not a feature.
+### Confirmed assets (real, citable)
 
-The test, inherited from the project's surgical-change ethos: **every feature must make the
-graph more queryable or more deterministic. If it adds a surface the agent talks *to* instead
-of a graph the agent reasons *over*, it does not belong in OpenLore.**
+- **Deterministic code graph + fast orient.** `orient()` path (search + 5×callers + callees)
+  runs **~429µs p50** on the TypeScript compiler (~15k nodes), per
+  [scripts/BENCHMARKS.md](../../scripts/BENCHMARKS.md) (200 iters after warmup) and
+  [README.md:206](../../README.md#L206). High trust; repeatable.
+- **Typed edges, but only four kinds.** `EdgeKind = 'calls' | 'tested_by' | 'references' |
+  'depends_on'` — [src/core/analyzer/call-graph.ts:39](../../src/core/analyzer/call-graph.ts#L39).
+  `references`/`depends_on` are produced **only by the IaC parsers**; `tested_by` by test
+  detection. **No edge originates from git, PRs, or docs.**
+- **Code + infrastructure on one primitive.** The IaC subsystem (terraform/pulumi/k8s/
+  cloudformation/cdk/ansible/helm) projects resources onto the *same* `FunctionNode/CallEdge/
+  ClassNode` graph — [src/core/analyzer/iac/types.ts](../../src/core/analyzer/iac/types.ts),
+  [project.ts](../../src/core/analyzer/iac/project.ts). **This is a genuine differentiator no
+  code-only competitor has.**
+- **Decision store + spec-drift gate.** Decisions carry SHA-stable 8-char IDs and `affectedFiles`
+  ([src/core/decisions/store.ts:123](../../src/core/decisions/store.ts#L123),
+  [src/types/index.ts](../../src/types/index.ts)); the `record_decision → consolidate → commit
+  gate → spec sync → drift` workflow exists in code. **No navigation competitor ships decision
+  governance or a spec-drift gate.**
+- **SCIP export** with a correct human-readable string-moniker scheme
+  ([src/core/scip/moniker.ts](../../src/core/scip/moniker.ts)).
+
+### What does NOT exist yet (do not claim it)
+
+- **There is no "code↔org join via parsed edges."** Three of the four advertised org artifacts
+  are unbuilt: **PRs are never parsed; git is used only for changed-file drift diffing; in-repo
+  docs are explicitly *excluded* from drift** ([drift-detector.ts](../../src/core/services/drift-detector.ts)
+  skips `docs/`). The fourth (decisions) is **not a graph join** — `orient` surfaces decisions
+  by a plain string set-membership test on `affectedFiles`
+  ([orient.ts:367](../../src/core/services/mcp-handlers/orient.ts#L367)), not a traversable edge.
+- **SCIP is one-way export only** — [src/cli/export/scip.ts:6](../../src/cli/export/scip.ts#L6)
+  says so explicitly. There is no import path. **Do not brand "bidirectional SCIP."**
+- **The headline "~1–3k vs 15–50k tokens" claim is unmeasured.** It is a generic assertion in
+  [README.md:19](../../README.md#L19), not a benchmark. There is no end-to-end WITH-vs-WITHOUT
+  agent-run measurement in the repo; `BENCHMARKS.md` measures raw DB query latency only.
+- **No Zed integration exists.** Install targets are Claude Code, Cursor, Cline, Continue,
+  AGENTS.md. Earlier drafts' "Zed has no index" anchor was fabricated — drop it.
+- **Decision content is LLM-extracted**, so "deterministic" applies to the graph and the
+  ID/file addressing, **not** to the decision text.
+- **The governance gate is not even active in OpenLore's own repo** (its `.openlore/decisions/`
+  is empty). The flagship dogfood project does not yet run its own differentiator.
+
+---
+
+## The True North
+
+> **OpenLore is the always-fresh, deterministic *structural substrate beneath* agentic search —
+> it answers who-calls / what-breaks / call-path in one sub-millisecond MCP call against a typed
+> code graph that also spans infrastructure, and it uniquely pairs that graph with a governance
+> layer (recorded decisions + a spec-drift gate) that no navigation competitor ships.**
+
+The substrate is the **credibility proof**, not the pitch. The pitch is the two things the
+crowded cohort does not have: **cross-domain (code↔infra) impact** and **decision/drift
+governance coupled to the graph.**
+
+**Defense against the strongest attack** — the marginal-value / "Cherny killed the index"
+objection: Anthropic moved Claude Code off a *semantic RAG embeddings* index, a like-for-like
+substitution where lexical grep genuinely won. OpenLore is not a semantic retriever; it is a
+**typed relational graph** answering reverse-edge and transitive-impact queries that iterative
+grep+read can only reconstruct through many round-trips. The staleness tax Cherny rejected was a
+*batch re-index*; OpenLore answers it with **incremental** watcher updates, so the staleness
+surface is small. This survives — but only once the benchmark (step 1) proves the round-trip
+savings are real. Until then it is a hypothesis, not a result.
+
+---
+
+## How the org-context dream fits — the honest answer
+
+The owner's original excitement was bringing in **all** context (Jira/Notion/Drive/Gmail via
+OAuth) and joining it to code. Here is the truth, sequenced:
+
+- **It is a deferred horizon — closer to a separate product than to core.** The deterministic
+  code↔org *join* does not exist today (3 of 4 artifacts unbuilt; decisions are a filter).
+- **Cloud OAuth connectors would detonate OpenLore's one verified advantage.** The moment you
+  ingest Gmail/Drive/Jira over OAuth, you inherit exactly what Cherny listed as reasons to
+  *avoid* an index — security, privacy, staleness, "uploading sensitive context to a third
+  party." OpenLore's entire credibility rests on *local, deterministic, no cloud.* Cloud
+  connectors trade the moat for a feature Glean and every RAG vendor already sell.
+- **So the join enters LOCAL-first, with zero cloud surface:** git history + PR metadata via
+  local `gh`/git, and in-repo ADRs/docs as decision sources. That is the "code↔org join" made
+  real without OAuth.
+- **Cloud OAuth is horizon-3:** opt-in, clearly fire-walled, **never default, never the pitch**,
+  and only after the local join is proven and adopted. It may never ship — and that is fine.
+
+The vision is preserved. It is just correctly sequenced behind the things that make OpenLore
+defensible first.
+
+---
+
+## The compounding roadmap (benchmark-first, local throughout)
+
+Each step ships on what exists and makes the next cheaper.
+
+1. **Ship the WITH-vs-WITHOUT benchmark first.** Claude Code headless, N≥4 runs, ≥5 OSS repos,
+   with/without the MCP server, reporting tokens / tool-calls / cost / wall-clock in a per-repo
+   table — mirror CodeGraph's published methodology so it is apples-to-apples. Until it lands,
+   **demote the README "~1–3k vs 15–50k" line to a hypothesis.** *Verify:* a reproducible
+   `BENCHMARKS.md` end-to-end section. *This step decides which product OpenLore actually is.*
+2. **Dogfood the governance.** Turn the gate on in OpenLore's own repo; accumulate real
+   decisions; sync them into specs. *Verify:* non-empty decision store + synced spec sections.
+3. **Make `Decision` a first-class graph node** with `affects` edges to functions/files,
+   traversable by `analyze_impact`/`get_subgraph`. This converts the string-filter weakness into
+   the deterministic join we want. *Verify:* `analyze_impact(file)` returns decisions as graph
+   neighbors, not a post-hoc filter.
+4. **Land the cross-domain impact query** — route → handler → the Terraform/K8s resource that
+   deploys it. The IaC subsystem already shares primitives; wire the end-to-end traversal as a
+   headline capability. *Verify:* one published code→infra blast-radius example. No grep-agent
+   or code-only competitor can do this.
+5. **Local org-artifact join — no OAuth.** Parse git blame/history + PR metadata via local
+   `gh`/git into `authored_by`/`changed_in_pr` edges; ingest in-repo ADRs as decision sources.
+   *Verify:* orient surfaces "who last changed this, in which PR/decision" as graph edges.
+6. **Harden distribution on real anchor hosts.** Lead with **Claude Code** (verified: off RAG,
+   native grep, no index — the textbook complement). One-command install tested for Claude
+   Code + Cursor + Cline. (Only name Zed if/when it is actually wired.)
+7. **(Horizon-3, optional, may never ship) Cloud OAuth connectors** as a fire-walled, opt-in
+   plugin. Only after 1–5 prove the local join is adopted. The *only* step where cloud enters.
+
+---
+
+## What to explicitly NOT build
+
+- **No semantic/embedding RAG for code navigation.** The graph is relational, not semantic;
+  keep it that way. You lose to free built-in grep there.
+- **No "bidirectional SCIP" branding.** It is one-way export
+  ([src/cli/export/scip.ts:6](../../src/cli/export/scip.ts#L6)). Frame it honestly as "export
+  for Sourcegraph/Glean interop." Stop making it a headline noun.
+- **No cloud OAuth connectors as a core/default feature.** They detonate the local-deterministic
+  moat. Plugin-only, horizon-3, or not at all.
+- **No fighting bare code-navigation on traction.** Serena (~24.8k) and CodeGraph (~34k) win
+  that fight. Do not pitch "a better grep."
+- **No tool-count race.** tokensave ships 48 tools; that is surface area, not a moat. Keep
+  `orient` as the frozen single entry verb (the LSP lesson: standardize the thinnest contract).
+- **No chat UI, no LLM hosting, no agent loop.** Be the layer others build above.
+- **No claiming benchmarks or integrations you have not shipped.** A reviewer falsifies the
+  15–50k figure and the Zed claim in 60 seconds, and it taints everything else that is true.
 
 ---
 
 ## Positioning
 
-> **OpenLore: the deterministic context graph for AI agents — tree-sitter for your org,
-> not just your code.**
+> **OpenLore is the always-fresh code graph beneath your agent: one `orient()` call gives
+> who-calls, what-breaks, and call-path that grep would burn 20 round-trips to rebuild — plus
+> the only decision-and-drift governance layer that travels with the code.**
 
-Local-first. Token-cheap. Auditable edges. Rides the MCP ecosystem it sits above.
+Local-first. Token-scoped. Auditable edges. Code *and* infrastructure on one graph.
 
 ---
 
-## Risks and kill signals
+## Biggest risk + earliest kill signal
 
-| Risk | Earliest signal the bet is wrong |
-|------|----------------------------------|
-| **Redundancy with coding-context maps** (Cursor/SCIP/Augment already "good enough") | Spec 14 (co-change) lands and no agent workflow measurably improves over plain file reads |
-| **Deterministic substrate is too thin** — the useful edges turn out to need LLM inference after all | In the forge/tracker layers, >50% of valuable edges require fuzzy matching, not ID/URL joins |
-| **Connector contract too heavy** — community doesn't write connectors | After Spec 15, no external contributor ships a connector in <1 day |
-| **MCP servers can't bulk-crawl** — query-time tools won't enumerate for graph construction | Tracker/docs layers stall because official MCP servers expose no listing; forces direct-API fallback (raises maintenance back toward connector-graveyard levels) |
-| **No distribution** — substrate with no consumers | After 6 months, OpenLore is not the default context layer under any agent it didn't ship itself |
+- **Biggest risk: marginal-value collapse.** If, in real agent loops, "a few greps" get close
+  enough to one `orient()` call, the freshness/structure tax is not worth it and OpenLore is a
+  complement nobody installs — exactly the lane Cherny's data threatens.
+- **Earliest kill signal:** the step-1 benchmark comes back showing **<15% token/tool-call
+  reduction** vs. plain agentic grep on relational queries (meaningfully worse than CodeGraph's
+  published ~25%/~62%). If so, the substrate pitch is dead and the only surviving reason to
+  exist is the **governance layer** — at which point pivot hard to "decision-and-drift
+  governance for agents" and stop competing as a code graph at all.
 
-The single biggest risk is **redundancy**: if the coding-context incumbents are already
-good enough that the *deterministic + cross-domain join* doesn't change agent outcomes, the
-substrate has no reason to exist. The co-change layer (Spec 14) is deliberately first because
-it is the cheapest possible test of that risk — it needs no auth, no LLM, and either visibly
-improves orientation or it doesn't.
+**Run the benchmark before writing another line of feature code. It tells you which product you
+actually have.**
 
 ---
 
 ## Relationship to existing specs
 
-- **Spec 04 (SCIP export)** — interop format; the code half of the substrate, already shippable.
-- **Spec 05 (federation manifest)** — cross-repo self-description; the "SBOM of cognition." The
-  context graph is the natural superset (org nodes + cross-source edges added to the same idea).
+- **Spec 04 (SCIP export)** — one-way export for ecosystem interop. Honest framing only.
+- **Spec 05 (federation manifest)** — cross-repo self-description ("SBOM of cognition"); the
+  natural superset once the single-repo graph is proven.
 - **Spec 06 (BM25 without embeddings)** — guarantees deterministic retrieval with zero network;
-  the floor the semantic layer sits on top of, never replaces.
-
-Specs 14–17 (git/co-change, connector contract, cross-source resolver, merged `orient()`) are
-the concrete first implementations of this true north and should be written next.
+  the floor any optional semantic layer sits on, never replaces.
 
 ---
 
-## Appendix — the reasoning trail (brainstorm of 2026-05-29)
+## Sources & verification provenance
 
-This spec is the durable output of a brainstorming session. The reasoning, the rejected
-alternatives, and the multi-agent stress-test synthesis are appended below so a future
-session can re-derive *why* without repeating the exploration.
+External (primary unless noted):
+- Cherny on Claude Code off RAG — Latent Space, *"Claude Code: Anthropic's Agent in Your Terminal,"* 2025-05-07; HN item 43164253.
+- Augment / grep vs embeddings — jxnl.co, *"Why Grep Beat Embeddings in Our SWE-Bench Agent,"* 2025-09-11.
+- Cursor semantic search — cursor.com/blog/semsearch, 2025-11-06.
+- Glean knowledge graph / Onyx — glean.com, github.com/onyx-dot-app/onyx (earlier landscape pass).
+- Competitor stars/licenses — GitHub API, 2026-05-30 (point-in-time).
+- **Unverified secondary (do not cite as fact):** an Amazon Science paper (~Feb 2026) reportedly
+  finding agentic search reaches >90% of RAG performance without a vector DB — not independently
+  opened; treat as rumor until the paper is read.
 
-> The multi-agent "true north" workflow synthesis is appended in a follow-up commit to this
-> same PR (research of coding-context-map competitors, protocol-precedent lessons, adversarial
-> stress-tests of the three core theses, and the judged candidate true-norths).
+Repo facts: file:line references inline above, verified 2026-05-30.
+
+## Appendix — the reasoning trail
+
+This spec is the durable output of a brainstorming session plus two multi-agent research
+workflows (landscape + candidate true-norths; then verification + adversarial stress-test +
+synthesis). The verification pass is what corrected the first draft's overstatements. A future
+session can re-run the same shape to re-validate as the market moves.

--- a/docs/specs/openlore-spec-13-context-substrate.md
+++ b/docs/specs/openlore-spec-13-context-substrate.md
@@ -85,6 +85,42 @@ adds to it; it does not change or break it.** Concretely:
 strictly better or strictly broader, while leaving every current behavior intact?* If not, it
 does not belong here.
 
+### Compatibility verification (grounded against the code, 2026-05-30)
+
+A read-only pass over the subsystems specs 14–23 touch confirms the additions are additive, and
+names the *specific mechanism* that makes each safe — so this is evidence, not assertion:
+
+- **New edge kinds are safe.** Nothing in the codebase switches *exhaustively* on `EdgeKind`. The
+  only pattern that inspects it is the defensive filter `e => !e.kind || e.kind === 'calls'`
+  ([call-graph.ts](../../src/core/analyzer/call-graph.ts#L39) and the analysis handlers), so a new
+  kind is simply *excluded* from call-only logic by default — it cannot break existing traversal.
+  A filter opts a new kind in explicitly only where wanted. This is exactly how the IaC
+  `references`/`depends_on` kinds already coexist with `calls`.
+- **New node types are safe.** Nodes live in dedicated tables (`nodes`, `classes`); a new type
+  (e.g. decision nodes, Spec 16) adds a table and bumps `SCHEMA_VERSION`. On a bump the edge store
+  **drops and rebuilds from source** ([edge-store.ts](../../src/core/services/edge-store.ts),
+  `SCHEMA_VERSION = 2`) — no migration, no data loss, one re-analyze.
+- **Retrieval cannot break, because tool responses are additive by contract.** `orient`,
+  `analyze_impact`, and `get_subgraph` return `unknown`; consumers *cast* (`as OrientResult`), they
+  do not schema-validate. Adding optional fields is invisible to them. The only discipline is:
+  *never remove or retype an existing field.*
+- **The analysis instruments reuse existing traversal.** `bfs()` / `bfsFromDB()` /
+  `buildAdjacency()` ([graph.ts](../../src/core/services/mcp-handlers/graph.ts)) already power
+  `analyze_impact` and `get_subgraph`; test selection, reachability, and structural diff are new
+  *callers* of these primitives, not changes to them.
+- **Decisions, drift, and git are untouched in shape.** The decision file format
+  (`.openlore/decisions/pending.json`, `version: '1'`) and the gate are unchanged by Spec 16
+  (the graph projection is derived and optional). The drift detector already excludes `docs/`
+  ([drift-detector.ts](../../src/core/drift/drift-detector.ts)). Git is read locally via
+  [git-diff.ts](../../src/core/drift/git-diff.ts) (`execFile('git', …)`; no `gh` today); Specs
+  18/22 add new read functions beside the existing ones.
+- **Benchmarks are added, not modified.** `scripts/bench.ts` and `scripts/bench-mcp.ts` measure
+  query/handler latency; Spec 14 adds a new end-to-end script beside them.
+
+**Net:** every instrument is a new *reader* of existing data, plus at most an additive edge kind
+or node table behind a `SCHEMA_VERSION` bump. Retrieval is a hard dependency of analysis, so it is
+preserved *by construction* — we build **on** it, never around it.
+
 ## How the shape of the product changes
 
 This is growth along the axis OpenLore already chose, not a turn onto a new one:
@@ -195,7 +231,7 @@ on 2026-05-30.
 
 - **There is no "code↔org join via parsed edges."** Three of the four advertised org artifacts
   are unbuilt: **PRs are never parsed; git is used only for changed-file drift diffing; in-repo
-  docs are explicitly *excluded* from drift** ([drift-detector.ts](../../src/core/services/drift-detector.ts)
+  docs are explicitly *excluded* from drift** ([drift-detector.ts](../../src/core/drift/drift-detector.ts)
   skips `docs/`). The fourth (decisions) is **not a graph join** — `orient` surfaces decisions
   by a plain string set-membership test on `affectedFiles`
   ([orient.ts:367](../../src/core/services/mcp-handlers/orient.ts#L367)), not a traversable edge.

--- a/docs/specs/openlore-spec-14-agent-benchmark-harness.md
+++ b/docs/specs/openlore-spec-14-agent-benchmark-harness.md
@@ -1,0 +1,78 @@
+# OpenLore Spec 14 — Agent Token-Efficiency Benchmark Harness (WITH vs WITHOUT)
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md). **Do this spec first.**
+
+---
+
+## Progress
+
+Branch: `openlore-spec-14-agent-benchmark-harness`. Not started.
+
+- [ ] Task suite (relational queries where a graph beats grep) + a control task
+- [ ] Harness: drive a headless agent WITH and WITHOUT the openlore MCP server
+- [ ] Metric capture: tokens, tool-calls, cost, wall-clock — per repo and aggregate
+- [ ] Pinned repo set (fixed commit SHAs) for reproducibility
+- [ ] Committed results doc with a one-command reproduce path
+- [ ] Demote the unmeasured README token claim to a hypothesis until results land
+
+---
+
+## Context for you (the agent)
+
+OpenLore's headline value claim — that `orient()` replaces a costly file-by-file orientation
+pass — is currently **unmeasured**. The figure in [README.md:19](../../README.md#L19) and
+[README.md:50](../../README.md#L50) is an assertion, not a result; [scripts/BENCHMARKS.md](../../scripts/BENCHMARKS.md)
+measures only raw EdgeStore query latency (~429µs p50), which is plumbing, not an end-to-end
+agent outcome.
+
+This is the single most falsifiable claim in the project, and a competitor (CodeGraph) already
+publishes the exact benchmark we lack: median of 4 runs across 7 OSS repos, headless agent,
+with/without its MCP server, reporting cost / tokens / tool-calls / wall-clock. We need our own,
+apples-to-apples. This harness is also the **kill-signal instrument** from Spec 13: if the
+measured reduction on relational queries is small, that is the earliest signal to re-weight
+toward the governance layer.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Change any runtime behavior of `orient`, the graph, or the analyzer.
+- Modify or remove the existing micro-benchmarks (`scripts/bench.ts`, `scripts/bench-mcp.ts`,
+  `npm run bench`, `npm run bench:mcp`) — add alongside them.
+- Make network calls part of the core product; the harness is a dev/CI tool only.
+- Inflate or hand-pick results. Pin inputs, publish methodology, report losses honestly.
+
+This PR must:
+
+- Add a separate harness (e.g. `scripts/bench-agent.ts`, `npm run bench:agent`) that runs a
+  fixed task suite against pinned OSS repos, once WITH the openlore MCP server configured and
+  once WITHOUT, capturing tokens / tool-calls / cost / wall-clock.
+- Produce a committed, reproducible results document (`docs/AGENT-BENCHMARKS.md`) with the full
+  methodology (repos + SHAs, task list, run count, agent + model, how metrics were captured).
+- Update the README to cite the measured numbers, and until they exist, mark the token-savings
+  line explicitly as a hypothesis pending this benchmark.
+
+## The deliverable
+
+- **Task suite** — queries where a relational graph is structurally cheaper than iterative
+  grep+read: enumerate callers of a symbol, blast radius of a signature change, a call path
+  between two functions, plus a "find where feature X lives" control task. Tasks must have
+  checkable answers so a run can be scored, not just measured.
+- **Harness** — toggles the openlore MCP server in the agent config, runs each task N≥4 times
+  per repo across ≥5 pinned repos, and records the metrics. Determinism: pin repo SHAs; fix the
+  model; record the agent/CLI version.
+- **Results** — a per-repo table plus aggregate, mirroring the competitor's published format so
+  comparison is fair. Include variance, not just medians.
+
+## Acceptance
+
+- A reviewer runs one documented command and reproduces the table.
+- Numbers are committed in `docs/AGENT-BENCHMARKS.md`; the README cites them (or marks the claim
+  as a pending hypothesis).
+- If the reduction on relational queries is below the Spec 13 kill-signal threshold, open a
+  follow-up to re-weight toward the governance layer — do not bury the result.
+
+## Compatibility note
+
+Pure addition: a new dev/CI script and a docs file. No user-facing or runtime change.

--- a/docs/specs/openlore-spec-14-agent-benchmark-harness.md
+++ b/docs/specs/openlore-spec-14-agent-benchmark-harness.md
@@ -31,7 +31,8 @@ publishes the exact benchmark we lack: median of 4 runs across 7 OSS repos, head
 with/without its MCP server, reporting cost / tokens / tool-calls / wall-clock. We need our own,
 apples-to-apples. This harness is also the **kill-signal instrument** from Spec 13: if the
 measured reduction on relational queries is small, that is the earliest signal to re-weight
-toward the governance layer.
+toward the governance layer. And it is the **gate for the entire Layer-3 analysis cluster**
+(specs 19–23): those instruments layer on only after this benchmark shows the graph earns its keep.
 
 ## Scope contract — do not break these things
 
@@ -58,7 +59,9 @@ This PR must:
 - **Task suite** — queries where a relational graph is structurally cheaper than iterative
   grep+read: enumerate callers of a symbol, blast radius of a signature change, a call path
   between two functions, plus a "find where feature X lives" control task. Tasks must have
-  checkable answers so a run can be scored, not just measured.
+  checkable answers so a run can be scored, not just measured. As Layer-3 instruments ship
+  (specs 19–23), add their tasks too — e.g. "which tests cover this change?" — so the benchmark
+  measures the analysis layer, not just orientation.
 - **Harness** — toggles the openlore MCP server in the agent config, runs each task N≥4 times
   per repo across ≥5 pinned repos, and records the metrics. Determinism: pin repo SHAs; fix the
   model; record the agent/CLI version.

--- a/docs/specs/openlore-spec-14-agent-benchmark-harness.md
+++ b/docs/specs/openlore-spec-14-agent-benchmark-harness.md
@@ -68,6 +68,28 @@ This PR must:
 - **Results** — a per-repo table plus aggregate, mirroring the competitor's published format so
   comparison is fair. Include variance, not just medians.
 
+## Implementation approach (where it lives)
+
+- **A new script beside the existing benches, not a change to them.** `scripts/bench.ts` and
+  `scripts/bench-mcp.ts` measure *query/handler latency* (e.g. the ~429µs p50 orient path) — not
+  end-to-end agent tokens. Add `scripts/bench-agent.ts` (`npm run bench:agent`) for the
+  WITH-vs-WITHOUT agent runs; leave the latency benches untouched.
+- **Toggle the MCP server in the agent config**, run the fixed task suite headless over pinned
+  repos, and capture tokens / tool-calls / cost / wall-clock from the agent's telemetry.
+- **Reuse the clean-repo dogfooding approach** from the `first-run-hardening` skill for setup.
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **Pure addition:** a new script + `docs/AGENT-BENCHMARKS.md`. No runtime, library, or API change.
+  The existing benches and their `npm run bench` / `bench:mcp` entry points are unmodified.
+
+## Notes
+
+- Keep both stories: the micro-benches are the *latency* story; this is the *token / round-trip*
+  story. They answer different questions.
+- Mirror CodeGraph's methodology (median of N≥4 runs, ≥5 repos, headless, with/without) so the
+  comparison is apples-to-apples and not dismissible.
+
 ## Acceptance
 
 - A reviewer runs one documented command and reproduces the table.

--- a/docs/specs/openlore-spec-15-governance-dogfooding.md
+++ b/docs/specs/openlore-spec-15-governance-dogfooding.md
@@ -1,0 +1,71 @@
+# OpenLore Spec 15 — Decision & Drift Governance Dogfooding
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md).
+
+---
+
+## Progress
+
+Branch: `openlore-spec-15-governance-dogfooding`. Not started.
+
+- [ ] Activate the decisions pre-commit gate in OpenLore's own repo
+- [ ] Retroactively record the genuinely-architectural decisions already made
+- [ ] Consolidate, then sync into `openspec/specs/`
+- [ ] Verify the gate blocks/passes correctly on a test commit
+- [ ] Document the dogfood result
+
+---
+
+## Context for you (the agent)
+
+The decision store and spec-drift gate are OpenLore's genuinely differentiated asset — no code
+navigation tool in the field pairs a code graph with recorded architectural decisions and a
+drift gate. The full workflow exists in code:
+[src/core/decisions/](../../src/core/decisions/) (`extractor`, `consolidator`, `store`,
+`syncer`, `verifier`) plus the gate documented in [CLAUDE.md](../../CLAUDE.md).
+
+But it is not exercised in this repository — `.openlore/decisions/` is empty and the gate is not
+active here. An unused differentiator reads as "a feature even the authors do not run." Spec 16
+(promoting decisions to graph nodes) also depends on there being real decisions to project.
+This spec turns the system on, on ourselves, and produces the evidence.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Change the decision data model or file format in ways that invalidate existing stores.
+- Make the gate mandatory for downstream users — it stays opt-in, exactly as today.
+- Add LLM cost to commits beyond what the gate already documents.
+
+This PR must:
+
+- Activate the pre-commit decisions gate in this repo's hook config.
+- Record the real architectural decisions already embedded in the codebase via the existing
+  `record_decision` path — for example: SCIP as one-way export only
+  ([src/cli/export/scip.ts:6](../../src/cli/export/scip.ts#L6)); IaC resources projecting onto
+  the existing graph primitives ([iac/project.ts](../../src/core/analyzer/iac/project.ts)); the
+  edge-store `SCHEMA_VERSION` rebuild-on-bump strategy
+  ([edge-store.ts](../../src/core/services/edge-store.ts)); BM25-without-embeddings as the
+  zero-network retrieval floor (Spec 06).
+- Run consolidation and sync the results into `openspec/specs/`.
+- Verify the gate behaves correctly (blocks when decisions are pending/unsynced, passes when
+  clean), then document what was recorded and synced.
+
+## The deliverable
+
+- A non-empty, consolidated decision store in `.openlore/decisions/`.
+- Synced decision sections in the relevant `openspec/specs/` domains.
+- The gate wired into this repo's hooks, with a short `docs/` note describing the dogfood run
+  and the decision IDs/domains produced.
+
+## Acceptance
+
+- `openlore decisions` lists real, consolidated decisions for this repo.
+- The corresponding spec domains contain synced decision content.
+- A deliberate test commit demonstrates the gate blocking and then passing after sync.
+
+## Compatibility note
+
+Affects only OpenLore's own repository configuration and its self-authored specs/decisions.
+Zero change to the shipped product's behavior for users.

--- a/docs/specs/openlore-spec-15-governance-dogfooding.md
+++ b/docs/specs/openlore-spec-15-governance-dogfooding.md
@@ -30,6 +30,10 @@ active here. An unused differentiator reads as "a feature even the authors do no
 (promoting decisions to graph nodes) also depends on there being real decisions to project.
 This spec turns the system on, on ourselves, and produces the evidence.
 
+In the Spec 13 layering this is the **why-layer (Layer 2)**, and it is what the architecture-
+invariant instrument (Spec 23) consults at edit time. Dogfooding here is what makes that
+downstream analysis credible rather than theoretical.
+
 ## Scope contract — do not break these things
 
 This PR must NOT:

--- a/docs/specs/openlore-spec-15-governance-dogfooding.md
+++ b/docs/specs/openlore-spec-15-governance-dogfooding.md
@@ -63,6 +63,25 @@ This PR must:
 - The gate wired into this repo's hooks, with a short `docs/` note describing the dogfood run
   and the decision IDs/domains produced.
 
+## Implementation approach (where it lives)
+
+- **Install the idempotent pre-commit hook** (template + marker `# openlore-decisions-hook` in
+  [decisions.ts](../../src/cli/commands/decisions.ts)) via `openlore decisions --install-hook`.
+  Today this repo has only `pre-commit.sample` and no `.openlore/decisions/` — a clean slate.
+- **Record the real architectural decisions already embedded in the code** via `record_decision`:
+  SCIP as one-way export; IaC projecting onto the shared graph primitives; the edge-store
+  `SCHEMA_VERSION` rebuild-on-bump strategy; BM25-without-embeddings as the zero-network floor;
+  and the analysis-layer direction itself (Spec 13).
+- **Run the full workflow** — consolidate → verify → approve → sync into `openspec/specs/` (and
+  ADR files under `openspec/decisions/` for cross-domain/system scope).
+
+## Compatibility verification (grounded 2026-05-30)
+
+- Affects **only this repo's configuration and its self-authored specs/decisions** — zero change
+  to the shipped product's behavior for users.
+- The hook is **idempotent** (marker-guarded) and **skippable** (`git commit --no-verify`); the
+  decision store schema (`version: '1'`) is unchanged.
+
 ## Acceptance
 
 - `openlore decisions` lists real, consolidated decisions for this repo.

--- a/docs/specs/openlore-spec-16-decisions-as-graph-nodes.md
+++ b/docs/specs/openlore-spec-16-decisions-as-graph-nodes.md
@@ -31,6 +31,9 @@ it governs turns the filter into the deterministic join Spec 13 calls for, and m
 "what decisions govern this code, and what does changing it implicate?" answerable by the same
 impact machinery as code edges. This is the relationship no navigation competitor offers.
 
+In the Spec 13 layering this is itself a **Layer-3 analysis instrument** (decisions made
+queryable), and it is the substrate the architecture-invariant guardrails (Spec 23) build on.
+
 The pattern already exists in the repo: the IaC subsystem projects external records onto the
 existing `FunctionNode` / `CallEdge` / `ClassNode` primitives via a parser→projector split
 ([iac/types.ts](../../src/core/analyzer/iac/types.ts),

--- a/docs/specs/openlore-spec-16-decisions-as-graph-nodes.md
+++ b/docs/specs/openlore-spec-16-decisions-as-graph-nodes.md
@@ -1,0 +1,80 @@
+# OpenLore Spec 16 — Architectural Decisions as First-Class Graph Nodes
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md).
+> Depends on [Spec 15](openlore-spec-15-governance-dogfooding.md) (needs real decisions to project).
+
+---
+
+## Progress
+
+Branch: `openlore-spec-16-decisions-as-graph-nodes`. Not started.
+
+- [ ] Add a decision node type and an `affects` edge kind
+- [ ] Project the existing decision store onto graph nodes/edges (derived, like IaC)
+- [ ] Make `analyze_impact` / `get_subgraph` return governing decisions as neighbors
+- [ ] Keep `orient`'s existing decision-surfacing working; upgrade it additively
+- [ ] Bump `SCHEMA_VERSION`; confirm clean rebuild and backward compatibility
+
+---
+
+## Context for you (the agent)
+
+Today decisions are stored in a side-file and surfaced by a runtime string set-membership test
+on `affectedFiles` / `affectedDomains`
+([orient.ts](../../src/core/services/mcp-handlers/orient.ts#L355-L380)). That is a filter, not a
+graph relationship: decisions are not nodes, not traversable, and invisible to
+`analyze_impact` / `get_subgraph`.
+
+Promoting `Decision` to a first-class graph node with `affects` edges to the function/file nodes
+it governs turns the filter into the deterministic join Spec 13 calls for, and makes
+"what decisions govern this code, and what does changing it implicate?" answerable by the same
+impact machinery as code edges. This is the relationship no navigation competitor offers.
+
+The pattern already exists in the repo: the IaC subsystem projects external records onto the
+existing `FunctionNode` / `CallEdge` / `ClassNode` primitives via a parser→projector split
+([iac/types.ts](../../src/core/analyzer/iac/types.ts),
+[iac/project.ts](../../src/core/analyzer/iac/project.ts)). Decisions follow the same shape: the
+JSON store remains the authored source of truth; the graph projection is derived and regenerable.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Change the decision authoring workflow (`record_decision` → consolidate → gate → sync) or its
+  on-disk format. The store stays the source of truth.
+- Break `orient`'s current decision output — preserve the existing field; add to it.
+- Require an API key. Decisions already exist; this is pure graph wiring, fully deterministic.
+- Destabilize the call-graph / edge-store hubs (highest fan-in/out in the repo). Changes are
+  additive: a new edge kind and a derived projection, no rewrite of call edges.
+
+This PR must:
+
+- Extend `EdgeKind` ([call-graph.ts:39](../../src/core/analyzer/call-graph.ts#L39)) with an
+  `affects` (or `decided_by`) kind, and represent decision nodes in the node store.
+- Add a projector that maps the loaded decision store onto decision nodes + `affects` edges at
+  analyze/load time (mirroring `iac/project.ts`).
+- Update `analyze_impact` / `get_subgraph` and the analysis handlers to include decision
+  neighbors, clearly typed so callers can distinguish them from code nodes.
+- Keep `orient`'s response additive: the existing `pendingDecisions` surfacing continues to work;
+  graph-derived decisions are an addition, not a replacement.
+- Bump `SCHEMA_VERSION`; the edge store rebuilds from source on bump, so existing users incur one
+  re-analyze and no migration.
+
+## The deliverable
+
+- A decision-node + `affects`-edge projection of the decision store, derived and regenerable.
+- Impact/subgraph queries that return governing decisions as graph neighbors.
+- Tests: a fixture decision store projects into nodes/edges; `analyze_impact(file)` returns the
+  intersecting decision as a neighbor (not a post-hoc filter); legacy stores project cleanly.
+
+## Acceptance
+
+- `analyze_impact(file)` and `get_subgraph` surface governing decisions as typed graph neighbors.
+- `orient` still returns decisions (existing behavior intact).
+- `SCHEMA_VERSION` bumped; a re-analyze produces the projected nodes/edges; no data loss.
+
+## Compatibility note
+
+The decision JSON store remains authoritative and unchanged; the graph projection is derived and
+rebuilt from it. `orient`'s output is additive. The schema bump costs users a single re-analyze.

--- a/docs/specs/openlore-spec-16-decisions-as-graph-nodes.md
+++ b/docs/specs/openlore-spec-16-decisions-as-graph-nodes.md
@@ -71,6 +71,37 @@ This PR must:
 - Tests: a fixture decision store projects into nodes/edges; `analyze_impact(file)` returns the
   intersecting decision as a neighbor (not a post-hoc filter); legacy stores project cleanly.
 
+## Implementation approach (where it lives)
+
+- **Project decisions exactly like IaC.** A projector (mirroring
+  [iac/project.ts](../../src/core/analyzer/iac/project.ts)) maps the loaded decision store onto
+  decision nodes + `affects` edges at analyze/load time. Decisions remain authored in
+  `.openlore/decisions/pending.json` (the source of truth); the graph copy is derived and
+  regenerable — the IaC pattern, applied to a second data source.
+- **Storage:** a new `decisions` table in
+  [edge-store.ts](../../src/core/services/edge-store.ts) + a `SCHEMA_VERSION` bump (rebuild from
+  source). A new `affects` `EdgeKind` ([call-graph.ts:39](../../src/core/analyzer/call-graph.ts#L39)).
+- **Traversal:** `analyze_impact` / `get_subgraph` include decision neighbors via
+  `buildAdjacency()`, which already merges inheritance edges the same way — typed so callers can
+  tell a decision from a function.
+- **`orient`:** keep the existing `pendingDecisions` set-membership output
+  ([orient.ts ~362–382](../../src/core/services/mcp-handlers/orient.ts#L362)); **add** graph-derived
+  decisions as an optional field.
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **Decision file format unchanged**; the gate is unaffected (it only reads decision statuses).
+- **`affects` is additive** — no code switches exhaustively on `EdgeKind`, and `calls`-only filters
+  exclude it by default.
+- The new `decisions` table sits behind a `SCHEMA_VERSION` bump → rebuild from source, no migration.
+- `orient` / `analyze_impact` responses gain **optional** fields only (additive-by-cast).
+
+## Edge cases & failure modes
+
+- **Inactive decisions** (`synced` / `rejected` / `phantom`) are excluded from projection, matching
+  orient's `INACTIVE_STATUSES`.
+- **Empty / legacy store** → zero decision nodes; everything else is unchanged.
+
 ## Acceptance
 
 - `analyze_impact(file)` and `get_subgraph` surface governing decisions as typed graph neighbors.

--- a/docs/specs/openlore-spec-17-cross-domain-impact.md
+++ b/docs/specs/openlore-spec-17-cross-domain-impact.md
@@ -30,6 +30,9 @@ paths are affected?" This is the most distinctive capability OpenLore can demons
 code-only navigation tool or a grep-based agent structurally cannot answer it. The work is
 wiring and surfacing, not new parsing.
 
+In the Spec 13 layering this is the **first cross-domain Layer-3 analysis instrument**: a
+consequence *computed* over the unified graph, not a retrieval.
+
 ## Scope contract — do not break these things
 
 This PR must NOT:

--- a/docs/specs/openlore-spec-17-cross-domain-impact.md
+++ b/docs/specs/openlore-spec-17-cross-domain-impact.md
@@ -1,0 +1,70 @@
+# OpenLore Spec 17 — Cross-Domain Impact Analysis (Code ↔ Infrastructure)
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md).
+
+---
+
+## Progress
+
+Branch: `openlore-spec-17-cross-domain-impact`. Not started.
+
+- [ ] End-to-end traversal across the existing code↔infra edges
+- [ ] Surface it through `analyze_impact` (blast radius now spans infra) and `orient`
+- [ ] One published, reproducible code→infra example
+- [ ] Deterministic and offline; tests over existing IaC fixtures
+
+---
+
+## Context for you (the agent)
+
+OpenLore already parses seven IaC ecosystems (terraform, pulumi, kubernetes, cloudformation,
+cdk, ansible, helm) and projects their resources onto the *same* `FunctionNode` / `CallEdge` /
+`ClassNode` primitives as code ([iac/types.ts](../../src/core/analyzer/iac/types.ts),
+[iac/project.ts](../../src/core/analyzer/iac/project.ts)). The data to cross the code↔infra
+boundary is therefore already in one unified graph.
+
+What is missing is a query that *traverses* that boundary end-to-end: route → handler → the
+Terraform/K8s resource that deploys it, and the reverse — "if I change this resource, which code
+paths are affected?" This is the most distinctive capability OpenLore can demonstrate: a
+code-only navigation tool or a grep-based agent structurally cannot answer it. The work is
+wiring and surfacing, not new parsing.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Re-architect IaC parsing or change the shared graph primitives.
+- Add a parallel "god tool" that fragments the surface — extend the existing `analyze_impact` /
+  `orient` rather than inventing a competing entry point.
+- Introduce any network dependency; this is offline graph traversal.
+
+This PR must:
+
+- Implement an end-to-end traversal across existing code↔infra edges, reusing the existing
+  graph traversal (BFS/DFS) and edge store.
+- Surface results through `analyze_impact` so blast radius includes infrastructure neighbors,
+  clearly typed so a caller can tell code from infra, and ensure `orient` can return the
+  cross-domain neighbors when relevant.
+- Ship one reproducible example (a fixture or pinned OSS repo containing both code and IaC)
+  tracing a code→infra blast radius, committed as documentation.
+
+## The deliverable
+
+- Traversal logic that crosses the code↔infra edge boundary, built on existing primitives.
+- Handler updates exposing cross-domain neighbors through `analyze_impact` (and `orient` where
+  relevant), with node typing so consumers can distinguish domains.
+- A committed example + tests over the existing `iac/fixtures`.
+
+## Acceptance
+
+- A query of the form "what infrastructure does this handler reach / what code breaks if I change
+  this resource?" returns cross-domain neighbors from the unified graph.
+- The published example reproduces deterministically and offline.
+- Existing `analyze_impact` behavior for code-only queries is unchanged; infra neighbors are
+  additive and typed.
+
+## Compatibility note
+
+Additive query path over data the analyzer already produces. Existing impact results are
+preserved; infrastructure neighbors are additional, typed results.

--- a/docs/specs/openlore-spec-17-cross-domain-impact.md
+++ b/docs/specs/openlore-spec-17-cross-domain-impact.md
@@ -59,6 +59,31 @@ This PR must:
   relevant), with node typing so consumers can distinguish domains.
 - A committed example + tests over the existing `iac/fixtures`.
 
+## Implementation approach (where it lives)
+
+- **The graph is already unified.** `buildProjectedIac()`
+  ([iac/index.ts](../../src/core/analyzer/iac/index.ts)) merges IaC nodes (distinguished by
+  `node.language` ∈ the IaC languages, id prefix `iac-external::…`) and IaC edges (`EdgeKind`
+  `references` / `depends_on`) into the same call graph the analyzer builds.
+- **Cross-domain traversal** = `bfsFromDB` over the existing edges, **opting `references` /
+  `depends_on` into the impact walk** (they are excluded by default by the `calls`-only filter),
+  partitioned/typed by `node.language` so results separate code from infrastructure.
+- **Surface** through `analyze_impact` (infra neighbors become additional, typed blast-radius
+  entries) and/or an `orient` capability.
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **No schema change** — IaC already shares the graph primitives. The only change is *opting* the
+  `references` / `depends_on` kinds into the impact traversal when requested; default code-only
+  behavior is preserved because the existing `calls`-only filter still excludes them.
+- `analyze_impact` gains typed infra neighbors as an **optional / additive** result.
+
+## Edge cases & failure modes
+
+- **Repos with no IaC** behave exactly as today (no infra nodes exist).
+- **Strictly distinguish infra from code by `node.language`**, so existing code-only impact is
+  byte-for-byte unchanged unless infrastructure is explicitly requested.
+
 ## Acceptance
 
 - A query of the form "what infrastructure does this handler reach / what code breaks if I change

--- a/docs/specs/openlore-spec-18-local-provenance-edges.md
+++ b/docs/specs/openlore-spec-18-local-provenance-edges.md
@@ -1,0 +1,71 @@
+# OpenLore Spec 18 — Local Provenance Edges (Git & PR Metadata, No OAuth)
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md).
+
+---
+
+## Progress
+
+Branch: `openlore-spec-18-local-provenance-edges`. Not started.
+
+- [ ] `authored_by` and `changed_in_pr` edges sourced from local git / `gh`
+- [ ] Projected onto existing function/file nodes (derived, regenerable)
+- [ ] Surfaced additively in `orient`
+- [ ] Graceful degradation: git-only when `gh` is absent or unauthenticated
+- [ ] Deterministic given a fixed git state; no network upload
+
+---
+
+## Context for you (the agent)
+
+This is the "code ↔ organizational context" join made real **without any cloud surface**. Today
+git is used only for changed-file diffing in drift detection; pull requests are never parsed and
+no provenance edges exist. Yet the most valuable provenance — "who last changed this function,
+in which PR, citing which decision" — is sitting in the local `.git` history and reachable via
+the local `gh` CLI under the user's existing authentication.
+
+Parsing that locally yields `authored_by` (code → person) and `changed_in_pr` (code → PR) edges
+that let `orient` answer provenance questions grep cannot. Crucially, this stays inside Spec 13's
+prime constraint: **local, deterministic, nothing uploaded.** It is the deliberate alternative to
+cloud OAuth connectors, which Spec 13 fences to an optional far-horizon plugin precisely because
+they would forfeit this local-only guarantee.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Introduce OAuth, cloud connectors, or any network upload. Reads are local git plus local `gh`
+  using the user's own credentials; nothing is sent anywhere.
+- Require `gh`. When `gh` is absent or unauthenticated, degrade gracefully to git-only provenance.
+- Fail or block `analyze` when git history is shallow or absent.
+- Bloat the graph. Cap provenance (for example, last-touch author plus top-N recent authors per
+  node) and document the cap; do not import unbounded history.
+
+This PR must:
+
+- Add a local provenance extractor (parser→projector pattern) producing `authored_by` and
+  `changed_in_pr` edges, optionally `references` edges for issue/SHA mentions in commit messages.
+- Project these onto existing function/file nodes as derived, regenerable graph data.
+- Surface provenance additively in `orient` ("last changed by X in PR #N").
+- Be deterministic for a fixed git state and fully offline (git-only path requires no network).
+- Document the no-OAuth / no-upload guarantee prominently.
+
+## The deliverable
+
+- A git/`gh` provenance extractor + projector, mirroring the existing parser→projector split.
+- `EdgeKind` extensions for the new provenance edges.
+- `orient` surfacing of last-author / PR provenance, additive to its current response.
+- Tests over a fixture repository with commit history, covering both the `gh`-present and
+  git-only paths.
+
+## Acceptance
+
+- `orient` / impact surfaces last-author and originating PR for a function as graph edges.
+- The git-only path works with no network and no `gh`.
+- No network upload occurs on any path; the guarantee is documented and tested.
+
+## Compatibility note
+
+Additive and local-only. `gh` is optional with graceful degradation. The graph projection is
+derived and rebuilt on the `SCHEMA_VERSION` bump; no user data leaves the machine.

--- a/docs/specs/openlore-spec-18-local-provenance-edges.md
+++ b/docs/specs/openlore-spec-18-local-provenance-edges.md
@@ -31,6 +31,9 @@ prime constraint: **local, deterministic, nothing uploaded.** It is the delibera
 cloud OAuth connectors, which Spec 13 fences to an optional far-horizon plugin precisely because
 they would forfeit this local-only guarantee.
 
+The git history this ingests is also the data source for the **change-coupling & volatility
+instrument (Spec 22)**: provenance edges here, statistical co-change analysis there.
+
 ## Scope contract — do not break these things
 
 This PR must NOT:

--- a/docs/specs/openlore-spec-18-local-provenance-edges.md
+++ b/docs/specs/openlore-spec-18-local-provenance-edges.md
@@ -62,6 +62,33 @@ This PR must:
 - Tests over a fixture repository with commit history, covering both the `gh`-present and
   git-only paths.
 
+## Implementation approach (where it lives)
+
+- **Extend the existing local git wrapper.** Add `getGitLog()` / `getCommitBlame()` beside the
+  current helpers in [git-diff.ts](../../src/core/drift/git-diff.ts) (already `execFile('git', …)`,
+  no `gh`, no network) for `authored_by` and last-touch. PR metadata comes from local `gh` **only
+  if it is present and authenticated**, with a graceful git-only fallback.
+- **Projector** (parser→projector pattern, like IaC) maps to `authored_by` (code → person) and
+  `changed_in_pr` (code → PR) edges on existing function/file nodes; derived and regenerable.
+- **New `EdgeKind`s** `authored_by` / `changed_in_pr` (additive). `orient` surfaces last-author /
+  PR additively.
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **Local-only:** `execFile` git + optional local `gh`; no network upload. `gh` is optional and
+  never on the core path.
+- **New `EdgeKind`s are additive** (defensive `calls`-only filters ignore them). If persisted,
+  behind a `SCHEMA_VERSION` bump.
+- `orient` gains **optional** fields only.
+
+## Edge cases & failure modes
+
+- **Shallow / no history** → degrade to no provenance and say so; never block `analyze`.
+- **`gh` absent / unauthenticated** → git-only path (`authored_by` works; `changed_in_pr` may be
+  empty).
+- **Bound graph growth:** cap provenance (last-touch + top-N recent authors per node) and document
+  the cap.
+
 ## Acceptance
 
 - `orient` / impact surfaces last-author and originating PR for a function as graph edges.

--- a/docs/specs/openlore-spec-19-test-impact-selection.md
+++ b/docs/specs/openlore-spec-19-test-impact-selection.md
@@ -1,0 +1,93 @@
+# OpenLore Spec 19 — Deterministic Test Impact Selection
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md). The headline Layer-3 instrument.
+
+---
+
+## Progress
+
+Branch: `openlore-spec-19-test-impact-selection`. Not started.
+
+- [ ] Backward reachability from changed functions/files to the tests that exercise them
+- [ ] Input from an explicit symbol set **or** a git diff (reuse drift's changed-file logic)
+- [ ] Output: the test set + the reaching path + an explicit soundness note
+- [ ] Surfaced through the MCP layer; deterministic and offline
+- [ ] Tests over a fixture with known test→code reachability
+
+---
+
+## Context for you (the agent)
+
+**The instrument:** an agent changes `parseConfig()` and asks OpenLore *"which tests should I
+run?"* — and gets, deterministically, the exact set of tests that transitively reach that
+function, by walking the call graph backward from the change to every test that can hit it.
+
+This is the clearest demonstration of the Layer-3 thesis (Spec 13):
+
+- **grep cannot do it** — the tests reach the code through indirect call paths, not text matches.
+- **the model is expensive and unreliable at it** — it would have to read the whole suite and guess.
+- **a deterministic graph does it instantly** — it is backward reachability over edges we already store.
+- **it saves real money** — agents running full suites or guessing wrong is a major time/token sink.
+- **no MCP competitor ships it.**
+
+It is also ~80% built: the graph already has `tested_by` edges and test detection
+([EdgeKind](../../src/core/analyzer/call-graph.ts#L39); test-file detection in
+[call-graph.ts](../../src/core/analyzer/call-graph.ts)), plus working graph traversal in the
+existing `analyze_impact`/`get_subgraph` handlers.
+
+**Prior art (this is established CS, not novelty):** regression test selection (RTS). Dynamic RTS
+(Ekstazi) collects file dependencies at runtime; static RTS (RTS++, building on Ryder & Tip's
+call-graph change-impact analysis) selects tests from the call graph. OpenLore's flavor is
+**static, call-graph-based RTS served to the agent at edit time** rather than to CI after the
+fact — the same algorithm, a different consumer.
+
+**Soundness — state it honestly.** Static call-graph RTS is an approximation:
+
+- For direct/static dispatch it is a safe *over-approximation* (it may select a few extra tests —
+  acceptable, the agent runs slightly more).
+- Dynamic dispatch, reflection, dependency injection, and runtime wiring can cause
+  *under-approximation* (a relevant test is missed). This is the classic RTS hazard.
+
+The instrument must **prefer over-approximation, surface its confidence, and never claim it is a
+sound replacement for the full suite.** It is a *prioritizer* — "run these first / these are
+almost certainly the relevant ones" — not a guarantee.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Change `tested_by` extraction semantics in a way that regresses existing graphs.
+- Run the test suite, replace the test runner, or require a build.
+- Claim soundness the analysis does not have. Document over/under-approximation explicitly.
+- Add a network or API-key dependency. This is pure graph traversal, deterministic and offline.
+
+This PR must:
+
+- Add an MCP capability (extend `analyze_impact`, or a focused tool surfaced through the existing
+  handler layer) that takes a set of changed functions/files **or** a git diff and returns the
+  tests that transitively reach the change, each with the reaching path and a confidence note.
+- Reuse the changed-file logic the drift subsystem already has for the git-diff input path.
+- Degrade gracefully where `tested_by` coverage is sparse (some languages detect tests better than
+  others) — say so in the response rather than returning a falsely-confident empty set.
+- Be deterministic for a fixed graph state.
+
+## The deliverable
+
+- **Backward reachability**: from each changed node, BFS over call edges to reachable test nodes.
+- **Inputs**: an explicit symbol/file set, or a git diff (HEAD vs working tree, or two refs).
+- **Output**: the selected tests, the path that connects each test to the change, and a soundness
+  banner (approximation posture + coverage caveats for the languages involved).
+- **Surface**: through the existing MCP handler layer, additive to current tools.
+
+## Acceptance
+
+- Changing a function in a fixture returns exactly the tests that reach it, with paths.
+- The response documents when it may over- or under-select.
+- Runs offline, deterministically, with no API key.
+
+## Compatibility note
+
+Pure addition over existing edges (`calls`, `tested_by`). No schema change required if the edges
+already exist; if a new typed result field is added to `orient`/`analyze_impact`, it is additive
+and optional. Existing behavior is untouched.

--- a/docs/specs/openlore-spec-19-test-impact-selection.md
+++ b/docs/specs/openlore-spec-19-test-impact-selection.md
@@ -80,6 +80,47 @@ This PR must:
   banner (approximation posture + coverage caveats for the languages involved).
 - **Surface**: through the existing MCP handler layer, additive to current tools.
 
+## Implementation approach (where it lives)
+
+- **Reuse, do not rebuild.** The backward walk is `bfsFromDB(seeds, 'backward', maxDepth, edgeStore)`
+  ([graph.ts](../../src/core/services/mcp-handlers/graph.ts)) — the same primitive `analyze_impact`
+  already uses for upstream chains. Seeds = the changed functions; hits = nodes with `isTest`
+  ([FunctionNode](../../src/core/analyzer/call-graph.ts)) reached on the walk.
+- **`tested_by` is already a first-class edge** (`EdgeKind` includes it,
+  [call-graph.ts:39](../../src/core/analyzer/call-graph.ts#L39)). Use it directly and/or the
+  inverse of `calls` from test nodes; decide and document which during build.
+- **Changed-set input reuses the drift git layer.** `getChangedFiles()` / `resolveBaseRef()`
+  ([git-diff.ts](../../src/core/drift/git-diff.ts)) turn a diff into changed files; map those to
+  changed functions via the node table, then run the backward walk.
+- **Inheritance is followed for free.** `buildAdjacency()` already propagates across inheritance
+  edges, so overridden/parent methods widen selection (a safety win for dynamic dispatch).
+
+## Tool contract (additive)
+
+- **Input:** `{ dir, changedSymbols?: string[], diffRef?: string, maxDepth?: number }` (one of
+  `changedSymbols` / `diffRef` required).
+- **Output:** `{ changed: string[], selectedTests: [{ test, file, viaPath: string[], confidence }],
+  soundness: { posture: 'over-approximate', caveats: string[] },
+  coverage: { languages: string[], testDetection: 'full' | 'partial' | 'none' } }`.
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **No schema change**: `tested_by` edges and `isTest` nodes already exist.
+- **New read-only handler returning `unknown`** — existing tool responses are untouched (the
+  additive-by-cast contract from Spec 13).
+- Reuses `bfsFromDB`; no change to traversal primitives or to `analyze_impact`.
+- Offline, deterministic, no API key.
+
+## Edge cases & failure modes
+
+- **Sparse `tested_by` coverage** (test detection varies by language): return
+  `coverage.testDetection: 'partial' | 'none'` rather than a falsely-confident empty set.
+- **Dynamic dispatch / DI / reflection** may under-select: documented in `soundness.caveats`;
+  prefer widening via inheritance edges. Posture is *over-approximate* by design.
+- **A test reaches code via `calls` but has no `tested_by` edge**: include via the inverse-`calls`
+  path and dedupe.
+- **Newly-added function with no edges yet**: fall back to file-level test association.
+
 ## Acceptance
 
 - Changing a function in a fixture returns exactly the tests that reach it, with paths.

--- a/docs/specs/openlore-spec-20-reachability-dead-code.md
+++ b/docs/specs/openlore-spec-20-reachability-dead-code.md
@@ -1,0 +1,77 @@
+# OpenLore Spec 20 — Reachability & Dead-Code Analysis
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md). Layer-3 analysis instrument.
+
+---
+
+## Progress
+
+Branch: `openlore-spec-20-reachability-dead-code`. Not started.
+
+- [ ] Reachability from declared/detected entry points over the existing graph
+- [ ] Candidate dead-code report (unreachable symbols) with confidence + caveats
+- [ ] "What becomes dead if I delete X?" — downstream-only-reachable set
+- [ ] Cross-language (rides the existing tree-sitter graph), offline, MCP-surfaced
+- [ ] Tests over a fixture with known live/dead regions
+
+---
+
+## Context for you (the agent)
+
+**The instrument:** "is this function reachable from any entry point?", "what is dead?", and
+"what becomes dead if I delete X?" — classic graph reachability questions the model burns tokens
+guessing at and grep cannot answer (it sees text, not reach).
+
+OpenLore is well placed: the analysis already identifies **entry points** (functions with no
+internal callers — see [CODEBASE.md](../../.openlore/analysis/CODEBASE.md)) and holds a call graph
+across 15+ languages. Reachability is BFS from entry points; candidate dead code is the
+unreachable remainder; "what dies if I delete X" is the set reachable *only* through X.
+
+**Prior art:** knip and ts-prune do exactly this — mark-and-sweep from entry points — but are
+**TypeScript/JavaScript-only**, and ts-prune is in maintenance mode. OpenLore's contribution is
+the **cross-language** version over the unified graph.
+
+**Honest limits — frame output as *candidates*, never deletion authority.** Entry points are not
+always statically visible: dynamic entry points, framework magic (routes, DI, plugin registries),
+reflection, and public-API exports consumed externally all produce false "dead" positives. The
+instrument must:
+
+- treat exported/public-API symbols and detected framework entry points as roots,
+- report confidence and the reason a symbol looks dead,
+- and explicitly **not** auto-delete or assert certainty.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Auto-delete code or present results as certain.
+- Require a build, a run, or a network/API key.
+- Regress entry-point detection used elsewhere.
+
+This PR must:
+
+- Compute reachability from declared + detected entry points (including exported/public symbols)
+  over the existing graph.
+- Report candidate-dead symbols with a confidence level and the reason (e.g. "no static caller;
+  not exported; not a detected entry point").
+- Answer "what becomes dead if I delete X?" as the set reachable only via X.
+- Be cross-language, deterministic, and offline; surface through the existing MCP handler layer.
+
+## The deliverable
+
+- Reachability pass (BFS from roots) + the unreachable-set computation, reusing graph traversal.
+- A "delete impact" query: nodes whose only path to a root runs through the target.
+- MCP surfacing, additive; results typed and confidence-tagged.
+
+## Acceptance
+
+- A fixture with known live and dead regions yields the correct candidate-dead set, with caveats
+  for dynamically-reached symbols.
+- "Delete X" returns the correct downstream-dead set.
+- Runs offline and deterministically across at least two languages.
+
+## Compatibility note
+
+Pure addition: a read-only analysis over the existing graph. No schema change, no behavior change
+to existing tools; results are an additive, confidence-tagged output.

--- a/docs/specs/openlore-spec-20-reachability-dead-code.md
+++ b/docs/specs/openlore-spec-20-reachability-dead-code.md
@@ -64,6 +64,32 @@ This PR must:
 - A "delete impact" query: nodes whose only path to a root runs through the target.
 - MCP surfacing, additive; results typed and confidence-tagged.
 
+## Implementation approach (where it lives)
+
+- **Roots** = the entry points the analyzer already computes (functions with no internal caller —
+  see [CODEBASE.md](../../.openlore/analysis/CODEBASE.md) and the call graph) **plus** exported /
+  public-API symbols and detected framework entry points.
+- **Reachability** = `bfs` / `bfsFromDB(roots, 'forward', maxDepth)`
+  ([graph.ts](../../src/core/services/mcp-handlers/graph.ts)); candidate-dead = nodes not in the
+  reached set. External nodes are already filtered at the DB boundary.
+- **"Dead if I delete X"** = nodes whose every root-path runs through X — recompute reachability
+  with X removed and diff against the baseline reached set.
+- **Surface:** a new read-only handler returning `Promise<unknown>`.
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **No schema change**; a pure read over the existing graph + entry-point data.
+- Reuses `bfs` / `bfsFromDB`; external-node filtering already exists.
+- New handler returns `unknown` → existing tools untouched.
+
+## Edge cases & failure modes
+
+- **Dynamic / framework entry points** (routes, DI, plugin registries), reflection, and
+  externally-consumed exports cause false "dead" positives. Treat exported/public symbols and
+  detected entry points as roots; tag confidence; **never auto-delete**.
+- **Libraries / monorepos:** public-API symbols are roots even with no internal caller.
+- **Weaker per-language symbol resolution** → lower confidence, stated in the output.
+
 ## Acceptance
 
 - A fixture with known live and dead regions yields the correct candidate-dead set, with caveats

--- a/docs/specs/openlore-spec-21-structural-change-analysis.md
+++ b/docs/specs/openlore-spec-21-structural-change-analysis.md
@@ -1,0 +1,75 @@
+# OpenLore Spec 21 — Structural Change Analysis (Graph Diff)
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md). Layer-3 analysis instrument.
+
+---
+
+## Progress
+
+Branch: `openlore-spec-21-structural-change-analysis`. Not started.
+
+- [ ] Graph delta between two states (working tree vs HEAD, or two refs)
+- [ ] Report: nodes/edges added & removed, signature changes, newly-stale callers
+- [ ] Surfaced through the MCP layer for review/refactor agents
+- [ ] Deterministic given two fixed states; tests over a fixture change
+
+---
+
+## Context for you (the agent)
+
+**The instrument:** given a change (working tree vs `HEAD`, or two commits), compute what changed
+*structurally* — which functions/edges were added or removed, which signatures changed, and which
+existing callers are now **stale** because a callee's signature moved under them. A review or
+refactor agent gets a precise structural changelog instead of re-deriving consequences from a raw
+text diff.
+
+This is the difference between *"these 40 lines changed"* (git diff) and *"this change removed
+function C, altered the signature of D, and 5 of D's callers are now stale"* (structural diff).
+The latter is a computed consequence — Layer 3 — not retrieval.
+
+**Prior art:** structural/AST diffing (e.g. difftastic) compares syntax trees instead of lines.
+OpenLore goes one level up: it diffs the **graph** (the call/dependency relationships), which is
+where the consequences of a change actually live.
+
+**Why it is cheap here:** the analyzer is fast and incremental, so producing a graph for two
+states and diffing them is inexpensive relative to the value.
+
+**Honest limits:** rename/move detection is heuristic (a renamed function can look like a delete +
+add); say so, and prefer reporting both interpretations over guessing one. Cross-language signature
+notions differ; keep the signature-change check to what the analyzer reliably extracts.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Replace or wrap `git diff`; this is a structural *complement* to it.
+- Require an LLM or network; the diff is deterministic graph computation.
+- Mutate the canonical graph while diffing (operate on snapshots).
+
+This PR must:
+
+- Compute a graph delta between two states (working tree vs a ref, or two refs), reusing the
+  existing analyzer to produce each snapshot.
+- Report added/removed nodes and edges, changed signatures, and newly-stale callers of changed
+  callees.
+- Be deterministic for two fixed states and surface through the existing MCP handler layer.
+- Flag rename/move ambiguity rather than silently guessing.
+
+## The deliverable
+
+- Snapshot-and-diff over two analyzed states; a typed delta (added/removed/changed + stale callers).
+- MCP surfacing aimed at review/refactor flows, additive to current tools.
+- Tests: a fixture change produces the correct structural delta, including the stale-caller set.
+
+## Acceptance
+
+- A known fixture change yields the correct added/removed/changed sets and the correct stale-caller
+  list.
+- Rename/move ambiguity is reported, not hidden.
+- Runs offline and deterministically.
+
+## Compatibility note
+
+Read-only analysis over analyzer output for two states. No change to the canonical graph, no
+change to existing tools; the delta is an additive, typed result.

--- a/docs/specs/openlore-spec-21-structural-change-analysis.md
+++ b/docs/specs/openlore-spec-21-structural-change-analysis.md
@@ -62,6 +62,31 @@ This PR must:
 - MCP surfacing aimed at review/refactor flows, additive to current tools.
 - Tests: a fixture change produces the correct structural delta, including the stale-caller set.
 
+## Implementation approach (where it lives)
+
+- **Two snapshots, one diff.** Produce a graph for each state (working tree vs a ref, or two refs)
+  via the existing analyzer, then diff node sets (by stable id), edge sets, and `FunctionNode.signature`.
+- **Stale callers** = `bfsFromDB(changedCallee, 'backward', 1)` for any callee whose signature
+  changed ([graph.ts](../../src/core/services/mcp-handlers/graph.ts)).
+- **Resolve the two states** with `resolveBaseRef()` / `validateGitRef()`
+  ([git-diff.ts](../../src/core/drift/git-diff.ts)); operate on snapshots so the canonical graph is
+  never mutated.
+- **Surface:** a new read-only handler returning `Promise<unknown>`, aimed at review/refactor flows.
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **No schema change**; operates on analyzer output for two states and never mutates the canonical
+  graph.
+- Reuses the analyzer, `bfsFromDB`, and `git-diff.ts`; additive handler.
+
+## Edge cases & failure modes
+
+- **Rename / move** looks like delete + add. Report both interpretations (heuristic match on
+  name/signature/file proximity); never silently guess one.
+- **Two-state analysis cost** is bounded by the incremental analyzer — document it.
+- **Cross-language signatures differ:** restrict signature-change detection to what
+  `FunctionNode.signature` reliably captures per language.
+
 ## Acceptance
 
 - A known fixture change yields the correct added/removed/changed sets and the correct stale-caller

--- a/docs/specs/openlore-spec-22-change-coupling-volatility.md
+++ b/docs/specs/openlore-spec-22-change-coupling-volatility.md
@@ -1,0 +1,80 @@
+# OpenLore Spec 22 — Change-Coupling & Volatility Analysis
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md). Layer-3 analysis instrument.
+> Builds on [Spec 18](openlore-spec-18-local-provenance-edges.md) (git ingestion).
+
+---
+
+## Progress
+
+Branch: `openlore-spec-22-change-coupling-volatility`. Not started.
+
+- [ ] Co-change coupling (files/functions that change together) from local git history
+- [ ] Volatility/churn metrics (how often a unit changes)
+- [ ] Surfaced in `orient` as a caution signal; deterministic for a fixed git state
+- [ ] Documented thresholds + bulk-commit noise filtering
+- [ ] Tests over a fixture repo with crafted history
+
+---
+
+## Context for you (the agent)
+
+**The instrument:** two facts the call graph structurally cannot see, both computed from git:
+
+1. **Change coupling** — "these files/functions almost always change together." This surfaces the
+   *invisible* coupling that has no import or call edge: the config and the parser that must move
+   in lockstep, the handler and the migration. An agent editing one is warned about the sibling it
+   would otherwise miss.
+2. **Volatility / churn** — "this unit changed 40 times in six months." A caution flag: high-churn
+   code is where edits are riskiest.
+
+**Prior art:** logical/change coupling and behavioral code analysis (CodeScene). Their own framing
+is decisive for us: *change coupling "isn't possible to calculate from code alone — it is mined
+from git."* That is exactly why it is a distinct instrument and a real complement to the structural
+graph, and it is deterministic from history.
+
+**Why it complements the labs and the MCP cohort:** none of the code-graph tools compute co-change
+(they read code, not history), and the frontier agents do not mine your git log for coupling. It
+is local, free, deterministic, and unclaimed.
+
+**Honest limits:** co-change is *correlation, not causation*; it is statistical and needs
+sufficient history; and bulk commits (formatting sweeps, mass renames, vendored drops) create false
+coupling. The instrument must apply support/confidence thresholds and filter implausibly large
+commits, and present coupling as a *signal*, not a rule.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Require a remote, a network call, or any upload — local git history only (builds on Spec 18).
+- Treat coupling as causation or as a hard constraint.
+- Fail on shallow or short history — degrade and say so.
+
+This PR must:
+
+- Compute co-change coupling (pairs above documented support/confidence thresholds) and churn
+  metrics from the local git log, reusing Spec 18's git-reading machinery.
+- Filter bulk commits above a documented size so they do not manufacture coupling.
+- Surface results in `orient` as additive caution signals ("frequently changes with …",
+  "volatility: high"), not as blockers.
+- Be deterministic for a fixed git state.
+
+## The deliverable
+
+- Co-change computation over commit history with thresholding and bulk-commit filtering.
+- Churn/volatility metric per file/function.
+- Additive surfacing in `orient`; documented thresholds and noise handling.
+- Tests over a fixture repo with crafted history (coupled pairs, a volatile file, a bulk commit
+  that must be filtered out).
+
+## Acceptance
+
+- The fixture's intended coupled pairs and volatile units are reported; the bulk commit does not
+  create spurious coupling.
+- Runs offline and deterministically for a fixed git state; degrades cleanly on shallow history.
+
+## Compatibility note
+
+Builds on Spec 18's local git ingestion; adds an analysis pass and additive `orient` signals. No
+network, no schema break to existing tools; results are advisory.

--- a/docs/specs/openlore-spec-22-change-coupling-volatility.md
+++ b/docs/specs/openlore-spec-22-change-coupling-volatility.md
@@ -68,6 +68,36 @@ This PR must:
 - Tests over a fixture repo with crafted history (coupled pairs, a volatile file, a bulk commit
   that must be filtered out).
 
+## Implementation approach (where it lives)
+
+- **New read functions on the existing git wrapper.** Add `getGitLog()` (e.g.
+  `--pretty=format:… --name-only`) beside the current helpers in
+  [git-diff.ts](../../src/core/drift/git-diff.ts) (which already uses `execFile('git', …)`, no
+  `gh`, no network). Derive per-commit changed-file sets.
+- **Coupling** = pairwise support/confidence over those sets (file A and B in the same commit,
+  above thresholds). **Volatility/churn** = commit count per file/function over a window.
+- **Bulk-commit filter:** drop commits touching more than a configured number of files so
+  formatting sweeps / mass renames / vendored drops do not manufacture coupling.
+- **Granularity:** map file-level coupling to a function when a commit touches only that function's
+  line range; otherwise report at file level.
+- **Surface:** additive `orient` metadata (`frequentlyChangesWith[]`, `volatility`) — caution
+  signals, not blockers.
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **Local git only** (`execFile`, no `gh`, no network); reuses the `git-diff.ts` patterns with new
+  functions beside the existing ones.
+- `orient` gains **optional** fields (additive-by-cast); existing behavior unchanged.
+- **No schema change required** — computable on demand / cached; if ever persisted, behind a
+  `SCHEMA_VERSION` bump.
+
+## Edge cases & failure modes
+
+- **Shallow / short history** → degrade and report low confidence; never block.
+- **Bulk commits** → filtered by the documented size threshold.
+- **Correlation, not causation** → presented as a signal, never a rule.
+- **Monorepo mega-commits** → same bulk filter applies.
+
 ## Acceptance
 
 - The fixture's intended coupled pairs and volatile units are reported; the bulk commit does not

--- a/docs/specs/openlore-spec-23-architecture-invariants.md
+++ b/docs/specs/openlore-spec-23-architecture-invariants.md
@@ -1,0 +1,87 @@
+# OpenLore Spec 23 — Architecture Invariant Guardrails
+
+> A Claude Code prompt. Paste into a fresh session opened at the OpenLore repo root.
+> Parent direction: [Spec 13](openlore-spec-13-context-substrate.md). Layer-3 analysis instrument.
+> Builds on [Spec 16](openlore-spec-16-decisions-as-graph-nodes.md) (decisions as graph data).
+
+---
+
+## Progress
+
+Branch: `openlore-spec-23-architecture-invariants`. Not started.
+
+- [ ] A declarative rule format for dependency/layer constraints (opt-in)
+- [ ] A deterministic checker over the dependency graph
+- [ ] A pre-edit query the agent consults *before* writing a violating import
+- [ ] Continuous violation reporting; rules optionally sourced from recorded decisions
+- [ ] Tests over a fixture with a declared rule and a known violation
+
+---
+
+## Context for you (the agent)
+
+**The instrument:** let a repo declare architectural constraints — "the domain layer must not
+import infrastructure," "nothing may depend on `legacy/`" — and have OpenLore answer, *before* the
+agent writes the code, *"may I add this import here?"* with a deterministic yes/no, the rule that
+applies, and why. Plus continuous reporting of existing violations.
+
+The distinctive angle is **when** the check happens. Existing tools enforce architecture in CI,
+*after* the violating code is written. OpenLore can answer the agent at **edit time**, turning an
+architectural rule from a post-hoc failure into a pre-write guardrail — a computed Layer-3 fact
+("this edit would violate rule R"), not a retrieval.
+
+**Prior art:** architecture fitness functions — ArchUnit (Java), dependency-cruiser (JS),
+import-linter (Python) — express rules as test-like assertions ("classes in X must not depend on
+Y") and run them in CI. OpenLore's contributions are (a) **cross-language** rules over the unified
+dependency graph, and (b) **agent-facing, pre-edit** evaluation. The analyzer already surfaces
+"layer violations" in [CODEBASE.md](../../.openlore/analysis/CODEBASE.md), so the detection
+primitive exists; this spec makes the rules explicit, queryable, and consulted in the loop.
+
+**Optional tie to decisions (Spec 16):** a recorded architectural decision can *carry* an
+invariant ("we decided the API layer stays transport-agnostic"). Where it does, the guardrail can
+source the rule from the decision node, so the "why" (Layer 2) and the "may I?" (Layer 3) share one
+source of truth.
+
+**Honest limits:** rules must be authored — the instrument is opt-in and inert until a repo
+declares constraints; do **not** invent rules with an LLM. Keep the rule vocabulary to the
+well-understood, deterministic kind (dependency/layer/module-boundary constraints); do not drift
+into fuzzy "semantic" rules a graph cannot decide.
+
+## Scope contract — do not break these things
+
+This PR must NOT:
+
+- Infer or generate rules via an LLM; rules are author-declared (optionally from recorded decisions).
+- Block or burden users who declare no rules — fully opt-in, inert by default.
+- Replace existing linters/CI tools; this is an additional, agent-facing checker.
+- Require a network or API key.
+
+This PR must:
+
+- Define a small declarative rule format for dependency/layer/module-boundary constraints.
+- Implement a deterministic checker over the existing dependency graph, reusing the layer-violation
+  detection primitive.
+- Expose a pre-edit query through the MCP layer ("is an import from A to B allowed?") returning a
+  verdict + the governing rule + rationale, and a continuous report of current violations.
+- Optionally source rules from decision nodes (Spec 16) when a decision encodes an invariant.
+- Be deterministic and offline.
+
+## The deliverable
+
+- Rule format + parser (opt-in config; optional decision-sourced rules).
+- Deterministic dependency-graph checker (verdict for a hypothetical edge; full violation scan).
+- MCP pre-edit query + violation report, additive to existing tools.
+- Tests: a declared "domain must not import infra" rule flags an existing violation and correctly
+  answers an allowed vs. disallowed pre-edit query.
+
+## Acceptance
+
+- With a declared rule, the checker flags existing violations and answers a pre-edit import query
+  correctly (allowed / disallowed + the rule + why).
+- With no rules declared, behavior is unchanged and nothing is reported.
+- Runs offline and deterministically.
+
+## Compatibility note
+
+Opt-in and additive: inert until a repo declares rules. Reuses the existing dependency graph and
+the Spec 16 decision data; no change to existing tools or behavior for repos that declare nothing.

--- a/docs/specs/openlore-spec-23-architecture-invariants.md
+++ b/docs/specs/openlore-spec-23-architecture-invariants.md
@@ -74,6 +74,40 @@ This PR must:
 - Tests: a declared "domain must not import infra" rule flags an existing violation and correctly
   answers an allowed vs. disallowed pre-edit query.
 
+## Implementation approach (where it lives)
+
+- **Reuse the existing detector.** Layer violations are already computed by
+  `detectLayerViolations(edges, nodes, layers)` in
+  [call-graph.ts](../../src/core/analyzer/call-graph.ts) (≈lines 2876–2917), where
+  `layers: Record<layerName, pathPrefixes[]>` and key order defines the hierarchy. Generalize the
+  rule input to a small declarative config (forbidden dependency directions, module boundaries)
+  that compiles down to this check, plus the file-level dependency graph
+  ([dependency-graph.ts](../../src/core/analyzer/dependency-graph.ts)).
+- **Pre-edit query:** given `(fromFile, toFileOrSymbol)`, resolve layers/modules and answer
+  allowed/denied + the governing rule + reason, writing nothing.
+- **Optional decision-sourced rules:** read invariants from **synced ADR files**
+  (`openspec/decisions/adr-*.md`) and/or active decisions — *not* from `pending.json` fields, which
+  are purged on sync (see Edge cases). Keeps Spec 16's "why" and this "may I?" on one source.
+- **Surface:** a new read-only handler (pre-edit verdict + a full violation scan reusing
+  `detectLayerViolations`).
+
+## Compatibility verification (grounded 2026-05-30)
+
+- **Opt-in and inert** with no rules declared; the existing layer-violation reporting is unchanged.
+- Reuses `detectLayerViolations` + the dependency graph; new handler returns `unknown`.
+- **Decision integration reads ADR files / active decisions** and does not alter the decision file
+  format or the gate — specifically avoiding the purge-on-sync pitfall below.
+
+## Edge cases & failure modes
+
+- **No rules declared** → fully inert: no output, no behavior change.
+- **Purge-on-sync hazard:** `INACTIVE_STATUSES` (`synced`/`rejected`/`phantom`) decisions are
+  removed from `pending.json` ([store.ts](../../src/core/decisions/store.ts)), so invariants must
+  live in the synced ADR files, not in pending decision fields.
+- **Rules referencing non-existent paths** → reported as config warnings, never a crash.
+- **Keep the vocabulary deterministic** (dependency / layer / module-boundary). Reject fuzzy
+  "semantic" rules a graph cannot decide.
+
 ## Acceptance
 
 - With a declared rule, the checker flags existing violations and answers a pre-edit import query


### PR DESCRIPTION
## What

Product-direction and implementation specifications for OpenLore's next features. **Docs only** — no runtime code changes. Every spec is additive and coding-agent-first by contract; the current product (deterministic code graph → `CODEBASE.md` + `orient()` over MCP) is preserved unchanged.

## The throughline

OpenLore evolves into the **deterministic analysis layer** for coding agents — computing the facts a model is structurally bad at (impact, reachability, test selection, coupling, invariants) — which **complements** agentic-search retrieval instead of competing with it. Three layers, nothing removed:

- **Layer 1 — the map** (today): structure — the graph, `orient`, `CODEBASE.md`.
- **Layer 2 — the why** (today): specs, decisions, drift.
- **Layer 3 — the analysis** (this PR): consequences — computed over Layers 1–2.

## Specs

**Direction & foundations**
- **13** — Product Direction: the analysis-layer thesis, Layer 1/2/3 framing, honest competitive landscape, scope/compatibility guarantee, kill signal.
- **14** — Agent Token-Efficiency Benchmark Harness (WITH vs WITHOUT). *Do first; it gates everything.*
- **15** — Decision & Drift Governance Dogfooding.
- **16** — Architectural Decisions as First-Class Graph Nodes.
- **17** — Cross-Domain Impact Analysis (Code ↔ Infrastructure).
- **18** — Local Provenance Edges (Git & PR metadata, no OAuth).

**Layer-3 analysis instruments** (each deterministic, additive, grounded in established CS)
- **19** — Deterministic Test Impact Selection (regression test selection; the headline, ~80% built).
- **20** — Reachability & Dead-Code Analysis (cross-language; cf. knip/ts-prune).
- **21** — Structural Change Analysis / graph diff (cf. difftastic).
- **22** — Change-Coupling & Volatility (co-change from git; cf. CodeScene).
- **23** — Architecture Invariant Guardrails (fitness functions; cf. ArchUnit/dependency-cruiser).

## Scope discipline

Graph-schema changes are safe via the edge-store `SCHEMA_VERSION` rebuild (the graph is derived from source). The core stays offline and key-free. Cloud OAuth connectors are fenced to an optional, far-horizon plugin — never default, never on the core path. The Spec 14 benchmark gates the whole Layer-3 cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)