### PR TITLE
chore(release): v2.0.6 + guard release against tag/version mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,21 @@ jobs:
 
       - run: npm ci
 
+      # Fail fast and loud if the tag doesn't match package.json's version.
+      # Without this, a tag pushed without the matching `chore(release)` bump
+      # sails through validate and dies late in `npm publish` with the cryptic
+      # "cannot publish over the previously published version" (this is exactly
+      # how the first v2.0.6 publish failed). Catch it here with a clear message.
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          PKG="v$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Release tag '$TAG' does not match package.json version '$PKG'. Bump package.json + package-lock.json in a chore(release) commit, retag at that commit, and re-run."
+            exit 1
+          fi
+          echo "Tag '$TAG' matches package.json version '$PKG'."
+
       - name: Run linting
         run: npm run lint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Reverse-engineer OpenSpec specifications from existing codebases",
   "type": "module",
   "main": "dist/api/index.js",


### PR DESCRIPTION
## Why

The first **v2.0.6 publish failed** (Actions run `71639223540`):

```
npm error You cannot publish over the previously published versions: 2.0.5.
```

Root cause: the `v2.0.6` tag was pushed at the #103 merge commit, where `package.json` still said **2.0.5** — the `chore(release)` version bump was never made. So `npm publish` tried to republish 2.0.5 and npm rejected it. The release workflow had **no guard** that the tag matches the package version, so it sailed through `validate` and died late in `publish` with a cryptic message.

## What this does

1. **Bump** `package.json` + `package-lock.json` 2.0.5 → 2.0.6 (the missing bump; 3 lines, matching the v2.0.5 release commit's footprint).
2. **Guard** the release workflow: a new *"Verify tag matches package.json version"* step in the `validate` job fails fast with an actionable message when the tag ≠ `v<package.json version>`. Sanity-checked: `v2.0.6`→pass, `v2.0.5`→fail.

## Why v2.0.6 is ready to ship — field fix validated

v2.0.6 carries the spec 13.1 watch-mode fix (#102) + its verification (#103). PR #102 honestly noted the original field symptom was **never reproduced**. I have now reproduced it cleanly, on enklayve's **real 2.1 MB `llm-context.json`** corpus, comparing published 2.0.5 vs the local fix (median of 5; methodology = drive the real `McpWatcher` through real chokidar on a copy of enklayve's artifacts):

| | OLD 2.0.5 | NEW (fix) |
|---|---|---|
| Single-save flush | ~276 ms | ~220 ms (no regression — G7) |
| Next tool-call read after a save | ~4.6 ms (cold re-parse) | **0.03 ms** (cache HIT) |
| stderr lines per save | 3 | **1** |
| **15-file burst — processing time** | **~5,900 ms** (30 serialized O(repo) passes) | **443 ms** (1 coalesced flush) |
| **15-file burst — stderr lines** | **46** | **2** |

The 15-file burst is the field "severe, batched result-delivery latency": old runs a full 2.1 MB rewrite + full 1,416-function BM25 rebuild **per file**, serialized, flooding stderr. The fix coalesces to one flush. A 50-file branch switch extrapolates to ~20 s vs one flush.

## Release steps after merge (owner — NOT done here, publish intentionally held)

1. Merge this PR.
2. Re-create the tag at the merge commit: `git tag -f v2.0.6 <merge-sha> && git push -f origin v2.0.6` (it currently points at the pre-bump #103 merge), **or** delete + recreate, **or** re-run the publish workflow via `workflow_dispatch` against the retagged ref.
3. The release workflow validates (now incl. the tag/version guard) → creates the Release → publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)