### PR TITLE
chore(release): v2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Reverse-engineer OpenSpec specifications from existing codebases",
   "type": "module",
   "main": "dist/api/index.js",


### PR DESCRIPTION
Version bump for **v2.0.7**. Ships, since v2.0.6:

- **Spec 14** — `openlore mcp --preset navigation`: a lean 7-tool graph-navigation surface (orient, search_code, get_subgraph, trace_execution_path, analyze_impact, suggest_insertion_points, get_function_skeleton). Measured net win on deep codebase questions (N=4): **−7% cost, −26% tool-calls**, scaling with repo size. See `docs/AGENT-BENCHMARKS.md`.
- **Spec 15** — decisions-gate dogfood + a real **concurrency fix**: a cross-process lock that stops concurrent `record_decision` consolidations from clobbering `pending.json` (silent data loss).

3 lines (package.json + package-lock.json); fast-levenshtein@2.0.6 left untouched. The validate-job tag/version guard (added in v2.0.6) will confirm the tag matches.

After merge: tag `v2.0.7` at the merge commit → release workflow validates → creates the GitHub Release → publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)