### PR TITLE
test(watcher): close the spec 13.1 verification gap (read-cache handoff via the watcher's own flush)

### DIFF
--- a/src/core/services/mcp-watcher-incremental.test.ts
+++ b/src/core/services/mcp-watcher-incremental.test.ts
@@ -127,6 +127,37 @@ describe('McpWatcher — Spec 13.1 freshness', () => {
     for (const f of files) expect(paths.has(f)).toBe(true);
   });
 
+  it("G1: the watcher's flush primes the cache so the next read is a HIT (same object), not a cold re-parse", async () => {
+    // Root-cause #2 (Spec 13.1): the watcher's write used to bump llm-context.json's
+    // mtime and force the NEXT tool call to re-parse the whole file cold. The other
+    // G1 test proves primeContextCache→hit when called directly; this proves the
+    // WATCHER's own flush path (enqueue → flush → handleBatch → persistContext)
+    // hands the patched context to the read cache, and that the next readCachedContext
+    // returns that exact object — reference identity ⇒ no disk re-parse.
+    await writeContext([]);
+    await readCachedContext(root); // cold-prime the cache at the original mtime
+
+    const fooAbs = join(root, 'svc.ts');
+    await writeFile(fooAbs, 'export function after() {}\n', 'utf-8');
+
+    const utils = await import('./mcp-handlers/utils.js');
+    const primeSpy = vi.spyOn(utils, 'primeContextCache');
+
+    const watcher = new McpWatcher({ rootPath: root, embed: false, debounceMs: 20, maxBatchMs: 1000 });
+    (watcher as unknown as { enqueue(p: string): void }).enqueue(fooAbs);
+    await new Promise((r) => setTimeout(r, 150));
+
+    // The flush handed the patched context to the read cache exactly once.
+    expect(primeSpy).toHaveBeenCalledTimes(1);
+    const primed = primeSpy.mock.calls[0][1] as { signatures: Array<{ path: string; entries: Array<{ name: string }> }> };
+    expect(primed.signatures.find((s) => s.path === 'svc.ts')?.entries.some((e) => e.name === 'after')).toBe(true);
+
+    // The next tool-call read is served from that primed object — a cold re-parse
+    // would return a different object reference.
+    const afterRead = await readCachedContext(root);
+    expect(afterRead).toBe(primed);
+  });
+
   it('G3: a batch ≥ BULK_THRESHOLD is reported as a single coalesced refresh', async () => {
     await writeContext([]);
     const files = ['x.ts', 'y.ts', 'z.ts'];

--- a/src/core/services/mcp-watcher.integration.test.ts
+++ b/src/core/services/mcp-watcher.integration.test.ts
@@ -7,12 +7,14 @@
  * No embedding server required.  No mocks.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { LLMContext } from '../analyzer/artifact-generator.js';
 import { McpWatcher } from './mcp-watcher.js';
+import * as utils from './mcp-handlers/utils.js';
+import { readCachedContext, _resetContextCacheForTesting } from './mcp-handlers/utils.js';
 
 // ── Timing ────────────────────────────────────────────────────────────────────
 //   stabilityThreshold 100ms  +  debounce 100ms  +  processing slack 200ms
@@ -125,6 +127,42 @@ describe('McpWatcher — real fs watcher', () => {
     // No duplicate entries for the same file
     expect(after2.signatures?.filter(s => s.path === 'service.ts')).toHaveLength(1);
   }, 15_000);
+
+  it('G1: a real save primes the read cache — the next tool-call read is a HIT, not a cold re-parse', async () => {
+    // The root-cause #2 fix (Spec 13.1): the watcher's write used to bump
+    // llm-context.json's mtime and force the NEXT MCP tool call to re-parse the
+    // whole ~2 MB file cold. persistContext now hands the patched context to the
+    // shared read cache (primeContextCache) so the next read is served from
+    // memory. The unit tests prove primeContextCache→hit in isolation; this proves
+    // the REAL chokidar → handleBatch → persistContext → primeContextCache chain,
+    // then proves the next read returns that exact primed object (reference
+    // identity ⇒ no disk re-parse).
+    const { rootPath } = await setupProject(); // standard .openlore/analysis layout
+    _resetContextCacheForTesting();
+    const primeSpy = vi.spyOn(utils, 'primeContextCache');
+
+    const srcFile = join(rootPath, 'svc.ts');
+    await writeFile(srcFile, 'export function before() {}', 'utf-8');
+
+    const watcher = new McpWatcher({ rootPath, debounceMs: DEBOUNCE_MS }); // no outputPath → standard layout
+    watchers.push(watcher);
+    await watcher.start();
+
+    await writeFile(srcFile, 'export function after() {}', 'utf-8');
+    await wait(WAIT_MS);
+
+    // The real event path handed the patched context to the read cache.
+    expect(primeSpy, 'watcher must prime the read cache after a save').toHaveBeenCalled();
+    const primed = primeSpy.mock.calls.at(-1)![1] as LLMContext;
+    // Freshness (G6) landed in the primed object itself.
+    const entry = primed.signatures?.find((s) => s.path === 'svc.ts');
+    expect(entry?.entries.some((e) => e.name === 'after'), 'primed context reflects the edit').toBe(true);
+
+    // G1: the next tool-call read is served from that primed object — a cold
+    // re-parse would return a different object reference.
+    const afterRead = await readCachedContext(rootPath);
+    expect(afterRead, 'post-save read must be the primed object, not a fresh disk parse').toBe(primed);
+  }, 10_000);
 
   it('ignores .test.ts files', async () => {
     const { rootPath, outputPath, contextPath } = await setupProject();


### PR DESCRIPTION
## What this is

Follow-up **verification** for #102 (spec 13.1, watch-mode performance). I re-read the merged work, re-ran the full test/bench/build, and audited each of the five documented root causes against the code. The mechanism is sound and the existing tests are genuine. This PR adds two regression tests that close the one real **proof gap** I found. **No source changes.**

## Verification performed (all real, all re-run on this machine)

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `npm run lint` | 0 errors (3 pre-existing warnings in an untouched file) |
| CI-mirror `vitest run src examples` | **2936 passed / 2 skipped / 0 failures** |
| `npm run bench:watch` | next-call read after save **0.02 ms** (cache HIT) vs **4.0 ms** cold (169×); 50-file burst → **1** flush |
| watcher integration suite (real chokidar) | 5/5 green |

Root-cause → fix → test, audited:

1. **Full `llm-context.json` rewrite per save** → coalesced to one write per batch (Step 1). ✔ covered (G2 burst→1-flush test).
2. **Forced cold re-parse on next tool call (mtime cache-bust)** → `primeContextCache` handoff (Step 2). ✔ covered in isolation — **the gap this PR closes** (see below).
3. **Full vector read + `createTable(overwrite)`** → row-level `updateFiles` (`delete(\`filePath\` IN …) + add`) (Step 3). ✔ covered, incl. the backtick-quoting trap.
4. **stderr line per change** → one summary line per batch (Step 6). ✔ covered (G5).
5. **No cross-file coalescing** → single pending Set + debounce + max-batch ceiling (Step 1). ✔ covered (G2/G3).

## The gap I found

The merged PR proved root-cause #2 in two **disconnected** halves: a unit test proves `primeContextCache`→hit when called directly, and the integration tests prove freshness lands *on disk* through a real save. But **nothing proved the two connect** — that the watcher's own flush path (`enqueue → flush → handleBatch → persistContext → primeContextCache`) actually makes the next tool-call read a cache HIT instead of the cold ~2 MB re-parse that was the single biggest per-save cost. Freshness alone can't prove it (a cold re-parse also returns fresh data); the discriminator is *whether a parse happened*.

## What this PR adds

- **`mcp-watcher-incremental.test.ts` (runs in CI):** drives a flush via `enqueue`, spies on `primeContextCache` to capture the exact object the flush hands to the read cache, then asserts the next `readCachedContext` returns that **same object reference** — reference identity ⇒ no disk re-parse. Also asserts the flush primes exactly once.
- **`mcp-watcher.integration.test.ts` (real chokidar; `npm run test:integration`):** the same proof through an actual file save + real `FSWatcher`, for end-to-end fidelity to the field scenario.

## Finding for the owner (not changed here)

`*.integration.test.ts` is excluded from the default vitest config, so CI (`npm run test:run`) runs **zero** real-chokidar watcher tests — the integration suite only runs via `npm run test:integration`. Wiring the *hermetic* watcher integration file into CI would be worthwhile, but the full integration suite pulls in network/embedding-dependent files, so I left that as an owner decision rather than bundling it. The CI-covered incremental test added here gives regression protection in the meantime.

## Honest limits (unchanged from #102)

This does **not** reproduce the original multi-second field symptom — that needs a real MCP client under load / a denser corpus than this box has. Confidence still rests on the root-cause analysis + the now-complete mechanism tests + the microbenchmark. This PR strengthens the second leg; it doesn't claim the field magnitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)