### PR TITLE
fix: move all soft-loaded grammars to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,18 +98,12 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "tree-sitter": "^0.22.4",
-    "tree-sitter-bash": "^0.23.3",
-    "tree-sitter-c": "^0.23.6",
-    "tree-sitter-c-sharp": "^0.23.1",
     "tree-sitter-cpp": "^0.23.4",
-    "tree-sitter-elixir": "^0.3.5",
     "tree-sitter-go": "^0.23.4",
     "tree-sitter-java": "^0.23.5",
-    "tree-sitter-php": "^0.23.12",
     "tree-sitter-python": "^0.23.6",
     "tree-sitter-ruby": "^0.23.1",
     "tree-sitter-rust": "^0.24.0",
-    "tree-sitter-scala": "^0.24.0",
     "tree-sitter-typescript": "^0.23.2",
     "tree-sitter-wasms": "0.1.13",
     "vite": "^7.1.3",
@@ -117,7 +111,13 @@
     "yaml": "^2.6.1"
   },
   "optionalDependencies": {
+    "tree-sitter-bash": "^0.23.3",
+    "tree-sitter-c": "^0.23.6",
+    "tree-sitter-c-sharp": "^0.23.1",
+    "tree-sitter-elixir": "^0.3.5",
     "tree-sitter-kotlin": "^0.3.8",
+    "tree-sitter-php": "^0.23.12",
+    "tree-sitter-scala": "^0.24.0",
     "tree-sitter-swift": "^0.7.1"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "tree-sitter-elixir": "^0.3.5",
     "tree-sitter-go": "^0.23.4",
     "tree-sitter-java": "^0.23.5",
-    "tree-sitter-kotlin": "^0.3.8",
     "tree-sitter-php": "^0.23.12",
     "tree-sitter-python": "^0.23.6",
     "tree-sitter-ruby": "^0.23.1",
@@ -118,6 +117,7 @@
     "yaml": "^2.6.1"
   },
   "optionalDependencies": {
+    "tree-sitter-kotlin": "^0.3.8",
     "tree-sitter-swift": "^0.7.1"
   },
   "overrides": {

--- a/src/core/analyzer/grammar-optional-deps.test.ts
+++ b/src/core/analyzer/grammar-optional-deps.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Ensures every grammar loaded via loadGrammarSoft() is declared as an
+ * optionalDependency in package.json, not a hard dependency.
+ *
+ * loadGrammarSoft = graceful failure at runtime → the package MUST be
+ * optional at install time, or npm install will fail in restricted
+ * environments (corporate proxy, TLS inspection, offline) when node-gyp
+ * cannot fetch build headers.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..', '..', '..');
+
+function extractSoftLoadedPackages(): string[] {
+  const src = readFileSync(join(ROOT, 'src', 'core', 'analyzer', 'call-graph.ts'), 'utf-8');
+  // Match: loadGrammarSoft('X', () => import('tree-sitter-foo'), ...)
+  const re = /loadGrammarSoft\('[^']+',\s*\(\)\s*=>\s*import\('(tree-sitter-[^']+)'\)/g;
+  const packages: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(src)) !== null) {
+    packages.push(m[1]);
+  }
+  return [...new Set(packages)];
+}
+
+describe('grammar optional dependencies', () => {
+  it('every package loaded via loadGrammarSoft is in optionalDependencies', () => {
+    const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
+    const optional = new Set<string>(Object.keys(pkg.optionalDependencies ?? {}));
+    const hardDeps = new Set<string>(Object.keys(pkg.dependencies ?? {}));
+
+    const softLoaded = extractSoftLoadedPackages();
+    expect(softLoaded.length).toBeGreaterThan(0); // regex sanity check
+
+    const violations: string[] = [];
+    for (const pkg of softLoaded) {
+      if (hardDeps.has(pkg) && !optional.has(pkg)) {
+        violations.push(pkg);
+      }
+    }
+
+    expect(
+      violations,
+      `These packages are loaded via loadGrammarSoft() (graceful failure) but declared ` +
+      `in "dependencies" (hard install). Move them to "optionalDependencies":\n` +
+      violations.map(p => `  - ${p}`).join('\n')
+    ).toEqual([]);
+  });
+
+  it('extractSoftLoadedPackages detects at least the known soft-loaded grammars', () => {
+    const softLoaded = extractSoftLoadedPackages();
+    const known = ['tree-sitter-kotlin', 'tree-sitter-bash', 'tree-sitter-c', 'tree-sitter-c-sharp'];
+    for (const k of known) {
+      expect(softLoaded, `Expected ${k} to be detected as soft-loaded`).toContain(k);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

All tree-sitter grammars loaded via `loadGrammarSoft()` can fail silently at runtime — `loadGrammarSoft` catches import errors and returns empty results with a warning when the module is absent. This means they are **optional by contract**.

However, 7 of them were declared in `dependencies` (hard install). On machines where `node-gyp` cannot compile native addons (corporate proxy, TLS inspection, offline CI), `npm install` fails entirely, blocking openlore adoption.

Previously discovered: `tree-sitter-kotlin` (PR from fork). Full audit reveals 6 more packages with the same issue.

## Fix

Move all `loadGrammarSoft`-loaded grammars to `optionalDependencies`:

| Package | Before | After |
|---------|--------|-------|
| `tree-sitter-bash` | `dependencies` | `optionalDependencies` |
| `tree-sitter-c` | `dependencies` | `optionalDependencies` |
| `tree-sitter-c-sharp` | `dependencies` | `optionalDependencies` |
| `tree-sitter-elixir` | `dependencies` | `optionalDependencies` |
| `tree-sitter-kotlin` | `dependencies` | `optionalDependencies` |
| `tree-sitter-php` | `dependencies` | `optionalDependencies` |
| `tree-sitter-scala` | `dependencies` | `optionalDependencies` |
| `tree-sitter-swift` | already optional | ✓ |

## Regression guard

Adds `grammar-optional-deps.test.ts`: statically parses `call-graph.ts` to extract every `loadGrammarSoft()` import target and asserts it is in `optionalDependencies`. Future additions of soft-loaded grammars will fail CI if not declared optional.

## Test plan

- [ ] `npm install openlore` succeeds in a restricted network environment
- [ ] All soft-loaded language analyses still work where native builds succeed
- [ ] Warning (not fatal error) displayed when a grammar is unavailable
- [ ] `grammar-optional-deps.test.ts` passes