### PR TITLE
Post-arc CI hardening + Spec 25 brainstorm: token-value optimization & honest proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -36,9 +36,9 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -52,9 +52,9 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -65,7 +65,7 @@ jobs:
         run: npm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,13 @@ jobs:
     name: Validate Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # workflow_dispatch → the explicitly-named tag.
           # push (tag) and release events → github.ref already points at the tag.
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -83,7 +83,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
 
@@ -123,11 +123,11 @@ jobs:
       name: npm-publish
       url: https://www.npmjs.com/package/openlore
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/docs/specs/openlore-spec-24-post-arc-ci-hardening.md
+++ b/docs/specs/openlore-spec-24-post-arc-ci-hardening.md
@@ -12,7 +12,7 @@ Branch: `chore/post-arc-ci-hardening`. **In progress** — PR pending. CI/test/w
 **no product code change and nothing user-facing**, so this does not warrant a version bump or npm
 publish.
 
-- [ ] **F1** — Bump GitHub Actions off the deprecated Node 20 runtime
+- [x] **F1** — Bump GitHub Actions off the deprecated Node 20 runtime — checkout@v6, setup-node@v6, upload-artifact@v7 in `ci.yml` + `release.yml`
 - [ ] **F2** — Stop `preflight.test.ts` leaking GitHub workflow-command annotations into the CI log
 
 ---

--- a/docs/specs/openlore-spec-24-post-arc-ci-hardening.md
+++ b/docs/specs/openlore-spec-24-post-arc-ci-hardening.md
@@ -8,12 +8,12 @@
 
 ## Progress
 
-Branch: `chore/post-arc-ci-hardening`. **In progress** — PR pending. CI/test/workflow hygiene only;
+Branch: `chore/post-arc-ci-hardening`. **Complete** — [PR #120](https://github.com/clay-good/OpenLore/pull/120). CI/test/workflow hygiene only;
 **no product code change and nothing user-facing**, so this does not warrant a version bump or npm
 publish.
 
 - [x] **F1** — Bump GitHub Actions off the deprecated Node 20 runtime — checkout@v6, setup-node@v6, upload-artifact@v7 in `ci.yml` + `release.yml`
-- [ ] **F2** — Stop `preflight.test.ts` leaking GitHub workflow-command annotations into the CI log
+- [x] **F2** — Stop `preflight.test.ts` leaking GitHub workflow-command annotations into the CI log — file-scope `beforeEach`/`afterEach` neutralizes `GITHUB_ACTIONS`. Reproduced (17 leaked lines under `GITHUB_ACTIONS=true`) → fixed (0), all 18 preflight tests still pass.
 
 ---
 

--- a/docs/specs/openlore-spec-24-post-arc-ci-hardening.md
+++ b/docs/specs/openlore-spec-24-post-arc-ci-hardening.md
@@ -1,0 +1,126 @@
+# OpenLore Spec 24 — Post-Arc CI/Release Hygiene (Dogfood Findings)
+
+> A maintenance spec, **not** a feature of the 13–23 context-substrate arc (that arc closed with
+> Spec 23 / v2.0.8). This captures issues found while dogfooding the published **v2.0.8** release
+> end-to-end, plus two CI annotations surfaced by the release run, and fixes them.
+
+---
+
+## Progress
+
+Branch: `chore/post-arc-ci-hardening`. **In progress** — PR pending. CI/test/workflow hygiene only;
+**no product code change and nothing user-facing**, so this does not warrant a version bump or npm
+publish.
+
+- [ ] **F1** — Bump GitHub Actions off the deprecated Node 20 runtime
+- [ ] **F2** — Stop `preflight.test.ts` leaking GitHub workflow-command annotations into the CI log
+
+---
+
+## Context — the dogfood pass (what we verified)
+
+Installed the **published** `openlore@2.0.8` from npm into a clean directory and exercised it
+end-to-end against a throwaway sample repo (a deliberate `core → cli` layer violation + an unused
+leaf function + an `.openlore/architecture.json`):
+
+- `openlore init` → `openlore analyze` produced the full v5 artifact set (call-graph.db,
+  dependency-graph.json, llm-context.json, CODEBASE.md, …). ✅
+- `openlore mcp` over stdio negotiated protocol `2025-11-25`, advertised **50 tools** including the
+  new `check_architecture`. ✅
+- `check_architecture` **scan** found both expected violations (`forbidden` + `layers` on
+  `src/core/service.ts → src/cli/view.ts`); **pre-edit** (`from`/`to`) returned `allowed: false`. ✅
+- `orient` surfaced the additive `architectureViolations` block (2) and suggested
+  `check_architecture`. ✅
+- `find_dead_code` flagged the unused leaf at low confidence. ✅
+
+**Conclusion: the published package is healthy.** No functional regression was found in 2.0.8. The
+only issues are CI/repo-hygiene items the release run surfaced as annotations — fixed below.
+
+---
+
+## F1 — GitHub Actions on the deprecated Node 20 runtime
+
+**Symptom.** Every workflow run prints:
+> Node.js 20 actions are deprecated. … `actions/checkout@v4`, `actions/setup-node@v4` … Actions will
+> be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed …
+> September 16th, 2026.
+
+**Root cause.** `actions/checkout@v4`, `actions/setup-node@v4`, and `actions/upload-artifact@v4` all
+run on the Node 20 action runtime, which GitHub is sunsetting.
+
+**Fix.** Bump each to its current latest major (all Node 24):
+
+| Action | From | To |
+|--------|------|----|
+| `actions/checkout` | `@v4` | `@v6` |
+| `actions/setup-node` | `@v4` | `@v6` |
+| `actions/upload-artifact` | `@v4` | `@v7` |
+
+Compatibility is safe for our usage: `setup-node` keeps `node-version` + `cache: npm`; `checkout`
+uses defaults (+ `ref:` in release.yml, unchanged across majors); `upload-artifact` uses only
+`name` / `path` / `retention-days`, stable across v4→v7.
+
+**Files / sites:**
+- `.github/workflows/ci.yml` — checkout/setup-node at lines 17/19, 39/41, 55/57; upload-artifact at 68.
+- `.github/workflows/release.yml` — checkout/setup-node at 36/42, 86, 126/130.
+
+**Verify:** push the branch; the deprecation annotation must be gone from the run and all jobs stay
+green.
+
+---
+
+## F2 — Preflight test leaks GHA workflow-command annotations into the CI log
+
+**Symptom.** A *passing* "Validate Release" (and CI) run carries spurious GitHub annotations like:
+> ✗ OpenLore preflight: staleness score 6 > threshold 0 (1 hub, 0 leaf changes). Run `openlore analyze`.
+> ⚠ OpenLore graph is stale for this file — run `openlore analyze` to refresh  (`src/foo.ts`)
+
+referencing fixture paths (`src/foo.ts`, `src/leaf.ts`) that don't exist in the repo. They look like
+failures but the jobs concluded `success`.
+
+**Root cause.** `renderGithubAnnotations` in
+[src/cli/preflight/report.ts](../../src/cli/preflight/report.ts) emits GitHub *workflow-command*
+lines (`::error::…`, `::warning file=…::…`) when `process.env.GITHUB_ACTIONS === 'true'` and the
+graph is STALE. [src/cli/preflight/index.ts](../../src/cli/preflight/index.ts) (`runPreflight`, line
+~144) writes that string to **`process.stdout`**. The preflight unit tests
+([src/cli/preflight/preflight.test.ts](../../src/cli/preflight/preflight.test.ts)) call
+`runPreflight()` over fixtures that are deliberately STALE. When the test suite runs **inside CI**,
+`GITHUB_ACTIONS` is already `'true'`, so those STALE `runPreflight` calls write real `::error::` /
+`::warning::` lines to the job's stdout, and GitHub parses them as run annotations. The product
+behavior (emit annotations during a real `openlore preflight` in CI) is correct and desired — the
+leak is purely a test-environment artifact.
+
+`GITHUB_ACTIONS` is read by **no other source file** (only `src/cli/preflight/*`), and only
+`preflight.test.ts` exercises this path — so the blast radius is one test file.
+
+**Fix.** Neutralize `GITHUB_ACTIONS` for the duration of the preflight test file so no `runPreflight`
+fixture inadvertently writes workflow commands to the job log. The one test that explicitly verifies
+GHA rendering sets `GITHUB_ACTIONS='true'` locally in a `try/finally` and calls the **pure**
+`renderGithubAnnotations()` (which returns a string and writes nothing) — so it keeps working and
+does not leak. Add a `beforeAll`/`afterAll` (or `beforeEach`/`afterEach`) in `preflight.test.ts` that
+saves and clears `process.env.GITHUB_ACTIONS`, restoring it afterward.
+
+**Verify:**
+- `grep` the captured CI test-job log for `::error::OpenLore preflight` / `::warning file=src/foo` →
+  zero matches (locally: run the suite with `GITHUB_ACTIONS=true` and confirm those lines no longer
+  reach stdout).
+- The explicit "emits GHA annotations" test still passes (asserts the pure-function output contains
+  the tokens).
+- All preflight tests pass; full suite stays green.
+
+---
+
+## Execution order
+
+1. **F1** — edit `ci.yml` + `release.yml`; one commit.
+2. **F2** — edit `preflight.test.ts`; reproduce the leak locally (`GITHUB_ACTIONS=true vitest run
+   src/cli/preflight`), confirm the fix removes the `::error::`/`::warning::` lines from stdout; one
+   commit with the reasoning.
+3. Full gate (lint + typecheck + `test:run` + build); update this spec's Progress; push; open PR;
+   confirm the pushed run is green **and** annotation-free.
+
+## Acceptance
+
+- Workflow runs show **no** Node 20 deprecation warning.
+- A green CI/release run carries **no** spurious `OpenLore preflight: staleness` annotations.
+- No product/runtime behavior changes; the published-package e2e remains healthy; no version bump.

--- a/docs/specs/openlore-spec-25-token-value-optimization-and-proof.md
+++ b/docs/specs/openlore-spec-25-token-value-optimization-and-proof.md
@@ -1,0 +1,240 @@
+# OpenLore Spec 25 — Token-Value Optimization & Honest Proof
+
+> **Brainstorm / architecture spec. No code is written in this session.** This is a wander toward a
+> concrete program: make OpenLore *provably* save an agent more than it costs, and show that proof
+> honestly and prominently. Parent: [Spec 13](openlore-spec-13-context-substrate.md) (substrate),
+> [Spec 14](openlore-spec-14-agent-benchmark-harness.md) (the benchmark we already have).
+> Prompt provocation: the `headroom` project (context compression for agents).
+
+---
+
+## 0. The proposition, stated bluntly
+
+OpenLore has exactly one reason to exist: **an agent *with* OpenLore must reach a correct answer
+for less total cost than the same agent *without* it.** If that is not true, the tool is negative
+value and should not ship. Everything below serves that single inequality:
+
+```
+cost_with_openlore(correct answer)  <  cost_without(correct answer)
+```
+
+"Cost" is dollars first, then its drivers: fresh (uncached) input tokens, round-trips, wall-clock.
+We will not hide behind a synthetic "tokens replaced" estimate. We will measure the inequality,
+publish it — wins **and** losses — and let users measure it on their own code.
+
+This spec has two halves that must ship together: **(A) optimize the inequality** and **(B) prove
+it, transparently.** Optimization without proof is marketing; proof without optimization is an
+honest admission of low value. We want both.
+
+---
+
+## 1. Ground truth — what we have actually measured (no spin)
+
+From [docs/AGENT-BENCHMARKS.md](../AGENT-BENCHMARKS.md) (Spec 14 harness: `claude -p
+--output-format json`, N=4, pinned SHAs, `--strict-mcp-config` isolating each arm):
+
+- **Round 1 — small/familiar repos, shallow "who calls X" tasks (chalk/express/flask/gin/zod):
+  OpenLore *lost*.** Median **+43% cost, +79% fresh input tokens, +38% round-trips**, losing 5 of 7
+  tasks. Correctness was **100% in both arms** — so it bought no accuracy either. Reported as-is.
+- **Root cause was the tool surface, not the responses.** The full ~45-tool MCP schema is sent on
+  every request; when the agent never calls most of those tools, their JSON Schemas are pure
+  per-request overhead that *erased* any saving. The responses themselves are already small.
+- **Round 2 — large repos, deep multi-hop traces, with `--preset navigation` (7 tools):** **−7%
+  cost, −26% round-trips, fresh tokens ≈ flat**, and the win **grows with repo size** (Django/Tokio/
+  Excalidraw −7%…−21%; Gin, the smallest, break-even +4%). The most consistent signal is
+  round-trips: fewer tool calls to reach the answer on *every* deep task.
+- **The README headline is an estimate.** "`orient()` … replaces 10+ file reads" and "~1–3k vs
+  15–50k tokens" ([README.md](../../README.md)) are intuitions, explicitly footnoted as unproven.
+
+**Two-tier conclusion, stated honestly:** OpenLore wins where the *orientation tax* is real (large,
+unfamiliar codebases the model has not memorized, deep multi-hop questions) and loses where it isn't
+(small, famous repos already in the model's weights). The whole program below is: **widen the win,
+kill the loss, replace every estimate with a measured, reproducible number.**
+
+---
+
+## 2. What `headroom` teaches — and what we deliberately reject
+
+`headroom` compresses everything an agent reads (tool output, files, RAG, logs, history) by
+**60–95%** and — critically — **proves answer quality is preserved** with a reproducible eval suite
+(GSM8K/TruthfulQA/SQuAD/BFCL, `python -m headroom.evals`). Its mechanisms: content-aware compressors
+(JSON "SmartCrusher", AST "CodeCompressor", a trained "Kompress" model), a **CacheAligner** that
+stabilizes prefixes for provider KV-cache hits, **reversible compression** (originals stored locally,
+the LLM calls `headroom_retrieve` to expand), **importance-scored** context fitting to a budget, and
+cross-agent dedup memory.
+
+**Adopt — as deterministic, offline mechanisms:**
+
+| headroom idea | OpenLore form |
+|---|---|
+| Reversible compression (store original, retrieve on demand) | **Progressive disclosure** — return the smallest sufficient *structural fact* plus an **exact** expansion handle (`symbol::file`, `file:line`). Our IDs are deterministic, so expansion is exact, not fuzzy. We already half-do this (`get_function_body`/`get_function_skeleton`); make it the contract. |
+| CacheAligner (stable prefix → KV-cache hits) | **Cache-stable tool surface** — fixed tool ordering + pinned schema/preamble text so the provider caches it and per-request schema cost drops ~10×. Directly attacks the Round-1 root cause. |
+| Importance-scored budget fitting | **Token-budgeted responses** — optional `tokenBudget`; importance-rank deterministically, greedily fill, replace overflow with expansion handles. |
+| Content-aware compaction | **Deterministic compaction only** — extend skeletonization; collapse near-duplicate implementations to one exemplar + count + deltas (reuse `get_duplicate_report`). |
+| Reproducible eval proving quality preserved | **Honest, prominent, reproducible proof** (§5) — including a self-serve "measure it on your repo" command. |
+
+**Reject — these violate OpenLore's north star (deterministic, local-first, offline, no API key):**
+
+- **Trained ML compressors / image routers** (`Kompress`, the ML image router). Non-deterministic, a
+  heavy dependency, and they'd make the substrate's output depend on a model — the opposite of
+  "deterministic structural context." Our payloads are already 15–25 KB and *structured*; squeezing
+  bytes with a model buys little and costs determinism.
+- **A network proxy / provider interception** (headroom's port-8787 proxy). OpenLore is plumbing the
+  agent calls *into*, not a man-in-the-middle on the model call.
+- **Lossy semantic compression of code.** A graph substrate must not paraphrase code; it points at
+  exact code. Compression here = *fewer, more precise facts + exact handles*, never *fuzzier facts*.
+
+The senior-engineer read: **headroom optimizes the bytes of a turn; OpenLore should optimize the
+*number of turns* and the *cache economics* of the turn.** Those are bigger levers for our use case,
+and they're deterministic.
+
+---
+
+## 3. The reframe that should drive everything
+
+The Round-2 data says the win is **−26% round-trips**, with fresh tokens roughly flat. That is the
+tell. Our value is not "smaller responses" — it's **fewer agent turns to a correct answer** and
+**avoided wrong-path exploration**. Each avoided round-trip saves a whole model turn re-reading an
+ever-growing context; that dwarfs a few KB shaved off one response.
+
+So the optimization priorities, ranked by expected leverage:
+
+1. **Cache economics of the surface** (fresh→cached) — the schema overhead only hurts when it isn't
+   cached. Make it cacheable and lean. *Biggest, cheapest win; fixes the Round-1 loss.*
+2. **Round-trips per task** — make `orient` and the traversal tools *complete* enough that the agent
+   stops looping. (This is already our strength; protect and extend it.)
+3. **Minimal-sufficient responses with exact expansion handles** — keep each turn small *without*
+   forcing a follow-up read, because a follow-up read is a round-trip (priority 2 again).
+4. **Raw byte compaction** — last, and only deterministically.
+
+Note the elegant tension: aggressive response trimming (priority 3) can *increase* round-trips
+(priority 2) if it strips something the agent then has to re-fetch. The resolution is the
+progressive-disclosure contract: trim to the smallest fact **that still lets the agent decide**, and
+attach the exact handle so expansion is a *cheap, optional, one-shot* call — not a blind re-search.
+
+---
+
+## 4. Optimization program (deterministic)
+
+### P1 — Cache-aware, lean-by-default tool surface
+- Make a lean preset (today's `navigation`, 7 tools) the **recommended default** for agents, and
+  document the full surface as opt-in. The benchmark already shows this flips +43% → −7%.
+- **Stabilize the cache prefix:** fixed tool-definition order, pinned schema/preamble strings, no
+  per-request variation, so the provider KV-cache holds the surface and it costs ~10× less after the
+  first call. Treat any per-request churn in the preamble as a bug.
+- **Explore deferred/lazy tool schemas:** advertise tool *names* cheaply and load a tool's full
+  JSON Schema only when it's about to be used (the pattern this very runtime uses for deferred
+  tools). If viable over MCP, it drives first-call schema overhead toward zero — potentially erasing
+  the Round-1 loss outright. Open question in §7.
+- **Instrument fresh-vs-cached explicitly** in the harness so we can *see* the cache working.
+
+### P2 — Progressive-disclosure contract (OpenLore's reversible compression)
+- Principle: **every tool returns the smallest sufficient structural fact + an exact expansion
+  handle.** `orient` returns signatures + `symbol::file` / `file:line` pointers, not bodies; the
+  agent expands exactly one body via `get_function_body` *only if it needs to*.
+- This is headroom's CCR, but **exact** instead of fuzzy — our determinism is the moat.
+- Make handles first-class and uniform across tools (a stable `expand:` field), so an agent learns
+  one expansion idiom.
+
+### P3 — Adaptive sizing / duplicate collapsing (the CodeGraph lever AGENT-BENCHMARKS flagged)
+- When results share a shape (overloads, near-duplicate handlers, generated code), collapse to **one
+  exemplar + a count + the deltas**, reusing existing duplicate detection. 10–50× on duplicate-heavy
+  results, zero loss of decision-relevant information.
+- Signatures by default; bodies on request (P2).
+
+### P4 — Token-budgeted responses
+- Optional `tokenBudget` on `orient`/`search_code`: importance-rank deterministically (existing
+  scores), greedily fill the budget, and replace the overflow with a single line: "*N more —
+  expand with `…`*". Deterministic, reproducible, and lets a caller fit the answer to a context
+  window on purpose.
+
+### P5 — Deterministic content compaction (lowest priority)
+- Extend skeletonization; prefer compact structured JSON over prose; drop fields that repeat the
+  query. Never at the expense of an expansion handle or correctness.
+
+---
+
+## 5. The proof program (honest, transparent, prominent)
+
+This is the half the user is really asking for: **prove the value, show it clearly, link it in the
+README, and never overstate it.**
+
+### Q1 — Re-base the benchmark on the *real* target, keep the loss case as control
+- **Corpus:** large, unfamiliar/private-shaped repos + **deep multi-hop tasks** (where orientation
+  tax is real) as the headline; **keep** the small/familiar repos as the honest control that *shows
+  the loss*. Choose the corpus and tasks **before** looking at results (anti-cherry-pick).
+- **Metrics:** end-to-end **USD cost (primary)**, fresh tokens, **cached tokens (new — see P1)**,
+  **round-trips (co-headline)**, correctness, wall-clock — WITH vs WITHOUT, N runs, median + spread.
+- Reuse the Spec 14 isolation discipline (`--strict-mcp-config`, pinned SHAs).
+
+### Q2 — `openlore prove`: measure it on *your* repo (the strongest honesty mechanism)
+- A command that runs a quick WITH/WITHOUT pass on **the user's own codebase** over a couple of
+  seeded/auto-derived tasks and prints a **personal token-value scorecard**: cost delta, round-trip
+  delta, correctness, "helps / break-even / doesn't help here."
+- Reframes the whole trust problem: *"Don't trust our numbers on famous repos — measure yours."*
+  This is the most credible possible answer to "is it actually a value add?"
+- Must surface its own caveats: LLM nondeterminism → N runs + median + variance; needs an API key
+  for the agent arm; states clearly when the sample is too small to conclude.
+
+### Q3 — A README "Value Scorecard," prominent and linked
+- A table near the top: **task class × repo size → cost Δ, round-trip Δ, correctness** — *including
+  the cells where OpenLore loses or breaks even.* Honesty is the feature.
+- A one-line **reproducible command**, the **pinned SHAs/date**, and ideally a **badge**.
+- A blunt **"when OpenLore helps / when it doesn't"** box that sets expectations before install.
+- Replace the unproven "15–50k tokens" estimate with measured ranges, or delete it.
+
+### Q4 — Honesty contract (written into the repo)
+- Never publish a savings number the harness didn't produce.
+- Always show the negative cases alongside the positive.
+- Re-measure and update the scorecard after each optimization phase; date-stamp it.
+- Consider a nightly CI benchmark so the README number is never stale (cost/flakiness tradeoff in §7).
+
+---
+
+## 6. Non-goals
+
+- No trained models, no network proxy, no API key for the *substrate* (the benchmark/`prove` agent
+  arm needs one; the tool itself must not).
+- No lossy/semantic compression of code; no fuzzy retrieval. Exact handles only.
+- Not chasing raw byte reduction for its own sake — round-trips and cache first.
+- Not re-litigating the two-tier reality: small/familiar repos may stay break-even, and that's fine
+  *if we say so plainly.*
+
+## 7. Risks & open questions (the wandering part)
+
+- **Is "round-trips" the more honest headline than "tokens"?** I lean yes — it's what we actually,
+  consistently move, and it's harder to game. Tokens/cost stay as the bottom line.
+- **Can MCP tool schemas be deferred/lazy** the way this runtime defers tools? If yes, P1 may erase
+  the small-repo loss entirely. Needs an MCP-capability check — biggest unknown, biggest upside.
+- **LLM nondeterminism** threatens any benchmark. Mitigate with N runs, median, published variance,
+  pinned models/SHAs — and admit the residual.
+- **Cache behavior is provider-specific.** Measure it; don't assume a 10× on faith.
+- **Over-trimming raises round-trips.** Every compaction must keep the exact expansion handle and be
+  gated on "correctness preserved" in the harness.
+- **Benchmark cost vs freshness.** A live nightly badge is great honesty but burns API budget and can
+  flake; maybe a cheap proxy metric (round-trips on a tiny pinned corpus) for the badge, full suite
+  on demand.
+- **Scope discipline.** This must not drift into a general compression library. It's: lean cacheable
+  surface + progressive disclosure + a credible, self-serve proof.
+
+## 8. Phasing (proposal — prove first, then optimize, then re-prove)
+
+- **Phase A — Prove the present, honestly.** Re-based benchmark (Q1) + README Value Scorecard (Q3) +
+  replace the unproven estimates with measured numbers (Q4). Ship the truth as it stands today.
+- **Phase B — Cache + surface (likely the biggest win).** Lean default + cache-stable prefix +
+  fresh/cached instrumentation (P1). Re-measure; expect the small-repo loss to shrink toward break-even.
+- **Phase C — Progressive disclosure + adaptive sizing.** Minimal-sufficient responses with exact
+  handles (P2), duplicate collapsing (P3), `tokenBudget` (P4). Re-measure round-trips.
+- **Phase D — `openlore prove`.** The self-serve, on-your-repo scorecard (Q2). The honesty capstone.
+- Re-measure and republish the scorecard after **every** phase. The number in the README is always
+  the last measured number, with its date.
+
+## 9. Success criteria
+
+- The README carries a **measured, reproducible** value scorecard — wins *and* losses — linked
+  prominently above the fold.
+- On the target corpus, WITH-OpenLore beats WITHOUT on **cost and round-trips at equal correctness**,
+  by a margin that **grows with repo size**.
+- The small/familiar-repo loss is **eliminated or reduced to break-even** (via P1).
+- Anyone can run **`openlore prove`** on their own repo and get an honest personal number in minutes.
+- Every public token claim traces to a command someone else can run.

--- a/docs/specs/openlore-spec-26-install-mcp-wiring-and-first-run-correctness.md
+++ b/docs/specs/openlore-spec-26-install-mcp-wiring-and-first-run-correctness.md
@@ -1,0 +1,300 @@
+# OpenLore Spec 26 — Install, MCP-Wiring & First-Run Correctness (Dogfood Findings)
+
+> A fix-plan spec. **No code in this session** — investigation + solutions only. Sourced from
+> dogfooding the published **v2.0.8** release across several real repos (verisim, nidus, …). Every
+> finding below was re-confirmed against the actual code by a 10-agent investigation workflow with
+> file:line evidence; all 10 came back **confirmed, high-confidence**. Parent:
+> [Spec 13](openlore-spec-13-context-substrate.md). Sibling: [Spec 24](openlore-spec-24-post-arc-ci-hardening.md)
+> (the earlier CI-hardening dogfood pass).
+
+---
+
+## Progress
+
+Branch: `chore/post-arc-ci-hardening` → [PR #120](https://github.com/clay-good/OpenLore/pull/120).
+This document is the **plan**; implementation lands in follow-up commits/PRs per the wave sequence in
+§4. Status: **analysis complete, implementation pending.**
+
+- [ ] Wave 0 — Fix MCP registration (the headline bug)
+- [ ] Wave 1 — Consolidated `doctor` pass
+- [ ] Wave 2 — Detection correctness (spec dir, agent/project, node version)
+- [ ] Wave 3 — Freshness ownership (drop redundant hook, auto-rebuild on reset)
+- [ ] Wave 4 — Cosmetic/cleanup wins (skill schema, ARCHITECTURE.md path, gitignore dedupe, model bump)
+
+---
+
+## 0. The two dominant themes (read these first)
+
+Everything below collapses to two root themes. Internalize them and most of the bugs are obvious:
+
+- **Theme A — "settings.json = hooks, `.mcp.json` = mcpServers."** OpenLore writes its MCP server
+  declaration to `.claude/settings.json`, which **Claude Code never reads for MCP**. The single most
+  important fact in this spec. It spans the headline bug (B1), the skill's detection heuristic (B8),
+  and the agent-detection layer (B6).
+- **Theme B — silent degradation / false-positive health.** The tool repeatedly *looks* fine while
+  being broken: MCP never loads (B1), an empty `openspec/` reports "✓" (B5), spec linking is silently
+  empty (B5), the graph index silently empties on a version bump (B10), `doctor` calls an optional
+  LLM dependency "fatal" (B4). **Fixing the *signal* is as valuable as fixing the behavior** — which
+  is exactly why `doctor` (Theme C below) gets a consolidated pass: it's the funnel where all of this
+  should have become visible.
+
+---
+
+## 1. Findings (confirmed, with root cause + deterministic fix)
+
+Severity order. Each fix is **deterministic and offline** (OpenLore's north star). File:line cites
+are from the investigation against `main` at v2.0.8.
+
+### B1 · CRITICAL · MCP server written to the file Claude Code ignores
+*Commands: install, setup, doctor, generate. Effort: M.*
+
+**Root cause.** The claude-code adapter registers the server in `.claude/settings.json` under
+`mcpServers.openlore` ([adapters/claude-code.ts:17-20, :112](../../src/cli/install/adapters/claude-code.ts)),
+but Claude Code loads MCP only from **`.mcp.json`** (project), `~/.claude.json`, or `claude mcp add`
+— never `settings.json`. `setup` calls `installClaudeHook`
+([setup.ts:363-365](../../src/cli/commands/setup.ts) → [decisions.ts:339-359](../../src/cli/commands/decisions.ts))
+which adds **only** a PostToolUse hook, never the server. `generate`/`doctor` don't register it at
+all. **Net: after `openlore install` / `setup --tools claude`, `mcp__openlore__*` tools never load.**
+The product's core value is silently dead on arrival. (Related: a malformed block written to
+`settings.json` also triggered Claude Code's *"expected array, but received undefined … settings not
+in effect"* — wiping the user's permissions too.)
+
+**Fix.** (1) Write the MCP server to **`.mcp.json`** at project scope (git-tracked, auto-loaded),
+merging via the existing managed-entry pattern in [json-managed.ts](../../src/cli/install/json-managed.ts).
+(2) Keep the SessionStart hook in `settings.json` (correct, schema-valid). (3) Ensure **nothing**
+written to `settings.json` violates its schema (the "expected array" report — audit the hooks/permissions
+shape). (4) Add a `doctor` check: if `mcpServers.openlore` is in `settings.json` but absent from
+`.mcp.json`, warn with the exact fix (`openlore install --agent claude-code --force`). (5) Update
+[docs/mcp-tools.md](../../docs/mcp-tools.md) + [docs/agent-setup.md](../../docs/agent-setup.md).
+*Files:* `adapters/claude-code.ts`, `doctor.ts`, the two docs. *Risk:* existing `settings.json`
+`mcpServers.openlore` entries need cleanup — the new doctor check + `--force` is the migration path.
+
+### B5 · HIGH · `init` creates an empty `openspec/` blind to existing specs
+*Commands: init, analyze, doctor. Effort: M.*
+
+**Root cause.** `init` unconditionally creates `openspec/specs/`
+([init.ts:170-174](../../src/cli/commands/init.ts) → [config-manager.ts:163-166](../../src/core/services/config-manager.ts))
+without detecting specs that already live in `docs/specs/` or `specs/`. Then `doctor` reports
+"✓ OpenSpec directory" off the **empty** dir ([doctor.ts:145](../../src/cli/commands/doctor.ts), hardcoded
+path), while `analyze` throws "No spec.md files found" internally
+([spec-vector-index.ts:319-322](../../src/core/analyzer/spec-vector-index.ts)) and logs "Spec index
+skipped" — so `linkedSpecs`/`specDomains`/drift are silently empty. A triple silent failure.
+
+**Fix.** Add `detectExistingSpecDir()` (scan `openspec/specs/`, `docs/specs/`, `specs/` for `*.md`),
+call it from `init` *before* `createOpenSpecStructure()`: if a non-empty dir is found, set
+`openspecPath` to it and skip creating an empty one; if empty, warn. Make `doctor`'s OpenSpec check
+read the **configured** `openspecPath`, not a hardcoded one. Sharpen the spec-index error to
+distinguish "dir missing" from "dir empty" so `analyze` can warn about misconfig. *Files:*
+`config-manager.ts`, `init.ts`, `api/init.ts`, `spec-vector-index.ts`, `analyze.ts`, `doctor.ts`.
+*Load-bearing caveat (document it):* non-OpenSpec-format `spec.md` files still won't *link* even after
+detection points at them — detection only fixes the silent false-positive, not the format gap.
+
+### B6 · HIGH · Detection is root-only and has no Claude-Code bias
+*Commands: install, init, analyze. Effort: M.*
+
+**Root cause.** (A) Project-type detection only checks manifests at the repo root
+([project-detector.ts:49-68](../../src/core/services/project-detector.ts)) → a nested
+`python/pyproject.toml` (nidus) yields "Unknown". (B) Agent detection walks up for markers
+(`.claude/`, `CLAUDE.md`, …) and, finding none, **unconditionally** falls back to `agents-md`
+([detect.ts:116-119](../../src/cli/install/detect.ts), [install/index.ts:113-126](../../src/cli/install/index.ts))
+— so a Claude Code user with a clean repo is silently mis-targeted. Bad for the headline audience.
+
+**Fix.** (A) Scan a small set of depth-1 subdirs (`python/`, `src/`, `backend/`, `frontend/`, …)
+before declaring "Unknown"; prefer the shallowest match. (B) Replace the blind `agents-md` fallback:
+check `~/.claude/`; if present, bias to `claude-code`; else, on a TTY prompt to choose, and only
+fall back to `agents-md` non-interactively with an explicit warning + "run with `--agent claude-code`".
+*Files:* `project-detector.ts`, `detect.ts`, `install/index.ts`. *Risk:* `~/.claude` is a new implicit
+dependency; keep prompts TTY-only so CI isn't surprised.
+
+### B7 · HIGH · Node `>=22.5.0` vs repo `.nvmrc` 20 — latent session-start breakage
+*Commands: install, mcp, orient. Effort: M.*
+
+**Root cause.** `engines.node >=22.5.0` ([package.json](../../package.json)) is required by
+`node:sqlite`/`DatabaseSync` ([edge-store.ts:3](../../src/core/services/edge-store.ts),
+[epistemic-lease.ts:30](../../src/core/services/mcp-handlers/epistemic-lease.ts), loaded at mcp.ts
+module-load). The MCP server and SessionStart hook shell out via `npx`
+([adapters/claude-code.ts:18-28](../../src/cli/install/adapters/claude-code.ts)); when a shell honors
+a repo `.nvmrc` pinned to Node 20 (nvm auto-switch), both fail cryptically. `doctor` only checks
+major-version ≥20 ([constants.ts:226](../../src/constants.ts) `MIN_NODE_MAJOR_VERSION = 20`), so it
+doesn't catch it. Works today only because the active node happens to be 25.x.
+
+**Fix (recommended = lock + warn, not lower the floor).** Keep `>=22.5.0` (the EdgeStore refactor
+deliberately moved off `better-sqlite3`; `node:sqlite` is RC as of Node 25.7). (1) `doctor` checks the
+**minor** version (≥22.5), failing fast with a `nvm use` remediation. (2) Wrap the generated npx
+invocations with a one-line node-version guard that prints a clear error instead of a module crash.
+(3) A try/catch around the `node:sqlite` import surfacing an actionable preflight message. *Files:*
+`package.json` (doc the why), the adapters, `doctor.ts`, `mcp.ts`, `orient.ts`. *Open decision:* whether
+to ever support Node 20 by feature-gating `node:sqlite` — recommend **no** (keep the floor, fix the
+signal).
+
+### B10 · HIGH · Version bump silently resets the graph index, no auto-rebuild
+*Commands: orient, analyze_codebase, MCP read paths. Effort: M.*
+
+**Root cause.** On a `SCHEMA_VERSION` bump ([edge-store.ts:51, :74](../../src/core/services/edge-store.ts))
+the store wipes graph tables and sets `_wasReset`. `readCachedContext` correctly withholds the empty
+store ([utils.ts:181](../../src/core/services/mcp-handlers/utils.ts)) and `orient` emits a
+`graphIndexNote` ([orient.ts:544, :553](../../src/core/services/mcp-handlers/orient.ts)) — but **no
+rebuild is triggered**; the watcher explicitly skips on `wasReset`
+([mcp-watcher.ts:363-368](../../src/core/services/mcp-watcher.ts)). Callers, call-paths, and insertion
+points are degraded until a manual `analyze`. (The note we added earlier mitigates *silence*; the
+finding is it should *self-heal*.)
+
+**Fix (recommended = watcher auto-rebuild).** When `handleBatch` sees `wasReset`, schedule **one**
+background `openlore analyze --force` (no-watch, session-global in-progress flag to avoid a thundering
+herd; log to stderr). Reset the flag on completion; on failure, fall back to the existing note (no
+infinite loop). *Files:* `mcp-watcher.ts`, `utils.ts`, `orient.ts`. *Sequence:* land **after** B9 so
+the watcher is the unambiguous freshness owner first. *Risk:* rebuild CPU during large repos — gate
+with the session flag + once-per-bump.
+
+### B4 · MEDIUM · `doctor` exits non-zero solely on the optional LLM/embedding check
+*Commands: doctor (perceived health of analyze/orient/search/mcp). Effort: S.*
+
+**Root cause.** `doctor` runs 8 checks — 6 deterministic + 2 LLM/embedding — and treats **any**
+`fail` as fatal: `process.exitCode = 1`, "X check(s) failed — fix before proceeding"
+([doctor.ts:440-450](../../src/cli/commands/doctor.ts)). The LLM/embedding checks return `fail` (never
+`warn`) when a key is absent ([doctor.ts:232-238, :262-318](../../src/cli/commands/doctor.ts)) — even
+though the entire deterministic workflow (`analyze --no-embed` + `orient`/`search` via BM25) needs
+**no** LLM. This contradicts the "No API Key" docs and the BM25-fallback design.
+
+**Fix (Approach A — recommended).** Make the LLM/embedding checks **`warn`, not `fail`**
+(doctor.ts:246, :295). Warnings already don't set `exitCode=1` (doctor.ts:446-447), so the no-LLM path
+exits 0 while still surfacing the advice. Reword the summary to "X failed, Y warnings" when both
+present. (Optional `--offline` flag = Approach B, more surface; A is the 2-line, more-honest fix.)
+*Files:* `doctor.ts`. *Risk:* scripts that asserted non-zero on missing-LLM now see 0 (acceptable; use
+`--json` for scripting).
+
+### B9 · MEDIUM · Redundant freshness: PostToolUse full-`analyze` vs `--watch-auto`
+*Commands: setup, mcp, decisions. Effort: S.*
+
+**Root cause.** The PostToolUse hook runs a **full O(repo)** `openlore analyze`
+([decisions.ts:334](../../src/cli/commands/decisions.ts)) on every tool call, while the MCP server's
+`--watch-auto` (default since v2.0.6/Spec 13.1, [mcp.ts:1848](../../src/cli/commands/mcp.ts)) already
+keeps freshness **incrementally O(change)** ([mcp-watcher.ts](../../src/core/services/mcp-watcher.ts)).
+Double work. The hook's `_comment` ("after every file edit", [decisions.ts:328](../../src/cli/commands/decisions.ts))
+is also wrong — PostToolUse fires for **all** tools (Read, Bash, …), masked only by a 10s lock.
+
+**Fix.** Declare `--watch-auto` the single freshness owner: **remove** the full-`analyze`
+`ANALYZE_HOOK_ENTRY` from `installClaudeHook`/`uninstallClaudeHook`. (If a post-call hook is wanted for
+other reasons, make it strictly lighter and fix the `_comment` to say it fires on every tool call.)
+*Files:* `decisions.ts`. *Risk:* verify no test/doc treats the hook as a required freshness contract
+before removal. *Sequence:* before B10.
+
+### B8 · MEDIUM · `openlore-orient` skill: stale schema + wrong MCP-detection
+*Commands: orient. Effort: S (docs-only).*
+
+**Root cause.** [skills/openlore-orient/SKILL.md:40-43](../../skills/openlore-orient/SKILL.md) tells
+agents to parse **snake_case** (`relevant_functions`, `spec_sections`, `insertion_points`, `callers`),
+but `orient --json` emits **camelCase** ([orient.ts:546-570](../../src/core/services/mcp-handlers/orient.ts):
+`relevantFunctions`, `relevantFiles`, `specDomains`, `callPaths`, `insertionPoints`). Its MCP-detection
+note (SKILL.md:28) only mentions `.claude/settings.json → mcpServers.openlore` (the wrong file per B1).
+
+**Fix.** Update SKILL.md to the real camelCase field names; fix the detection note to point at
+`.mcp.json` (after B1 lands). The "CLI subcommand not yet shipped" TODO is already corrected in this
+file — confirm it stays accurate (it ships in 2.0.8). *Files:* `skills/openlore-orient/SKILL.md`.
+*Sequence:* the `.mcp.json` half lands **after** B1; the camelCase half is independent.
+
+### B3 · MEDIUM · `ARCHITECTURE.md` written to repo root, not gitignored
+*Commands: analyze. Effort: S.*
+
+**Root cause.** `writeArchitectureMd()` writes to `join(rootPath, 'ARCHITECTURE.md')`
+([architecture-writer.ts:271](../../src/core/analyzer/architecture-writer.ts)); the call site passes
+only `rootPath` ([analyze.ts:605-614](../../src/cli/commands/analyze.ts)). Every *other* artifact
+(CODEBASE.md, SUMMARY.md) writes under `.openlore/analysis/`
+([codebase-digest.ts:74-78](../../src/core/analyzer/codebase-digest.ts)). So `ARCHITECTURE.md` churns
+in `git status` at the repo root (worsened by the freshness hook re-running analyze), and `init`'s
+gitignore only covers `.openlore/`.
+
+**Fix (recommended = move it, don't gitignore it).** Give `writeArchitectureMd(outputDir, overview)`
+and pass `outputPath` (already `join(rootPath, opts.output)` at analyze.ts:346), so it lands in
+`.openlore/analysis/` with the rest. Update the test assertion. Cleaner than adding a gitignore line —
+one gitignored home for all generated analysis. *Files:* `architecture-writer.ts`, `analyze.ts`,
+`architecture-writer.test.ts`. *Risk:* one-time manual cleanup of stray root `ARCHITECTURE.md`.
+
+### B2a · LOW · Redundant `.gitignore` child entry
+*Commands: init, setup, decisions. Effort: S.*
+
+**Root cause.** `ensureGitignored()` only matches an exact line
+([decisions.ts:179-188](../../src/cli/commands/decisions.ts)) and appends `.openlore/decisions/`
+([decisions.ts:247](../../src/cli/commands/decisions.ts)) even though `init` already added the covering
+`.openlore/`.
+
+**Fix.** Before appending `a/b/c/`, skip if an existing entry is a covering parent (`a/`, `a/b/`) with
+trailing-slash normalization. Guard against false parents (`.openlore` must not match `.openapi/`).
+*Files:* `decisions.ts`.
+
+### B2b · LOW · Stale default generation model
+*Commands: init. Effort: S.*
+
+**Root cause.** `DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-20250514'`
+([constants.ts:213](../../src/constants.ts)), used by `getDefaultConfig()`
+([config-manager.ts:65](../../src/core/services/config-manager.ts)).
+
+**Fix.** Bump to **`claude-sonnet-4-6`** (Sonnet 4.6 — **confirmed current** in the live model lineup).
+Update the hard-coded expectations in `config-manager.test.ts`, `generate.test.ts`, `run.test.ts`.
+Verify the `llm-service.ts` pricing table has a matching/version-agnostic `claude-sonnet-4` key so cost
+estimation still resolves. *Files:* `constants.ts` + those tests.
+
+### Non-bugs (credit, recorded so we don't "fix" them)
+- **`orient --json` stream separation is correct** — pure JSON on stdout, diagnostics on stderr. A
+  user's parse failure was self-inflicted (`2>&1`). 👍 Do not change.
+- **Semantic search defaulting to BM25** when no `EMBED_BASE_URL`/`EMBED_MODEL` is **by design** and
+  clearly messaged. Not a bug.
+
+---
+
+## 2. Cross-cutting themes (beyond §0)
+
+- **Theme C — `doctor` is under-powered and mis-calibrated.** It appears in five findings (B1 wants a
+  new "wrong-file" check, B5 a config-path-aware OpenSpec check, B7 a minor-version check, B4
+  warn-not-fail). It's the natural funnel for Theme B's silent failures → it earns a **single
+  consolidated pass** (Wave 1) instead of four colliding edits to `doctor.ts`.
+- **Theme D — detection is too literal / root-only.** Root-only manifest scan (B6A), no-bias agent
+  fallback (B6B), hardcoded spec-dir path (B5). All "look in exactly one place, assume the happy path."
+
+## 3. Conflicts & ordering dependencies
+
+1. **B1 → B8.** The skill's `.mcp.json` detection fix only makes sense once B1 makes `.mcp.json`
+   canonical. (B8's camelCase half is independent.)
+2. **`doctor.ts` is edited by B1, B4, B5, B7 — do one coordinated pass** (Wave 1) to avoid a four-way
+   collision.
+3. **B1 → B6.** Both touch the install/adapter layer; land B1 so the claude-code adapter is correct
+   before B6 routes more cases to it.
+4. **B1 → B7.** Both edit `claude-code.ts` (`MCP_ENTRY`/`ORIENT_COMMAND`); sequence so B7's node guard
+   isn't rebased onto a moved entry.
+5. **B9 → B10.** B9 makes `--watch-auto` the unambiguous freshness owner; B10 then gives that watcher
+   the auto-rebuild duty. Compatible and mutually reinforcing, but order matters.
+6. **B9 & B2a share `decisions.ts`** (different functions) — trivial to coordinate.
+
+## 4. Recommended fix sequence (execution order)
+
+- **Wave 0 — Ship the headline fix, alone, verified on a clean repo.** B1 (`.mcp.json` registration +
+  doctor migration check). Without it the product's core promise is dead on arrival; it also unblocks
+  B8/B6/B7.
+- **Wave 1 — One consolidated `doctor` PR.** B4 (warn-not-fail) + B1's wrong-file check + B7's minor-
+  version check + B5's config-path-aware OpenSpec check. Cheap, high signal, makes the tool's own
+  diagnostics honest (which is how these would've been caught).
+- **Wave 2 — Detection correctness.** B5 (spec-dir detection), B6 (nested manifest + Claude-Code bias),
+  B7 (the adapter npx guards; the doctor minor-version check already shipped in Wave 1).
+- **Wave 3 — Freshness ownership.** B9 (remove redundant hook) → B10 (watcher auto-rebuild on reset).
+- **Wave 4 — Cosmetic/cleanup, batch anytime.** B8 (skill camelCase now; `.mcp.json` note after B1),
+  B3 (move `ARCHITECTURE.md`), B2a (gitignore parent-guard), B2b (model bump).
+
+## 5. Acceptance
+
+- A **clean-repo dogfood** of `openlore install --agent claude-code` produces a **working** server:
+  `claude mcp get openlore` → Connected; `mcp__openlore__*` tools available; nothing breaks
+  `settings.json` parsing.
+- `openlore doctor` on a no-LLM project exits **0** (LLM/embedding as warnings), and **catches** the
+  wrong-file MCP wiring, a too-old node, and a misconfigured spec dir.
+- `openlore init` on a repo with `docs/specs/` does **not** silently create an empty `openspec/`;
+  detection + doctor agree on reality.
+- After a version bump, the first MCP session **self-heals** the graph index (background rebuild)
+  rather than degrading until a manual `analyze`.
+- `analyze` writes **no** files to the repo root; `ARCHITECTURE.md` lives under `.openlore/analysis/`.
+- All fixes are **deterministic and offline**; the skill docs match the real `orient --json` schema.
+
+## 6. Non-goals
+
+- No new runtime behavior beyond making install/first-run **work and tell the truth**.
+- Do **not** lower the Node floor to support 20 (keep `node:sqlite`; fix the *signal* instead).
+- No LLM/network in any fix (model-id bump is a default-string change, not a runtime dependency).

--- a/src/cli/preflight/preflight.test.ts
+++ b/src/cli/preflight/preflight.test.ts
@@ -24,6 +24,22 @@ import { renderJson, renderHuman, renderGithubAnnotations, buildSummary } from '
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
+// When this suite runs inside CI, GITHUB_ACTIONS=true makes runPreflight() write
+// GitHub workflow-command annotations (::error::/::warning::) to stdout for the
+// STALE fixtures below — GitHub then renders those as spurious annotations on a
+// green job (spec 24, F2). Neutralize it for the whole file; the one test that
+// verifies GHA rendering re-enables it locally and calls the *pure*
+// renderGithubAnnotations(), which returns a string and writes nothing.
+let savedGithubActions: string | undefined;
+beforeEach(() => {
+  savedGithubActions = process.env.GITHUB_ACTIONS;
+  delete process.env.GITHUB_ACTIONS;
+});
+afterEach(() => {
+  if (savedGithubActions === undefined) delete process.env.GITHUB_ACTIONS;
+  else process.env.GITHUB_ACTIONS = savedGithubActions;
+});
+
 interface FixtureNode {
   id: string;
   name: string;


### PR DESCRIPTION
Two things in this PR.

## 1. CI/release hygiene (shippable, green)
Maintenance after closing the 13–23 arc (v2.0.8). **CI/test-only — no product code change, no version bump.**
- **F1** — bump `actions/checkout@v4→v6`, `setup-node@v4→v6`, `upload-artifact@v4→v7` (off the deprecated Node 20 runtime).
- **F2** — stop `preflight.test.ts` leaking GitHub workflow-command annotations (`::error::`/`::warning::`) into the CI log under `GITHUB_ACTIONS=true` (17 leaked lines → 0; 18 preflight tests still pass).

CI verified green with **0 annotations**. Plan + context: [docs/specs/openlore-spec-24-post-arc-ci-hardening.md](docs/specs/openlore-spec-24-post-arc-ci-hardening.md).

## 2. Spec 25 — token-value optimization & honest proof (brainstorm, no code)
A no-code architecture spec prompted by the `headroom` context-compression project and our own Spec 14 finding that OpenLore's savings are **two-tiered** (wins on large/deep tasks, loses on small/familiar ones). It:
- States the proposition bluntly: an agent **with** OpenLore must cost less than **without**, or the tool is negative value.
- Takes headroom's deterministic-compatible ideas (progressive/reversible disclosure, **KV-cache prefix stability**, budget fitting, reproducible proof) and **rejects** what violates OpenLore's offline/deterministic north star (trained compressors, network proxy, lossy semantic compression).
- **Reframes the real lever as round-trips + cache economics, not response bytes.**
- Lays out two halves that ship together: **optimize** the inequality, and **prove** it — honestly and prominently in the README, including a self-serve **`openlore prove`** that measures value on the user's *own* repo, and a scorecard that shows **losses as well as wins**.

Spec: [docs/specs/openlore-spec-25-token-value-optimization-and-proof.md](docs/specs/openlore-spec-25-token-value-optimization-and-proof.md). Brainstorm only — no implementation in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)