### PR TITLE
Spec 26 (all waves) + audit fix: install/MCP wiring, doctor honesty, detection, freshness, cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,7 @@ test-results/
 result
 docker/
 docker-compose.yml
-ARCHITECTURE.md
+# (ARCHITECTURE.md now lands in .openlore/analysis/ — covered by .openlore/ above — Spec 26 B3)
 # openspec: the blanket `openspec/` silently ignored the ADR files written by
 # `openlore decisions --sync` (dogfooding, spec 15). Keep ignoring untracked
 # openspec content (already-tracked specs still commit), but un-ignore the

--- a/docs/output.md
+++ b/docs/output.md
@@ -36,5 +36,5 @@ Static analysis output is stored in `.openlore/analysis/`:
 | `audit-report.json` | Latest parity audit report (produced by `openlore audit`) |
 | `vector-index/` | LanceDB semantic index (produced by `--embed`) |
 
-`openlore analyze` also writes **`ARCHITECTURE.md`** to your project root -- a Markdown overview of module clusters, entry points, and critical hubs, refreshed on every run.
+`openlore analyze` also writes **`ARCHITECTURE.md`** into `.openlore/analysis/` -- a Markdown overview of module clusters, entry points, and critical hubs, refreshed on every run.
 

--- a/docs/specs/openlore-spec-26-install-mcp-wiring-and-first-run-correctness.md
+++ b/docs/specs/openlore-spec-26-install-mcp-wiring-and-first-run-correctness.md
@@ -11,11 +11,15 @@
 
 ## Progress
 
-Branch: `chore/post-arc-ci-hardening` → [PR #120](https://github.com/clay-good/OpenLore/pull/120).
+Branch: `chore/post-arc-ci-hardening` → [PR #120](https://github.com/clay-good/OpenLore/pull/120) (the plan).
 This document is the **plan**; implementation lands in follow-up commits/PRs per the wave sequence in
-§4. Status: **analysis complete, implementation pending.**
+§4. Status: **Wave 0 shipped; Waves 1–4 pending.**
 
-- [ ] Wave 0 — Fix MCP registration (the headline bug)
+- [x] **Wave 0** — Fix MCP registration (the headline bug). B1: `openlore install --agent claude-code`
+  now writes `mcpServers.openlore` to **`.mcp.json`** (the file Claude Code actually reads) and keeps
+  only the SessionStart hook in `.claude/settings.json`; re-running migrates a legacy
+  `settings.json` entry away. Added a `doctor` **MCP wiring** check that warns when the server is in
+  the wrong file (with the exact `--force` fix). [PR #121](https://github.com/clay-good/OpenLore/pull/121).
 - [ ] Wave 1 — Consolidated `doctor` pass
 - [ ] Wave 2 — Detection correctness (spec dir, agent/project, node version)
 - [ ] Wave 3 — Freshness ownership (drop redundant hook, auto-rebuild on reset)

--- a/docs/specs/openlore-spec-26-install-mcp-wiring-and-first-run-correctness.md
+++ b/docs/specs/openlore-spec-26-install-mcp-wiring-and-first-run-correctness.md
@@ -316,3 +316,42 @@ estimation still resolves. *Files:* `constants.ts` + those tests.
 - No new runtime behavior beyond making install/first-run **work and tell the truth**.
 - Do **not** lower the Node floor to support 20 (keep `node:sqlite`; fix the *signal* instead).
 - No LLM/network in any fix (model-id bump is a default-string change, not a runtime dependency).
+
+---
+
+## 7. Full-surface verification (specs 1–26)
+
+A final methodical pass on `2026-06-03` confirming every shipped spec is complete **and functionally
+working**, not just unit-green. No code changed in this pass.
+
+**Deterministic gates:** `lint` clean · `typecheck` clean · `build` clean · **3104 tests pass**, 2
+skipped (145 files).
+
+**Live MCP surface (driven over stdio against this repo):** `initialize` negotiates protocol
+`2025-11-25`; `tools/list` returns **50 tools**, each with a schema (specs 11/12). A 25-call battery
+of the headline read tools returned **25/25 OK, zero `isError`**:
+
+| Spec | Tool | Evidence |
+|------|------|----------|
+| 06/13 | `orient` | returns ranked functions via `bm25_fallback` |
+| 13 | `search_code` / `search_unified` | hits returned |
+| 17 | `analyze_impact` | impact set for `readOpenLoreConfig` |
+| 18 | provenance | `orient` surfaces last author/PR per file |
+| 19 | `select_tests` | reachable tests for changed symbols |
+| 20 | `find_dead_code` | swept 1,575 functions |
+| 21 | `structural_diff` | base/head delta computed |
+| 22 | `get_change_coupling` | volatility + co-change from git |
+| 23 | `check_architecture` | scan mode (no rules → clean); 55 unit tests incl. the layer-boundary regression |
+| 15/16 | `get_decisions` | the synced `e3d3214e` decision is a graph node |
+| drift | `check_spec_drift` · `audit_spec_coverage` | run clean |
+
+**CLI-only surfaces:** `preflight` (spec 03) exits 0; `export scip` (spec 04) emits a 641 KB SCIP
+index; `manifest emit` + `validate` (spec 05) round-trip as a valid v1 manifest.
+
+**Confirmed-intentional deferrals (behave correctly, never crash):** spec 04 SCIP import + column
+ranges, spec 05 federation index + events/RPC extraction, spec 08 deferred languages, spec 09
+(*NOT DOING — superseded*). Each emits empty arrays / a documented warning rather than wrong data.
+
+**Conclusion: specs 1–26 are complete and fully working.** The only confirmed defect found across the
+whole audit was the `layerOf` substring bug (fixed in Wave 1); two other reported findings were
+investigated and judged not-bugs.

--- a/docs/specs/openlore-spec-26-install-mcp-wiring-and-first-run-correctness.md
+++ b/docs/specs/openlore-spec-26-install-mcp-wiring-and-first-run-correctness.md
@@ -11,19 +11,33 @@
 
 ## Progress
 
-Branch: `chore/post-arc-ci-hardening` → [PR #120](https://github.com/clay-good/OpenLore/pull/120) (the plan).
-This document is the **plan**; implementation lands in follow-up commits/PRs per the wave sequence in
-§4. Status: **Wave 0 shipped; Waves 1–4 pending.**
+Original plan branch: `chore/post-arc-ci-hardening` → [PR #120](https://github.com/clay-good/OpenLore/pull/120).
+All implementation landed on `fix/spec-26-wave-0-mcp-registration` →
+[PR #121](https://github.com/clay-good/OpenLore/pull/121). Status: **Waves 0–4 shipped.**
 
 - [x] **Wave 0** — Fix MCP registration (the headline bug). B1: `openlore install --agent claude-code`
   now writes `mcpServers.openlore` to **`.mcp.json`** (the file Claude Code actually reads) and keeps
   only the SessionStart hook in `.claude/settings.json`; re-running migrates a legacy
   `settings.json` entry away. Added a `doctor` **MCP wiring** check that warns when the server is in
-  the wrong file (with the exact `--force` fix). [PR #121](https://github.com/clay-good/OpenLore/pull/121).
-- [ ] Wave 1 — Consolidated `doctor` pass
-- [ ] Wave 2 — Detection correctness (spec dir, agent/project, node version)
-- [ ] Wave 3 — Freshness ownership (drop redundant hook, auto-rebuild on reset)
-- [ ] Wave 4 — Cosmetic/cleanup wins (skill schema, ARCHITECTURE.md path, gitignore dedupe, model bump)
+  the wrong file (with the exact `--force` fix).
+- [x] **Wave 1** — Consolidated `doctor` pass. B4 (LLM/embedding = warn, not fail → no-LLM exits 0),
+  B7-doctor (Node *minor*-version check ≥22.5 for node:sqlite), B5-doctor (read the configured
+  openspecPath). Also fixed an audit-found layer-matching bug (`layerOf` substring → path-boundary).
+- [x] **Wave 2** — Detection correctness. B5 (`detectExistingSpecDir` → point at docs/specs/ or
+  specs/ instead of an empty openspec/; sharpened spec-index error), B6A (depth-1 nested-manifest
+  scan), B6B (bias to claude-code when `~/.claude` exists instead of blind AGENTS.md).
+- [x] **Wave 3** — Freshness ownership. B9 (removed the redundant full-`analyze` PostToolUse hook;
+  `--watch-auto` is the sole owner; setup migrates the legacy hook away), B10 (watcher schedules one
+  detached `analyze --force` to self-heal a schema-reset graph).
+- [x] **Wave 4** — Cleanup. B8 (skill SKILL.md → real camelCase fields + `.mcp.json` detection note),
+  B3 (`ARCHITECTURE.md` now lands in `.openlore/analysis/`; dropped the redundant gitignore line),
+  B2a (gitignore parent-prefix guard, slash-insensitive), B2b (default model → `claude-sonnet-4-6`).
+
+> **Deferred (low value, already mitigated):** B7's optional npx/`node:sqlite` import guards — the
+> doctor minor-version check (Wave 1) + `engines.node` already catch a too-old Node. Audit findings
+> in orient (`involvesRelevant`) and structural-diff (rename path) were investigated and judged
+> **not bugs** (both endpoints are full file paths so `===` is the real match; labeling the old
+> snapshot with the new path is intentional rename-matching).
 
 ---
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -298,6 +298,12 @@ The system SHALL expose a find_dead_code MCP tool that performs mark-and-sweep r
 
 > Decision recorded: bee7ef06
 > Date: 2026-06-02
+### Requirement: McpServerRegistrationMovesFromClaudesettingsjsonToMcpjson
+
+The system SHALL register the OpenLore MCP server in `.mcp.json` and migrate any stale `mcpServers.openlore` entry from `.claude/settings.json` during install.
+
+> Decision recorded: e3d3214e
+> Date: 2026-06-03
 
 ## Technical Notes
 
@@ -354,3 +360,13 @@ Enables agents to determine which tests to run after a code change by walking th
 Agents need a deterministic, call-graph-based way to identify unreachable code and assess deletion impact without LLM inference, consistent with the structural-context-substrate north star.
 
 **Consequences:** New read-only MCP tool find_dead_code; results are explicitly confidence-tagged candidates (not deletion authority) due to dynamic dispatch / DI blind spots; requires analyze_codebase to have been run first.
+
+### MCP server registration moves from .claude/settings.json to .mcp.json
+
+**Status:** Approved
+**Date:** 2026-06-03
+**ID:** e3d3214e
+
+Claude Code loads MCP servers only from .mcp.json (project scope), ~/.claude.json, or `claude mcp add` — never from .claude/settings.json. Earlier versions (≤2.0.8) wrote mcpServers.openlore to settings.json, so the server silently never loaded.
+
+**Consequences:** Install now writes MCP config to .mcp.json and migrates stale entries out of settings.json; settings.json retains only the SessionStart hook. Uninstall must clean both files. Doctor gains an MCP-wiring check to catch the stale-file misconfiguration.

--- a/skills/openlore-orient/SKILL.md
+++ b/skills/openlore-orient/SKILL.md
@@ -25,7 +25,7 @@ If you are reading source files without having called `orient` first, you are pr
 
 ### Preferred: via the OpenLore MCP server
 
-If `openlore` is registered as an MCP server in this project (look for `.claude/settings.json` → `mcpServers.openlore`), call the `orient` tool directly through the MCP interface. This is the lowest-latency path and gives the model access to the full openlore tool surface (45 tools), not just `orient`.
+If `openlore` is registered as an MCP server in this project (look for `.mcp.json` → `mcpServers.openlore` — the project-scope file Claude Code reads; **not** `.claude/settings.json`, which it ignores for MCP), call the `orient` tool directly through the MCP interface. This is the lowest-latency path and gives the model access to the full openlore tool surface (~50 tools), not just `orient`.
 
 ### Fallback: via the shell wrapper
 
@@ -37,12 +37,15 @@ bash scripts/orient.sh "<task description>"
 
 The wrapper tries the direct CLI subcommand first (`npx --yes openlore orient --json --task "<task>"`) and falls back to driving the `openlore mcp` server over stdio JSON-RPC via the sibling `orient-via-mcp.mjs` helper on older openlore versions that predate the CLI subcommand. Either path produces real orient JSON on stdout. Parse these arrays from the result:
 
-- **`relevant_functions`** — top scored functions for the task, with file/line, role classification, and a short reason.
-- **`callers`** — depth-1 caller neighbourhood for each top function. This is where "who breaks if I change this" lives.
-- **`spec_sections`** — OpenSpec sections that own the relevant files, including the requirements they encode. Read these before reading code.
-- **`insertion_points`** — ranked candidate locations to make the change, with structural justification.
+The result fields are **camelCase** (matching `orient --json`):
 
-Always start by reading **`spec_sections`**, then **`callers`**, then jump into source only at the **`insertion_points`** you actually plan to edit.
+- **`relevantFunctions`** — top scored functions for the task, each with `name`/`file`/`line`, role classification, and a short reason.
+- **`callPaths`** — caller/callee neighbourhood for the top functions. This is where "who breaks if I change this" lives.
+- **`specDomains`** — OpenSpec domains that own the relevant files, including the requirements they encode. Read these before reading code.
+- **`insertionPoints`** — ranked candidate locations to make the change, with structural justification.
+- **`relevantFiles`**, **`provenance`**, **`changeCoupling`**, **`suggestedTools`**, **`nextSteps`** — supporting context. **`searchMode`** is `semantic` when embeddings are built or `bm25_fallback` otherwise.
+
+Always start by reading **`specDomains`**, then **`callPaths`**, then jump into source only at the **`insertionPoints`** you actually plan to edit.
 
 > **Note:** the `openlore orient --json --task` CLI subcommand is available, so the wrappers use it directly. The MCP fallback in the wrappers only kicks in on older openlore versions that predate the subcommand.
 
@@ -51,7 +54,7 @@ Always start by reading **`spec_sections`**, then **`callers`**, then jump into 
 - **Do not open source files before `orient` has returned.** This is the single most expensive mistake — you'll re-derive what the graph already knows.
 - **Do not call `orient` on every edit.** It's a session-start and re-orient-on-staleness tool, not a per-call helper. Respect the Epistemic Lease signal — if no prefix appears, your context is still fresh.
 - **Do not paraphrase the task** when passing it to `orient`. Use the user's words. The semantic search matches better when the query language matches the eventual prompt.
-- **Do not ignore `spec_sections`.** Reading specs first is faster and more accurate than reading code first, in this repo.
+- **Do not ignore `specDomains`.** Reading specs first is faster and more accurate than reading code first, in this repo.
 
 ## Cost & latency
 
@@ -70,7 +73,7 @@ Cold-graph first call may take 2–4s if the on-disk index needs to be loaded; s
 
 If `orient` returns an empty result or errors:
 
-1. **Empty `relevant_functions` array** — the task description didn't match the graph. Try rephrasing using a known module name, function name, or domain word from the spec. Do not fall back silently — tell the user that `orient` didn't match and you're going to grep.
+1. **Empty `relevantFunctions` array** — the task description didn't match the graph. Try rephrasing using a known module name, function name, or domain word from the spec. Do not fall back silently — tell the user that `orient` didn't match and you're going to grep.
 2. **Wrapper output contains `"error": "No analysis found"`** — the codebase hasn't been analyzed yet. Run `npx openlore analyze` once to seed the graph, then retry. The wrapper itself is healthy in this case; the underlying tool is telling you what's missing.
 3. **Graph is stale (mtime older than recent edits)** — the JSON output will still come back, but the insertion points may be wrong. Re-run `npx openlore analyze` to rebuild.
 

--- a/src/api/init.test.ts
+++ b/src/api/init.test.ts
@@ -20,6 +20,7 @@ vi.mock('../core/services/config-manager.js', () => ({
   openloreConfigExists: vi.fn(),
   openspecDirExists: vi.fn(),
   createOpenSpecStructure: vi.fn(),
+  detectExistingSpecDir: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../core/services/gitignore-manager.js', () => ({

--- a/src/api/init.ts
+++ b/src/api/init.ts
@@ -17,6 +17,7 @@ import {
   openloreConfigExists,
   openspecDirExists,
   createOpenSpecStructure,
+  detectExistingSpecDir,
 } from '../core/services/config-manager.js';
 import {
   gitignoreExists,
@@ -40,7 +41,13 @@ function progress(onProgress: ProgressCallback | undefined, step: string, status
  */
 export async function openloreInit(options: InitApiOptions = {}): Promise<InitResult> {
   const rootPath = options.rootPath ?? process.cwd();
-  const openspecRelPath = options.openspecPath ?? DEFAULT_OPENSPEC_PATH;
+  let openspecRelPath = options.openspecPath ?? DEFAULT_OPENSPEC_PATH;
+  // Point at existing specs (docs/specs/, specs/) rather than creating an empty
+  // openspec/ blind to them, unless an explicit path was given (Spec 26 B5).
+  if (!options.openspecPath) {
+    const detected = await detectExistingSpecDir(rootPath);
+    if (detected && detected.root !== 'openspec') openspecRelPath = detected.root;
+  }
   const openspecFullPath = resolve(rootPath, openspecRelPath);
   const force = options.force ?? false;
   const { onProgress } = options;

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -607,7 +607,7 @@ After analysis, run 'openlore generate' to create OpenSpec files.
       try {
         const ctx = artifacts.llmContext ?? null;
         const overview = buildArchitectureOverview(depGraph, ctx, rootPath);
-        await writeArchitectureMd(rootPath, overview);
+        await writeArchitectureMd(outputPath, overview);
         architectureMdWritten = true;
       } catch (archErr) {
         logger.debug(`ARCHITECTURE.md generation skipped: ${(archErr as Error).message}`);
@@ -672,7 +672,7 @@ After analysis, run 'openlore generate' to create OpenSpec files.
       }
       if (architectureMdWritten) {
         console.log(`    ├─ ${opts.output}SUMMARY.md`);
-        console.log('    ├─ ARCHITECTURE.md');
+        console.log(`    ├─ ${opts.output}ARCHITECTURE.md`);
       } else {
         console.log(`    ├─ ${opts.output}SUMMARY.md`);
       }

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -323,40 +323,13 @@ export async function uninstallPreCommitHook(rootPath: string): Promise<void> {
   for (const filePath of agentFiles) await removeAgentInstructions(filePath);
 }
 
+// Marker for the legacy full-`analyze` PostToolUse hook. The MCP server's
+// `--watch-auto` (default since v2.0.6, Spec 13.1) is now the single freshness
+// owner and keeps the index fresh incrementally O(change); the old hook ran a
+// full O(repo) `openlore analyze` on *every* tool call (Read, Bash, …, masked
+// only by a 10s lock) — pure double work. We no longer install it, and
+// `uninstallClaudeHook` strips any copy a prior version left behind (Spec 26 B9).
 const ANALYZE_HOOK_MARKER = 'openlore analyze';
-const ANALYZE_HOOK_ENTRY = {
-  _comment: 'openlore: keep call graph fresh after every file edit (debounced 10s)',
-  type: 'command',
-  command: [
-    'LOCK=.openlore/.analyze.lock;',
-    'if [ ! -f "$LOCK" ] || [ $(( $(date +%s) - $(cat "$LOCK" 2>/dev/null || echo 0) )) -gt 10 ]; then',
-    '  echo $(date +%s) > "$LOCK";',
-    '  openlore analyze --output .openlore/analysis 2>/dev/null & true;',
-    'fi',
-  ].join(' '),
-};
-
-export async function installClaudeHook(rootPath: string): Promise<void> {
-  const settingsPath = join(rootPath, '.claude', 'settings.json');
-  let settings: ClaudeSettings = {};
-
-  try {
-    settings = JSON.parse(await readFile(settingsPath, 'utf-8')) as ClaudeSettings;
-  } catch { /* file missing or corrupt — start fresh */ }
-
-  const hooks = settings.hooks?.PostToolUse ?? [];
-  if (hooks.some((h) => JSON.stringify(h).includes(ANALYZE_HOOK_MARKER))) {
-    logger.success('Claude Code analyze hook already present in .claude/settings.json');
-    return;
-  }
-
-  settings.hooks ??= {};
-  settings.hooks.PostToolUse = [...hooks, ANALYZE_HOOK_ENTRY];
-
-  await mkdir(join(rootPath, '.claude'), { recursive: true });
-  await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
-  logger.success('Claude Code PostToolUse hook added to .claude/settings.json');
-}
 
 interface ClaudeSettings {
   hooks?: {

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -181,7 +181,17 @@ async function ensureGitignored(rootPath: string, entry: string): Promise<void> 
   let content = '';
   if (await fileExists(gitignorePath)) {
     content = await readFile(gitignorePath, 'utf-8');
-    if (content.split('\n').some((l) => l.trim() === entry)) return;
+    // Trailing-slash-insensitive segments, so `.openlore` and `.openlore/` match
+    // but `.openlore` never falsely matches a sibling like `.openapi/` (B2a).
+    const segs = (p: string) => p.trim().replace(/\/+$/, '').split('/').filter(Boolean);
+    const want = segs(entry);
+    for (const line of content.split('\n')) {
+      const have = segs(line);
+      if (have.length === 0) continue;
+      // Skip if an existing line is identical, or a covering parent prefix
+      // (e.g. existing `.openlore/` covers a new `.openlore/decisions/`).
+      if (have.length <= want.length && have.every((s, i) => s === want[i])) return;
+    }
   }
   await writeFile(gitignorePath, content.trimEnd() + '\n' + entry + '\n', 'utf-8');
   logger.discovery(`  → added ${entry} to .gitignore`);

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -23,6 +23,9 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     ...actual,
     access: vi.fn().mockResolvedValue(undefined),
     stat: vi.fn().mockResolvedValue({ mtime: new Date() }),
+    // checkMcpWiring reads .claude/settings.json + .mcp.json; default to "absent"
+    // so the suite is independent of the repo's own dogfood files.
+    readFile: vi.fn().mockRejectedValue(new Error('ENOENT')),
   };
 });
 
@@ -487,6 +490,52 @@ describe('doctor command', () => {
       const diskCheck = checks.find(c => c.name === 'Disk space')!;
       expect(diskCheck.status).toBe('ok');
       expect(diskCheck.detail).toContain('MB available');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  describe('MCP wiring check', () => {
+    /** Make readFile return given JSON for matching relative paths, ENOENT otherwise. */
+    async function mockMcpFiles(files: Record<string, unknown>): Promise<void> {
+      const { readFile } = await import('node:fs/promises');
+      vi.mocked(readFile).mockImplementation(((p: any) => {
+        const path = String(p);
+        for (const [rel, content] of Object.entries(files)) {
+          if (path.endsWith(rel)) return Promise.resolve(JSON.stringify(content));
+        }
+        return Promise.reject(new Error('ENOENT'));
+      }) as never);
+    }
+
+    const OPENLORE_SERVER = { mcpServers: { openlore: { command: 'npx', args: ['--yes', 'openlore', 'mcp'] } } };
+
+    it('is omitted when no MCP wiring is present', async () => {
+      const checks = await runDoctorJson();
+      expect(checks.find(c => c.name === 'MCP wiring')).toBeUndefined();
+    });
+
+    it('warns when the server lives only in .claude/settings.json', async () => {
+      await mockMcpFiles({ '.claude/settings.json': OPENLORE_SERVER });
+      const checks = await runDoctorJson();
+      const mcp = checks.find(c => c.name === 'MCP wiring')!;
+      expect(mcp.status).toBe('warn');
+      expect(mcp.detail).toContain('settings.json');
+      expect(mcp.fix).toContain('--force');
+    });
+
+    it('passes when the server lives in .mcp.json', async () => {
+      await mockMcpFiles({ '.mcp.json': OPENLORE_SERVER });
+      const checks = await runDoctorJson();
+      const mcp = checks.find(c => c.name === 'MCP wiring')!;
+      expect(mcp.status).toBe('ok');
+    });
+
+    it('warns about a stale settings.json entry when both files have it', async () => {
+      await mockMcpFiles({ '.claude/settings.json': OPENLORE_SERVER, '.mcp.json': OPENLORE_SERVER });
+      const checks = await runDoctorJson();
+      const mcp = checks.find(c => c.name === 'MCP wiring')!;
+      expect(mcp.status).toBe('warn');
+      expect(mcp.detail).toContain('stale');
     });
   });
 });

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -240,7 +240,7 @@ describe('doctor command', () => {
       }
     });
 
-    it('should fail when createLLMService throws (missing API key)', async () => {
+    it('warns (not fails) when createLLMService throws (missing API key) — LLM is optional', async () => {
       const saved = clearLLMKeys();
       const llmService = await import('../../core/services/llm-service.js');
       vi.mocked(llmService.createLLMService).mockImplementationOnce(() => {
@@ -249,15 +249,15 @@ describe('doctor command', () => {
       try {
         const checks = await runDoctorJson();
         const llmCheck = checks.find(c => c.name === 'LLM connection')!;
-        expect(llmCheck.status).toBe('fail');
+        expect(llmCheck.status).toBe('warn');
         expect(llmCheck.fix).toBeDefined();
-        expect(llmCheck.fix).toContain('API key');
+        expect(llmCheck.fix).toContain('Optional');
       } finally {
         restoreLLMKeys(saved);
       }
     });
 
-    it('should fail when complete() rejects (network error)', async () => {
+    it('warns (not fails) when complete() rejects (network error)', async () => {
       const saved = clearLLMKeys();
       process.env.ANTHROPIC_API_KEY = 'sk-test-anthropic';
       const llmService = await import('../../core/services/llm-service.js');
@@ -268,14 +268,14 @@ describe('doctor command', () => {
       try {
         const checks = await runDoctorJson();
         const llmCheck = checks.find(c => c.name === 'LLM connection')!;
-        expect(llmCheck.status).toBe('fail');
-        expect(llmCheck.fix).toContain('API key');
+        expect(llmCheck.status).toBe('warn');
+        expect(llmCheck.fix).toContain('Optional');
       } finally {
         restoreLLMKeys(saved);
       }
     });
 
-    it('should include a fix suggestion when failing', async () => {
+    it('should include a fix suggestion when degraded', async () => {
       const saved = clearLLMKeys();
       const llmService = await import('../../core/services/llm-service.js');
       vi.mocked(llmService.createLLMService).mockImplementationOnce(() => {
@@ -358,8 +358,29 @@ describe('doctor command', () => {
 
   // --------------------------------------------------------------------------
   describe('exit code', () => {
-    it('should set exitCode=1 when any check fails (JSON mode confirms fail status)', async () => {
+    it('should report a fail when a deterministic check fails (unparseable config)', async () => {
       consoleSpy.mockImplementation(() => {});
+      // A missing LLM is only a warning now (B4); a genuine fail comes from a
+      // deterministic check — here an existing-but-unparseable config.
+      const { access } = await import('node:fs/promises');
+      vi.mocked(access).mockResolvedValue(undefined);
+      const configManager = await import('../../core/services/config-manager.js');
+      vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue(null);
+
+      const checks = await runDoctorJson();
+      const configCheck = checks.find(c => c.name === 'openlore config')!;
+      expect(configCheck.status).toBe('fail');
+      const failures = checks.filter(c => c.status === 'fail');
+      expect(failures.length).toBeGreaterThan(0);
+    });
+
+    it('missing LLM/embedding alone does NOT fail (exit stays 0)', async () => {
+      consoleSpy.mockImplementation(() => {});
+      // Valid, parseable config so the deterministic checks all pass/warn.
+      const configManager = await import('../../core/services/config-manager.js');
+      vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue({
+        projectType: 'nodejs', createdAt: '2024-01-01T00:00:00Z', openspecPath: './openspec', maxFiles: 500,
+      } as never);
       const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_COMPAT_API_KEY'];
       const saved: Record<string, string | undefined> = {};
       for (const k of keyVars) { saved[k] = process.env[k]; delete process.env[k]; }
@@ -368,16 +389,11 @@ describe('doctor command', () => {
       vi.mocked(llmService.createLLMService).mockImplementationOnce(() => {
         throw new Error('No API key');
       });
-
       try {
-        // Confirm via JSON mode that the LLM check is a 'fail'
         const checks = await runDoctorJson();
         const llmCheck = checks.find(c => c.name === 'LLM connection')!;
-        expect(llmCheck.status).toBe('fail');
-        // The JSON path returns early, so exitCode is only set in the non-JSON path.
-        // Verify the failure count reported includes at least one failure.
-        const failures = checks.filter(c => c.status === 'fail');
-        expect(failures.length).toBeGreaterThan(0);
+        expect(llmCheck.status).toBe('warn');
+        expect(checks.filter(c => c.status === 'fail')).toHaveLength(0);
       } finally {
         for (const k of keyVars) { if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k]; }
       }
@@ -435,28 +451,22 @@ describe('doctor command', () => {
       }
     });
 
-    it('non-JSON: logger.error called and exitCode=1 when a check fails', async () => {
+    it('non-JSON: logger.error called and exitCode=1 when a deterministic check fails', async () => {
       doctorCommand.setOptionValue('json', false);
 
-      const keyVars = ['ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_COMPAT_API_KEY'];
-      const saved: Record<string, string | undefined> = {};
-      for (const k of keyVars) { saved[k] = process.env[k]; delete process.env[k]; }
-
-      const llmService = await import('../../core/services/llm-service.js');
-      vi.mocked(llmService.createLLMService).mockImplementationOnce(() => {
-        throw new Error('No API key');
-      });
+      // Trigger a genuine fail via an existing-but-unparseable config (missing
+      // LLM would only warn now, B4).
+      const { access } = await import('node:fs/promises');
+      vi.mocked(access).mockResolvedValue(undefined);
+      const configManager = await import('../../core/services/config-manager.js');
+      vi.mocked(configManager.readOpenLoreConfig).mockResolvedValue(null);
 
       const loggerModule = await import('../../utils/logger.js');
       vi.mocked(loggerModule.logger.error).mockClear();
 
-      try {
-        await doctorCommand.parseAsync(['node', 'doctor'], { from: 'user' });
-        expect(vi.mocked(loggerModule.logger.error)).toHaveBeenCalled();
-        expect(process.exitCode).toBe(1);
-      } finally {
-        for (const k of keyVars) { if (saved[k] !== undefined) process.env[k] = saved[k]; else delete process.env[k]; }
-      }
+      await doctorCommand.parseAsync(['node', 'doctor'], { from: 'user' });
+      expect(vi.mocked(loggerModule.logger.error)).toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
     });
   });
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -6,7 +6,7 @@
  */
 
 import { Command } from 'commander';
-import { access, stat } from 'node:fs/promises';
+import { access, stat, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -154,6 +154,52 @@ async function checkOpenSpecDir(rootPath: string): Promise<CheckResult> {
       fix: "Run 'openlore init' then 'openlore generate'",
     };
   }
+}
+
+/**
+ * Claude Code loads MCP servers only from `.mcp.json` (project scope), never
+ * from `.claude/settings.json`. A stale `mcpServers.openlore` in settings.json
+ * (written by OpenLore <= 2.0.8) means the server silently never loads. Catch
+ * that wrong-file wiring and point at the one-line fix. Returns null when there
+ * is no Claude Code MCP wiring to check.
+ */
+async function checkMcpWiring(rootPath: string): Promise<CheckResult | null> {
+  const readJson = async (rel: string): Promise<Record<string, unknown> | null> => {
+    try {
+      const parsed = JSON.parse(await readFile(join(rootPath, rel), 'utf8'));
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : null;
+    } catch {
+      return null;
+    }
+  };
+  const hasOpenlore = (doc: Record<string, unknown> | null): boolean =>
+    !!(doc?.mcpServers as Record<string, unknown> | undefined)?.openlore;
+
+  const inSettings = hasOpenlore(await readJson('.claude/settings.json'));
+  const inMcp = hasOpenlore(await readJson('.mcp.json'));
+
+  if (inSettings && !inMcp) {
+    return {
+      name: 'MCP wiring',
+      status: 'warn',
+      detail: 'openlore MCP server is in .claude/settings.json, which Claude Code never reads for MCP',
+      fix: "Run 'openlore install --agent claude-code --force' to move it to .mcp.json",
+    };
+  }
+  if (inSettings && inMcp) {
+    return {
+      name: 'MCP wiring',
+      status: 'warn',
+      detail: 'stale openlore entry still in .claude/settings.json (Claude Code reads .mcp.json)',
+      fix: "Run 'openlore install --agent claude-code --force' to remove the stale entry",
+    };
+  }
+  if (inMcp) {
+    return { name: 'MCP wiring', status: 'ok', detail: '.mcp.json registers the openlore MCP server' };
+  }
+  return null;
 }
 
 const CLI_PROVIDERS: Record<string, string> = {
@@ -392,6 +438,7 @@ Checks performed:
   • openlore configuration (${OPENLORE_CONFIG_REL_PATH})
   • Analysis artifacts freshness
   • OpenSpec directory presence
+  • MCP wiring (Claude Code reads .mcp.json, not .claude/settings.json)
   • LLM connection (live request with 10s timeout)
   • Embedding connection (if configured)
   • Available disk space
@@ -407,7 +454,7 @@ Checks performed:
       console.log('');
     }
 
-    const [staticChecks, llmCheck, embeddingCheck] = await Promise.all([
+    const [staticChecks, mcpCheck, llmCheck, embeddingCheck] = await Promise.all([
       Promise.all([
         checkNodeVersion(),
         checkGit(rootPath),
@@ -416,12 +463,14 @@ Checks performed:
         checkOpenSpecDir(rootPath),
         checkDiskSpace(rootPath),
       ]),
+      checkMcpWiring(rootPath),
       checkLLMConnection(rootPath),
       checkEmbeddingConnection(rootPath),
     ]);
 
     const checks = [
       ...staticChecks,
+      ...(mcpCheck ? [mcpCheck] : []),
       llmCheck,
       ...(embeddingCheck ? [embeddingCheck] : []),
     ];

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -15,6 +15,7 @@ import { readOpenLoreConfig } from '../../core/services/config-manager.js';
 import { createLLMService, ProviderName } from '../../core/services/llm-service.js';
 import {
   MIN_NODE_MAJOR_VERSION,
+  MIN_NODE_MINOR_VERSION,
   ANALYSIS_AGE_WARNING_HOURS,
   MIN_DISK_SPACE_FAIL_MB,
   MIN_DISK_SPACE_WARN_MB,
@@ -52,15 +53,19 @@ interface CheckResult {
 // ============================================================================
 
 async function checkNodeVersion(): Promise<CheckResult> {
-  const [major] = process.versions.node.split('.').map(Number);
-  if (major >= MIN_NODE_MAJOR_VERSION) {
+  const [major, minor] = process.versions.node.split('.').map(Number);
+  const min = `${MIN_NODE_MAJOR_VERSION}.${MIN_NODE_MINOR_VERSION}`;
+  const ok =
+    major > MIN_NODE_MAJOR_VERSION ||
+    (major === MIN_NODE_MAJOR_VERSION && minor >= MIN_NODE_MINOR_VERSION);
+  if (ok) {
     return { name: 'Node.js version', status: 'ok', detail: `v${process.versions.node}` };
   }
   return {
     name: 'Node.js version',
     status: 'fail',
-    detail: `v${process.versions.node} (requires >=${MIN_NODE_MAJOR_VERSION})`,
-    fix: `Install Node.js ${MIN_NODE_MAJOR_VERSION}+ from https://nodejs.org/`,
+    detail: `v${process.versions.node} (requires >=${min} for node:sqlite)`,
+    fix: `Switch to Node ${min}+ (\`nvm use ${MIN_NODE_MAJOR_VERSION}\`) or install from https://nodejs.org/ — a .nvmrc pinned to an older Node will crash the MCP server`,
   };
 }
 
@@ -142,15 +147,25 @@ async function checkAnalysis(rootPath: string): Promise<CheckResult> {
 }
 
 async function checkOpenSpecDir(rootPath: string): Promise<CheckResult> {
-  const specsDir = join(rootPath, OPENSPEC_DIR, OPENSPEC_SPECS_SUBDIR);
+  // Read the *configured* openspecPath rather than assuming the default — a
+  // project may point OpenLore at docs/specs/ or another root (Spec 26 B5).
+  let configuredRoot = OPENSPEC_DIR;
+  try {
+    const config = await readOpenLoreConfig(rootPath);
+    if (config?.openspecPath) configuredRoot = config.openspecPath;
+  } catch {
+    /* no config — fall back to the default */
+  }
+  const specsDir = join(rootPath, configuredRoot, OPENSPEC_SPECS_SUBDIR);
+  const rel = `${configuredRoot.replace(/^\.\//, '').replace(/\/$/, '')}/${OPENSPEC_SPECS_SUBDIR}/`;
   try {
     await access(specsDir);
-    return { name: 'OpenSpec directory', status: 'ok', detail: 'openspec/specs/ exists' };
+    return { name: 'OpenSpec directory', status: 'ok', detail: `${rel} exists` };
   } catch {
     return {
       name: 'OpenSpec directory',
       status: 'warn',
-      detail: 'openspec/specs/ not found',
+      detail: `${rel} not found`,
       fix: "Run 'openlore init' then 'openlore generate'",
     };
   }
@@ -250,9 +265,9 @@ async function checkLLMConnection(rootPath: string): Promise<CheckResult> {
     } catch {
       return {
         name: 'LLM connection',
-        status: 'fail',
+        status: 'warn',
         detail: `${provider} · '${bin}' not found on PATH`,
-        fix: `Install the ${bin} CLI and ensure it is on your PATH`,
+        fix: `Optional — only 'openlore generate' needs an LLM. Install the ${bin} CLI to enable it`,
       };
     }
   }
@@ -278,9 +293,9 @@ async function checkLLMConnection(rootPath: string): Promise<CheckResult> {
   } catch (err) {
     return {
       name: 'LLM connection',
-      status: 'fail',
+      status: 'warn',
       detail: `${provider} · ${(err as Error).message}`,
-      fix: 'Check that the required API key environment variable is set',
+      fix: 'Optional — set the provider API key only if you use \'openlore generate\'',
     };
   }
 
@@ -298,9 +313,9 @@ async function checkLLMConnection(rootPath: string): Promise<CheckResult> {
     const msg = (err as Error).message ?? String(err);
     return {
       name: 'LLM connection',
-      status: 'fail',
+      status: 'warn',
       detail: `${provider} · ${msg} (${ms}ms)`,
-      fix: 'Check your API key, base URL, and network connectivity',
+      fix: 'Optional — needed only for \'openlore generate\'. Check API key, base URL, and connectivity',
     };
   }
 }
@@ -339,9 +354,9 @@ async function checkEmbeddingConnection(rootPath: string): Promise<CheckResult |
       const body = (await response.text().catch(() => '')).trim() || '(empty)';
       return {
         name: 'Embedding connection',
-        status: 'fail',
+        status: 'warn',
         detail: `HTTP ${response.status}: ${body} (${ms}ms)`,
-        fix: 'Check your embedding server URL, API key, and that the server is running',
+        fix: 'Optional — search/orient fall back to BM25 without embeddings. Check the server URL, API key, and that it is running',
       };
     }
     const data = await response.json() as { data?: Array<{ embedding: number[] }> };
@@ -356,9 +371,9 @@ async function checkEmbeddingConnection(rootPath: string): Promise<CheckResult |
     const msg = (err as Error).message ?? String(err);
     return {
       name: 'Embedding connection',
-      status: 'fail',
+      status: 'warn',
       detail: `${url} · ${msg} (${ms}ms)`,
-      fix: 'Check your embedding server is running (npm run embed:up) and the URL is correct',
+      fix: 'Optional — search/orient fall back to BM25. Start the embedding server (npm run embed:up) and check the URL',
     };
   }
 }
@@ -433,7 +448,7 @@ Examples:
   $ openlore doctor --json    Output results as JSON
 
 Checks performed:
-  • Node.js version (>=${MIN_NODE_MAJOR_VERSION} required)
+  • Node.js version (>=${MIN_NODE_MAJOR_VERSION}.${MIN_NODE_MINOR_VERSION} required for node:sqlite)
   • Git repository detection
   • openlore configuration (${OPENLORE_CONFIG_REL_PATH})
   • Analysis artifacts freshness
@@ -490,10 +505,11 @@ Checks performed:
     const warnings = checks.filter(c => c.status === 'warn');
 
     if (failures.length > 0) {
-      logger.error(`${failures.length} check(s) failed — fix the issues above before proceeding`);
+      const warnSuffix = warnings.length > 0 ? `, ${warnings.length} warning(s)` : '';
+      logger.error(`${failures.length} check(s) failed${warnSuffix} — fix the failures above before proceeding`);
       process.exitCode = 1;
     } else if (warnings.length > 0) {
-      logger.warning(`${warnings.length} warning(s) — some features may not work correctly`);
+      logger.warning(`${warnings.length} warning(s) — optional features (LLM generate, embeddings) may be limited`);
     } else {
       logger.success('All checks passed!');
     }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -22,6 +22,7 @@ import {
   openspecDirExists,
   openspecConfigExists,
   createOpenSpecStructure,
+  detectExistingSpecDir,
 } from '../../core/services/config-manager.js';
 import {
   gitignoreExists,
@@ -64,7 +65,17 @@ After initialization, run 'openlore analyze' to scan your codebase.
   )
   .action(async (options: Partial<InitOptions>) => {
     const rootPath = process.cwd();
-    const openspecRelPath = options.openspecPath ?? DEFAULT_OPENSPEC_PATH;
+    // Honor an explicit --openspec-path; otherwise detect specs that already
+    // live in docs/specs/ or specs/ so we don't create an empty openspec/ that
+    // is blind to them (Spec 26 B5).
+    let openspecRelPath = options.openspecPath ?? DEFAULT_OPENSPEC_PATH;
+    let detectedSpecDir = null as Awaited<ReturnType<typeof detectExistingSpecDir>>;
+    if (!options.openspecPath) {
+      detectedSpecDir = await detectExistingSpecDir(rootPath);
+      if (detectedSpecDir && detectedSpecDir.root !== 'openspec') {
+        openspecRelPath = detectedSpecDir.root === '.' ? '.' : detectedSpecDir.root;
+      }
+    }
     const openspecPath = resolve(rootPath, openspecRelPath);
     const force = options.force ?? false;
 
@@ -144,7 +155,11 @@ After initialization, run 'openlore analyze' to scan your codebase.
       }
     }
 
-    if (existingOpenspecDir) {
+    if (detectedSpecDir && detectedSpecDir.root !== 'openspec') {
+      logger.success(
+        `Found existing specs in ${detectedSpecDir.specsRel}/ (${detectedSpecDir.count} file(s)) — pointing openspecPath at ${openspecRelPath}`
+      );
+    } else if (existingOpenspecDir) {
       logger.success('Found existing openspec/ directory');
       if (existingOpenspecConfig) {
         const openspecConfig = await readOpenSpecConfig(openspecPath);

--- a/src/cli/commands/run.test.ts
+++ b/src/cli/commands/run.test.ts
@@ -43,7 +43,7 @@ describe('run command', () => {
     it('should have --model option with default', () => {
       const modelOption = runCommand.options.find(o => o.long === '--model');
       expect(modelOption).toBeDefined();
-      expect(modelOption?.defaultValue).toBe('claude-sonnet-4-20250514');
+      expect(modelOption?.defaultValue).toBe('claude-sonnet-4-6');
     });
 
     it('should have --dry-run option', () => {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -22,7 +22,7 @@ import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { checkbox } from '@inquirer/prompts';
 import { logger } from '../../utils/logger.js';
-import { installPreCommitHook, installClaudeHook } from './decisions.js';
+import { installPreCommitHook, uninstallClaudeHook } from './decisions.js';
 
 // ============================================================================
 // TYPES
@@ -305,7 +305,7 @@ export const setupCommand = new Command('setup')
         message: 'Which agent tools do you want to install skills for?',
         choices: [
           {
-            name: 'Claude Code   (.claude/skills/ — 8 skills + pre-commit & PostToolUse hooks)',
+            name: 'Claude Code   (.claude/skills/ — 8 skills + pre-commit hook)',
             value: 'claude' as ToolName,
           },
           {
@@ -362,7 +362,9 @@ export const setupCommand = new Command('setup')
 
     if (tools.includes('claude')) {
       await installPreCommitHook(projectRoot);
-      await installClaudeHook(projectRoot);
+      // Freshness is owned by the MCP server's --watch-auto (Spec 13.1); strip
+      // any legacy full-analyze PostToolUse hook a prior version installed (B9).
+      await uninstallClaudeHook(projectRoot);
     }
 
     // ── Report ───────────────────────────────────────────────────────────────

--- a/src/cli/install/adapters/claude-code.ts
+++ b/src/cli/install/adapters/claude-code.ts
@@ -1,7 +1,13 @@
 /**
  * claude-code adapter — appends the OpenLore instruction block to CLAUDE.md
- * (creating it if absent) and adds a SessionStart hook + MCP server
- * registration to `.claude/settings.json`.
+ * (creating it if absent), registers the OpenLore MCP server in `.mcp.json`
+ * (the project-scope file Claude Code actually reads for MCP), and adds a
+ * SessionStart hook to `.claude/settings.json`.
+ *
+ * NB: Claude Code loads MCP servers only from `.mcp.json` (project),
+ * `~/.claude.json`, or `claude mcp add` — never from `.claude/settings.json`.
+ * Earlier versions wrote `mcpServers.openlore` to `settings.json`, so the
+ * server never loaded; `apply` now migrates that stale entry away.
  */
 
 import { mkdir, readFile, writeFile, unlink } from 'node:fs/promises';
@@ -13,6 +19,7 @@ import type { Adapter, ApplyContext, ApplyResult, PlannedChange } from './types.
 
 const MD_FILE = 'CLAUDE.md';
 const SETTINGS_PATH = '.claude/settings.json';
+const MCP_PATH = '.mcp.json';
 
 const MCP_ENTRY = {
   command: 'npx',
@@ -83,64 +90,88 @@ export const claudeCodeAdapter: Adapter = {
       blockBody: ctx.instructionTemplate,
     });
 
-    const settingsPath = join(ctx.root, SETTINGS_PATH);
-    const existing = await readJsonOrEmpty(settingsPath);
-    const had = await fileExists(settingsPath);
-    const prevMeta = readMeta(existing);
-    if (prevMeta && isHandEdited(existing, prevMeta) && !ctx.force) {
+    // --- 1. MCP server registration → .mcp.json (the file Claude Code reads) ---
+    const mcpPath = join(ctx.root, MCP_PATH);
+    const existingMcp = await readJsonOrEmpty(mcpPath);
+    const hadMcp = await fileExists(mcpPath);
+    const prevMcpMeta = readMeta(existingMcp);
+    if (prevMcpMeta && isHandEdited(existingMcp, prevMcpMeta) && !ctx.force) {
       mdResult.changes.push({
-        path: settingsPath,
+        path: mcpPath,
         kind: 'noop',
-        summary: `${SETTINGS_PATH}: refused to overwrite hand-edited OpenLore entries (use --force)`,
+        summary: `${MCP_PATH}: refused to overwrite hand-edited OpenLore entries (use --force)`,
       });
       mdResult.warnings.push(
-        `${SETTINGS_PATH} has hand-edits in OpenLore-managed paths — pass --force to overwrite`
+        `${MCP_PATH} has hand-edits in OpenLore-managed paths — pass --force to overwrite`
       );
       mdResult.conflict = true;
       return mdResult;
     }
-
-    // SessionStart is computed imperatively (preserving any user-defined
-    // entries) and written through mergeEntries, but only mcpServers.openlore
-    // is tracked in our meta — we identify our SessionStart entry by its
-    // `_openlore: true` marker, not by claiming the whole array.
-    const currentSessionStart =
-      ((existing.hooks as Record<string, unknown>)?.SessionStart as unknown) ?? [];
-    const nextSessionStart = mergeSessionStart(currentSessionStart);
-
-    const { next, action } = mergeEntries(existing, [
+    const { next: nextMcp, action: mcpAction } = mergeEntries(existingMcp, [
       { path: 'mcpServers.openlore', value: MCP_ENTRY },
     ]);
-    // Apply the SessionStart update outside the managed-paths set.
+    const mcpBefore = hadMcp ? JSON.stringify(existingMcp, null, 2) + '\n' : '';
+    const mcpAfter = JSON.stringify(nextMcp, null, 2) + '\n';
+    mdResult.changes.push({
+      path: mcpPath,
+      kind: !hadMcp ? 'create' : mcpAction === 'noop' ? 'noop' : 'update',
+      summary: !hadMcp
+        ? `create ${MCP_PATH} with mcpServers.openlore`
+        : mcpAction === 'noop'
+          ? `${MCP_PATH}: already up to date`
+          : `update mcpServers.openlore in ${MCP_PATH}`,
+      preview: !hadMcp
+        ? previewCreate(mcpPath, mcpAfter)
+        : mcpAction === 'noop'
+          ? undefined
+          : previewDiff(mcpPath, mcpBefore, mcpAfter),
+    });
+    if (!ctx.dryRun && (mcpAction !== 'noop' || !hadMcp)) {
+      await mkdir(dirname(mcpPath), { recursive: true });
+      await writeFile(mcpPath, mcpAfter, 'utf8');
+    }
+
+    // --- 2. SessionStart hook → .claude/settings.json (marker-identified) ---
+    const settingsPath = join(ctx.root, SETTINGS_PATH);
+    const existing = await readJsonOrEmpty(settingsPath);
+    const had = await fileExists(settingsPath);
+
+    // Migrate away the legacy mcpServers.openlore + meta a prior version wrote
+    // here (settings.json is never read for MCP). removeManaged strips the
+    // managed paths (mcpServers.openlore) and our top-level meta; SessionStart
+    // is identified separately by its `_openlore: true` marker, so it survives.
+    const migrated = removeManaged(existing);
+    const base = migrated.removed ? migrated.next : existing;
+
+    const currentSessionStart =
+      ((base.hooks as Record<string, unknown>)?.SessionStart as unknown) ?? [];
+    const nextSessionStart = mergeSessionStart(currentSessionStart);
+
+    const next = structuredClone(base) as Record<string, unknown>;
     if (!next.hooks || typeof next.hooks !== 'object') next.hooks = {};
     (next.hooks as Record<string, unknown>).SessionStart = nextSessionStart;
 
-    // Re-derive action: if existing already had identical SessionStart + meta noop, it's noop.
-    const sessionChanged =
-      JSON.stringify(currentSessionStart) !== JSON.stringify(nextSessionStart);
-    const finalAction =
-      action === 'noop' && !sessionChanged ? 'noop' : action === 'created' ? 'created' : 'updated';
-
+    const changed = JSON.stringify(existing) !== JSON.stringify(next);
     const before = had ? JSON.stringify(existing, null, 2) + '\n' : '';
     const after = JSON.stringify(next, null, 2) + '\n';
     const change: PlannedChange = {
       path: settingsPath,
-      kind: !had ? 'create' : finalAction === 'noop' ? 'noop' : 'update',
+      kind: !had ? 'create' : !changed ? 'noop' : 'update',
       summary: !had
-        ? `create ${SETTINGS_PATH} with SessionStart hook + mcpServers.openlore`
-        : finalAction === 'noop'
+        ? `create ${SETTINGS_PATH} with SessionStart hook`
+        : !changed
           ? `${SETTINGS_PATH}: already up to date`
-          : `update SessionStart hook + mcpServers.openlore in ${SETTINGS_PATH}`,
+          : `update SessionStart hook in ${SETTINGS_PATH}`,
       preview: !had
         ? previewCreate(settingsPath, after)
-        : finalAction === 'noop'
+        : !changed
           ? undefined
           : previewDiff(settingsPath, before, after),
     };
 
-    if (!ctx.dryRun && (finalAction !== 'noop' || !had)) {
+    if (!ctx.dryRun && changed) {
       await mkdir(dirname(settingsPath), { recursive: true });
-      await writeFile(settingsPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+      await writeFile(settingsPath, after, 'utf8');
     }
 
     mdResult.changes.push(change);
@@ -149,6 +180,33 @@ export const claudeCodeAdapter: Adapter = {
 
   async uninstall(ctx: ApplyContext): Promise<ApplyResult> {
     const md = await uninstallMarkdownBlock(ctx, MD_FILE, false);
+
+    // Strip mcpServers.openlore from .mcp.json; delete the file if it was ours.
+    const mcpPath = join(ctx.root, MCP_PATH);
+    try {
+      const parsedMcp = JSON.parse(await readFile(mcpPath, 'utf8')) as Record<string, unknown>;
+      const { next, removed } = removeManaged(parsedMcp);
+      if (removed) {
+        if (Object.keys(next).length === 0) {
+          if (!ctx.dryRun) await unlink(mcpPath);
+          md.changes.push({
+            path: mcpPath,
+            kind: 'delete',
+            summary: `remove ${MCP_PATH} (was OpenLore-only)`,
+          });
+        } else {
+          if (!ctx.dryRun) await writeFile(mcpPath, JSON.stringify(next, null, 2) + '\n', 'utf8');
+          md.changes.push({
+            path: mcpPath,
+            kind: 'update',
+            summary: `strip OpenLore entries from ${MCP_PATH}`,
+          });
+        }
+      }
+    } catch {
+      /* no .mcp.json — nothing to do */
+    }
+
     const settingsPath = join(ctx.root, SETTINGS_PATH);
     let parsed: Record<string, unknown>;
     try {
@@ -156,11 +214,13 @@ export const claudeCodeAdapter: Adapter = {
     } catch {
       return md;
     }
-    // Strip our SessionStart entry first (it's identified by _openlore marker,
-    // not by the managed-paths meta).
+    // Strip our SessionStart entry (identified by the `_openlore` marker, not by
+    // the managed-paths meta).
+    let changed = false;
     const hooksObj = parsed.hooks as Record<string, unknown> | undefined;
     if (hooksObj && Array.isArray(hooksObj.SessionStart)) {
       const filtered = stripOurSessionStart(hooksObj.SessionStart);
+      if (filtered.length !== hooksObj.SessionStart.length) changed = true;
       if (filtered.length === 0) {
         delete hooksObj.SessionStart;
         if (Object.keys(hooksObj).length === 0) delete parsed.hooks;
@@ -169,12 +229,11 @@ export const claudeCodeAdapter: Adapter = {
       }
     }
 
+    // Also strip any legacy managed entry (mcpServers.openlore + meta) a prior
+    // version wrote here before MCP moved to .mcp.json.
     const { next, removed } = removeManaged(parsed);
-    if (!removed && parsed.hooks === undefined) {
-      // We may have only stripped a SessionStart entry — that still counts as work.
-    } else if (!removed) {
-      return md;
-    }
+    if (removed) changed = true;
+    if (!changed) return md;
 
     // If file is now empty (only had our entries), delete it.
     const isEmpty = Object.keys(next).length === 0;

--- a/src/cli/install/detect.ts
+++ b/src/cli/install/detect.ts
@@ -8,6 +8,7 @@
 
 import { access, stat, readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
+import { homedir } from 'node:os';
 
 export type AgentName = 'claude-code' | 'cursor' | 'cline' | 'continue' | 'agents-md';
 
@@ -113,6 +114,19 @@ export async function detect(startDir: string): Promise<DetectedSurface[]> {
     if (parent === dir) break;
     dir = parent;
   }
+  // No in-tree markers at all: bias toward Claude Code when the user has a
+  // ~/.claude home (the headline audience) rather than silently targeting only
+  // AGENTS.md and mis-wiring a clean repo (Spec 26 B6B).
+  if (out.length === 0) {
+    try {
+      if ((await stat(join(homedir(), '.claude'))).isDirectory()) {
+        out.push({ agent: 'claude-code', root: resolve(startDir), markers: ['(~/.claude present)'] });
+      }
+    } catch {
+      /* no ~/.claude — fall through to the AGENTS.md fallback */
+    }
+  }
+
   // Universal fallback — anchored at the first detected root, or cwd.
   const fallbackRoot = out[0]?.root ?? resolve(startDir);
   out.push({ agent: 'agents-md', root: fallbackRoot, markers: ['(fallback)'] });

--- a/src/cli/install/install.test.ts
+++ b/src/cli/install/install.test.ts
@@ -60,19 +60,45 @@ describe('openlore install (end-to-end)', () => {
     expect(md).toContain('orient()');
   });
 
-  it('claude-code install creates settings.json with SessionStart + mcpServers', async () => {
+  it('claude-code install writes mcpServers to .mcp.json and SessionStart to settings.json', async () => {
     await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
     const code = await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
     expect(code).toBe(0);
-    const settings = JSON.parse(await readFile(join(dir, '.claude/settings.json'), 'utf8'));
-    expect(settings.mcpServers.openlore).toEqual({
+
+    // MCP server goes in .mcp.json — the file Claude Code actually reads.
+    const mcp = JSON.parse(await readFile(join(dir, '.mcp.json'), 'utf8'));
+    expect(mcp.mcpServers.openlore).toEqual({
       command: 'npx',
       args: ['--yes', 'openlore', 'mcp'],
     });
+    expect(mcp._openlore.managed).toBe(true);
+
+    // settings.json carries only the SessionStart hook — never mcpServers.
+    const settings = JSON.parse(await readFile(join(dir, '.claude/settings.json'), 'utf8'));
+    expect(settings.mcpServers).toBeUndefined();
     expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(
       'npx --yes openlore orient --json'
     );
-    expect(settings._openlore.managed).toBe(true);
+  });
+
+  it('claude-code install migrates a legacy mcpServers entry out of settings.json', async () => {
+    await writeFile(join(dir, 'CLAUDE.md'), '# project\n');
+    await mkdir(join(dir, '.claude'), { recursive: true });
+    // Simulate a pre-2.0.9 install that wrote the server to the wrong file.
+    const legacy = {
+      mcpServers: { openlore: { command: 'npx', args: ['--yes', 'openlore', 'mcp'] } },
+      _openlore: { managed: true, version: 1, fingerprint: 'x', paths: ['mcpServers.openlore'] },
+    };
+    await writeFile(join(dir, '.claude/settings.json'), JSON.stringify(legacy, null, 2), 'utf8');
+
+    const code = await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
+    expect(code).toBe(0);
+    const settings = JSON.parse(await readFile(join(dir, '.claude/settings.json'), 'utf8'));
+    expect(settings.mcpServers).toBeUndefined();
+    expect(settings._openlore).toBeUndefined();
+    expect(settings.hooks.SessionStart[0]._openlore).toBe(true);
+    const mcp = JSON.parse(await readFile(join(dir, '.mcp.json'), 'utf8'));
+    expect(mcp.mcpServers.openlore.command).toBe('npx');
   });
 
   it('re-running install is a no-op (no writes, exit 0)', async () => {
@@ -80,11 +106,13 @@ describe('openlore install (end-to-end)', () => {
     await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
     const mdBefore = await readFile(join(dir, 'CLAUDE.md'), 'utf8');
     const settingsBefore = await readFile(join(dir, '.claude/settings.json'), 'utf8');
+    const mcpBefore = await readFile(join(dir, '.mcp.json'), 'utf8');
 
     const code = await runInstall({ cwd: dir, agent: 'claude-code', analyze: false });
     expect(code).toBe(0);
     expect(await readFile(join(dir, 'CLAUDE.md'), 'utf8')).toBe(mdBefore);
     expect(await readFile(join(dir, '.claude/settings.json'), 'utf8')).toBe(settingsBefore);
+    expect(await readFile(join(dir, '.mcp.json'), 'utf8')).toBe(mcpBefore);
   });
 
   it('refuses to overwrite hand-edited block without --force', async () => {
@@ -120,8 +148,9 @@ describe('openlore install (end-to-end)', () => {
     const code = await runInstall({ cwd: dir, agent: 'claude-code', uninstall: true });
     expect(code).toBe(0);
     expect(await readFile(join(dir, 'CLAUDE.md'), 'utf8')).toBe(original);
-    // settings.json was created by us, so it should be removed
+    // settings.json and .mcp.json were created by us, so both should be removed
     expect(await exists(join(dir, '.claude/settings.json'))).toBe(false);
+    expect(await exists(join(dir, '.mcp.json'))).toBe(false);
   });
 
   it('--uninstall removes AGENTS.md when it was OpenLore-only', async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -222,8 +222,15 @@ export const DEFAULT_CHAT_OPENAI_MODEL = 'gpt-4o-mini';
 // DOCTOR / ENVIRONMENT CHECKS
 // ============================================================================
 
-/** Minimum Node.js major version required */
-export const MIN_NODE_MAJOR_VERSION = 20;
+/**
+ * Minimum Node.js version required. The floor is 22.5, not 20: the EdgeStore
+ * refactor moved onto `node:sqlite` / `DatabaseSync`, which is unavailable
+ * before Node 22.5 (and matches `engines.node` in package.json). doctor checks
+ * the minor version so a `.nvmrc`-pinned Node 20 shell fails fast with a clear
+ * `nvm use` remediation instead of a cryptic module-load crash (Spec 26 B7).
+ */
+export const MIN_NODE_MAJOR_VERSION = 22;
+export const MIN_NODE_MINOR_VERSION = 5;
 
 /** Analysis age (hours) beyond which doctor warns it may be stale */
 export const ANALYSIS_AGE_WARNING_HOURS = 24;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -210,7 +210,7 @@ export const GENERATION_OUTPUT_RATIO = 0.4;
 // DEFAULT MODELS (per provider)
 // ============================================================================
 
-export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-20250514';
+export const DEFAULT_ANTHROPIC_MODEL = 'claude-sonnet-4-6';
 export const DEFAULT_OPENAI_MODEL = 'gpt-4o';
 export const DEFAULT_OPENAI_COMPAT_MODEL = 'mistral-large-latest';
 export const DEFAULT_GEMINI_MODEL = 'gemini-2.0-flash';

--- a/src/core/analyzer/architecture-writer.test.ts
+++ b/src/core/analyzer/architecture-writer.test.ts
@@ -467,14 +467,14 @@ describe('writeArchitectureMd', () => {
     vi.clearAllMocks();
   });
 
-  it('writes ARCHITECTURE.md to rootPath and returns the path', async () => {
+  it('writes ARCHITECTURE.md into the given output dir and returns the path', async () => {
     const { writeFile } = await import('node:fs/promises');
     const overview = makeOverview();
-    const result = await writeArchitectureMd('/my/project', overview);
+    const result = await writeArchitectureMd('/my/project/.openlore/analysis', overview);
 
-    expect(result).toBe('/my/project/ARCHITECTURE.md');
+    expect(result).toBe('/my/project/.openlore/analysis/ARCHITECTURE.md');
     expect(writeFile).toHaveBeenCalledWith(
-      '/my/project/ARCHITECTURE.md',
+      '/my/project/.openlore/analysis/ARCHITECTURE.md',
       expect.stringContaining('# Architecture Overview'),
       'utf-8',
     );
@@ -485,7 +485,7 @@ describe('writeArchitectureMd', () => {
     const overview = makeOverview({
       summary: { totalFiles: 7, totalClusters: 1, totalEdges: 2, cycles: 0, layerViolations: 0 },
     });
-    await writeArchitectureMd('/root', overview);
+    await writeArchitectureMd('/root/.openlore/analysis', overview);
 
     const [, content] = (writeFile as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(content).toContain('| Files | 7 |');

--- a/src/core/analyzer/architecture-writer.ts
+++ b/src/core/analyzer/architecture-writer.ts
@@ -6,7 +6,7 @@
  *
  * Used by:
  *   - MCP tool `get_architecture_overview` (mcp.ts)
- *   - `openlore analyze` — writes ARCHITECTURE.md to the project root
+ *   - `openlore analyze` — writes ARCHITECTURE.md into .openlore/analysis/
  */
 
 import { writeFile } from 'node:fs/promises';
@@ -261,14 +261,16 @@ export function renderArchitectureMarkdown(overview: ArchitectureOverview): stri
 // ============================================================================
 
 /**
- * Write ARCHITECTURE.md to the project root.
+ * Write ARCHITECTURE.md into the given output directory (the analysis dir,
+ * `.openlore/analysis/`), alongside CODEBASE.md and the other generated
+ * artifacts, so nothing churns at the repo root (Spec 26 B3).
  * Returns the path written.
  */
 export async function writeArchitectureMd(
-  rootPath: string,
+  outputDir: string,
   overview: ArchitectureOverview
 ): Promise<string> {
-  const outPath = join(rootPath, 'ARCHITECTURE.md');
+  const outPath = join(outputDir, 'ARCHITECTURE.md');
   await writeFile(outPath, renderArchitectureMarkdown(overview), 'utf-8');
   return outPath;
 }

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -131,7 +131,10 @@ export interface LayerViolation {
  */
 export function layerOf(filePath: string, layers: Record<string, string[]>): string | undefined {
   for (const [layerName, prefixes] of Object.entries(layers)) {
-    if (prefixes.some(p => filePath.includes(p))) return layerName;
+    // Path-prefix match, not substring: `src/cli` must not classify
+    // `src/clinic/x.ts` or `src/api-deprecated/y.ts` into a neighbouring layer.
+    if (prefixes.some(p => { const q = p.endsWith('/') ? p : p + '/'; return filePath === p || filePath.startsWith(q); }))
+      return layerName;
   }
   return undefined;
 }

--- a/src/core/analyzer/spec-vector-index.test.ts
+++ b/src/core/analyzer/spec-vector-index.test.ts
@@ -161,13 +161,20 @@ describe('SpecVectorIndex', () => {
   // --------------------------------------------------------------------------
 
   describe('build()', () => {
-    it('throws when no spec files found', async () => {
+    it('throws a "present but empty" error when the spec dir exists but has no specs', async () => {
       const emptyDir = join(tmpDir, 'empty-specs');
       await mkdir(emptyDir, { recursive: true });
       const embedSvc = makeMockEmbedSvc();
       await expect(SpecVectorIndex.build(tmpDir, emptyDir, embedSvc)).rejects.toThrow(
-        'No spec.md files found'
+        'exists but contains no spec.md files'
       );
+    });
+
+    it('throws a "does not exist" error when the spec dir is missing', async () => {
+      const embedSvc = makeMockEmbedSvc();
+      await expect(
+        SpecVectorIndex.build(tmpDir, join(tmpDir, 'nope-specs'), embedSvc)
+      ).rejects.toThrow('does not exist');
     });
 
     it('returns the number of indexed sections', async () => {

--- a/src/core/analyzer/spec-vector-index.ts
+++ b/src/core/analyzer/spec-vector-index.ts
@@ -315,10 +315,16 @@ export class SpecVectorIndex {
       }
     }
 
-    // Discover spec files
+    // Discover spec files — distinguish "directory missing" from "directory
+    // present but empty" so callers can tell a misconfig from an unseeded repo.
     const specFiles = await findSpecFiles(specsDir);
     if (specFiles.length === 0) {
-      throw new Error(`No spec.md files found in ${specsDir}`);
+      const dirExists = await fileExists(specsDir);
+      throw new Error(
+        dirExists
+          ? `Spec directory ${specsDir} exists but contains no spec.md files — run 'openlore generate', or point openspecPath at your specs`
+          : `Spec directory ${specsDir} does not exist — run 'openlore init' (it now detects docs/specs/ and specs/)`
+      );
     }
 
     // Parse all specs into records (without vectors)

--- a/src/core/architecture/check.test.ts
+++ b/src/core/architecture/check.test.ts
@@ -67,6 +67,19 @@ describe('scanViolations', () => {
     expect(scan.violations[0]).toMatchObject({ kind: 'layers', from: 'src/core/x.ts', to: 'src/cli/y.ts' });
   });
 
+  it('layer prefixes match by path boundary, not substring (no false sibling match)', () => {
+    // `src/clinic` must NOT be classified into the `cli` layer; `src/coreutils`
+    // must NOT be classified into `core`. With substring matching both edges
+    // would be mis-layered and one would be flagged as a violation.
+    const g = depGraph([
+      ['src/clinic/a.ts', 'src/coreutils/b.ts'],
+      ['src/coreutils/b.ts', 'src/clinic/a.ts'],
+    ]);
+    const r = rules({ kind: 'layers', layers: { cli: ['src/cli'], core: ['src/core'] }, source: 'config' });
+    const scan = scanViolations(g, r);
+    expect(scan.violations).toHaveLength(0);
+  });
+
   it('flags an allowedOnly module-boundary breach but allows intra-module + allowlisted', () => {
     const g = depGraph([
       ['src/api/a.ts', 'src/db/conn.ts'], // not allowlisted → violation

--- a/src/core/services/config-manager.test.ts
+++ b/src/core/services/config-manager.test.ts
@@ -76,7 +76,7 @@ describe('config-manager', () => {
       expect(config.analysis.maxFiles).toBe(100_000);
       expect(config.analysis.includePatterns).toEqual([]);
       expect(config.analysis.excludePatterns).toEqual([]);
-      expect(config.generation.model).toBe('claude-sonnet-4-20250514');
+      expect(config.generation.model).toBe('claude-sonnet-4-6');
       expect(config.generation.domains).toBe('auto');
       expect(config.createdAt).toBeDefined();
       expect(config.lastRun).toBe(null);

--- a/src/core/services/config-manager.test.ts
+++ b/src/core/services/config-manager.test.ts
@@ -17,6 +17,7 @@ import {
   openspecConfigExists,
   createOpenSpecStructure,
   mergeOpenSpecConfig,
+  detectExistingSpecDir,
 } from './config-manager.js';
 
 describe('config-manager', () => {
@@ -29,6 +30,40 @@ describe('config-manager', () => {
 
   afterEach(async () => {
     await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('detectExistingSpecDir (Spec 26 B5)', () => {
+    it('returns null when no specs exist anywhere', async () => {
+      expect(await detectExistingSpecDir(testDir)).toBeNull();
+    });
+
+    it('detects specs under docs/specs/ and reports the root', async () => {
+      await mkdir(join(testDir, 'docs', 'specs', 'auth'), { recursive: true });
+      await writeFile(join(testDir, 'docs', 'specs', 'auth', 'spec.md'), '# auth\n');
+      const found = await detectExistingSpecDir(testDir);
+      expect(found).toEqual({ root: 'docs', specsRel: 'docs/specs', count: 1 });
+    });
+
+    it('prefers openspec/ over docs/ when both exist', async () => {
+      await mkdir(join(testDir, 'openspec', 'specs'), { recursive: true });
+      await writeFile(join(testDir, 'openspec', 'specs', 'a.md'), '# a\n');
+      await mkdir(join(testDir, 'docs', 'specs'), { recursive: true });
+      await writeFile(join(testDir, 'docs', 'specs', 'b.md'), '# b\n');
+      const found = await detectExistingSpecDir(testDir);
+      expect(found?.root).toBe('openspec');
+    });
+
+    it('ignores an empty specs directory (no *.md)', async () => {
+      await mkdir(join(testDir, 'openspec', 'specs'), { recursive: true });
+      expect(await detectExistingSpecDir(testDir)).toBeNull();
+    });
+
+    it('detects a bare specs/ dir as root "."', async () => {
+      await mkdir(join(testDir, 'specs'), { recursive: true });
+      await writeFile(join(testDir, 'specs', 'overview.md'), '# o\n');
+      const found = await detectExistingSpecDir(testDir);
+      expect(found).toEqual({ root: '.', specsRel: 'specs', count: 1 });
+    });
   });
 
   describe('getDefaultConfig', () => {

--- a/src/core/services/config-manager.ts
+++ b/src/core/services/config-manager.ts
@@ -4,7 +4,7 @@
  * Handles reading/writing .openlore/config.json and openspec/config.yaml
  */
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import YAML from 'yaml';
 import type { ProjectType, OpenLoreConfig } from '../../types/index.js';
@@ -163,6 +163,47 @@ export async function openspecConfigExists(openspecPath: string): Promise<boolea
 export async function createOpenSpecStructure(openspecPath: string): Promise<void> {
   await ensureDir(openspecPath);
   await ensureDir(join(openspecPath, 'specs'));
+}
+
+/** A spec directory discovered on disk before `init` decides where to point. */
+export interface DetectedSpecDir {
+  /** openspec-root, relative to the project root (config `openspecPath`). */
+  root: string;
+  /** The `<root>/specs` directory, relative to the project root. */
+  specsRel: string;
+  /** Count of `*.md` files found beneath the specs dir. */
+  count: number;
+}
+
+/**
+ * Detect an existing specs directory so `init` does not create an empty
+ * `openspec/` blind to specs that already live in `docs/specs/` or `specs/`
+ * (Spec 26 B5). Candidate openspec-roots are scanned in priority order; the
+ * first whose `<root>/specs` contains at least one `*.md` wins. Returns null
+ * when nothing is found.
+ */
+export async function detectExistingSpecDir(rootPath: string): Promise<DetectedSpecDir | null> {
+  // root (relative) → specs live at `<root>/specs`. '.' covers a bare `specs/`.
+  const candidateRoots = ['openspec', 'docs', '.'];
+  for (const root of candidateRoots) {
+    const specsRel = root === '.' ? 'specs' : `${root}/specs`;
+    const specsDir = join(rootPath, specsRel);
+    let count = 0;
+    try {
+      const stack = [specsDir];
+      while (stack.length) {
+        const dir = stack.pop()!;
+        for (const d of await readdir(dir, { withFileTypes: true })) {
+          if (d.isDirectory()) stack.push(join(dir, d.name));
+          else if (d.name.endsWith('.md')) count++;
+        }
+      }
+    } catch {
+      continue; // specs dir doesn't exist — try the next candidate
+    }
+    if (count > 0) return { root, specsRel, count };
+  }
+  return null;
 }
 
 /**

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -27,6 +27,7 @@
 import { readFile, writeFile, readdir } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { join, relative } from 'node:path';
+import { spawn } from 'node:child_process';
 import chokidar, { type FSWatcher } from 'chokidar';
 import { extractSignatures, detectLanguage } from '../analyzer/signature-extractor.js';
 import type { FunctionNode } from '../analyzer/call-graph.js';
@@ -48,6 +49,15 @@ const CALL_GRAPH_LANGS = new Set([
 ]);
 /** Max callerFiles to re-parse in a single watch event (guards against high-fanIn renames). */
 const CALLER_REPARSE_LIMIT = 10;
+
+/**
+ * Session-global latch: a SCHEMA_VERSION bump wipes the graph store, and an
+ * incremental update can't repair it — only a full `analyze` can. We schedule
+ * exactly one background rebuild per process (Spec 26 B10). Latched (never
+ * cleared) so a persistently-failing rebuild can't spin into a loop; on failure
+ * we fall back to the existing "run analyze" note.
+ */
+let backgroundRebuildTriggered = false;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -362,9 +372,10 @@ export class McpWatcher {
         // (only the changed file's nodes). Skip it — a full `analyze` must rebuild.
         if (store.wasReset) {
           process.stderr.write(
-            '[mcp-watcher] graph index was reset by a schema-version upgrade — run "openlore analyze" to rebuild. ' +
+            '[mcp-watcher] graph index was reset by a schema-version upgrade — scheduling a background rebuild. ' +
             'Skipping incremental update to avoid a partial graph.\n'
           );
+          this.scheduleBackgroundRebuild();
         }
         for (const f of files) {
           if (store.wasReset) break;
@@ -445,6 +456,36 @@ export class McpWatcher {
     process.stderr.write(
       `[mcp-watcher] ${isBulk ? `coalesced ${n} changes` : `updated ${n} file${n === 1 ? '' : 's'}`} (${Date.now() - t0}ms)\n`
     );
+  }
+
+  /**
+   * Self-heal a schema-reset graph by spawning one detached `analyze --force`
+   * (BM25-only, no network). Runs at most once per process (`backgroundRebuild
+   * Triggered`); a spawn failure logs and falls back to the existing "run
+   * analyze" note rather than retrying — no thundering herd, no loop (B10).
+   */
+  private scheduleBackgroundRebuild(): void {
+    if (backgroundRebuildTriggered) return;
+    backgroundRebuildTriggered = true;
+    const cli = process.argv[1];
+    if (!cli) {
+      process.stderr.write('[mcp-watcher] cannot locate the openlore CLI to auto-rebuild — run "openlore analyze".\n');
+      return;
+    }
+    try {
+      const child = spawn(
+        process.execPath,
+        [cli, 'analyze', '--force', '--no-embed', '--output', this.outputPath],
+        { cwd: this.rootPath, stdio: 'ignore', detached: true }
+      );
+      child.on('error', (err) => {
+        process.stderr.write(`[mcp-watcher] background rebuild failed to start (${err.message}) — run "openlore analyze".\n`);
+      });
+      child.unref();
+      process.stderr.write('[mcp-watcher] background "openlore analyze --force" started; the graph will self-heal shortly.\n');
+    } catch (err) {
+      process.stderr.write(`[mcp-watcher] background rebuild could not be spawned (${(err as Error).message}) — run "openlore analyze".\n`);
+    }
   }
 
   // ── llm-context load + persistence + read-cache handoff (Step 2) ─────────────

--- a/src/core/services/project-detector.test.ts
+++ b/src/core/services/project-detector.test.ts
@@ -173,6 +173,40 @@ describe('project-detector', () => {
     });
   });
 
+  describe('nested manifest detection (Spec 26 B6A)', () => {
+    it('detects a manifest one directory deep when the root has none', async () => {
+      await mkdir(join(testDir, 'python'), { recursive: true });
+      await writeFile(join(testDir, 'python', 'pyproject.toml'), '[project]\n');
+      const result = await detectProjectType(testDir);
+      expect(result.projectType).toBe('python');
+      expect(result.manifestFile).toBe(join('python', 'pyproject.toml'));
+      expect(result.confidence).toBe('medium');
+    });
+
+    it('still reports unknown when no manifest exists at root or depth-1', async () => {
+      await mkdir(join(testDir, 'docs'), { recursive: true });
+      await writeFile(join(testDir, 'docs', 'README.md'), '# hi\n');
+      const result = await detectProjectType(testDir);
+      expect(result.projectType).toBe('unknown');
+    });
+
+    it('prefers the root manifest over a nested one', async () => {
+      await writeFile(join(testDir, 'package.json'), '{}');
+      await mkdir(join(testDir, 'backend'), { recursive: true });
+      await writeFile(join(testDir, 'backend', 'go.mod'), 'module x\n');
+      const result = await detectProjectType(testDir);
+      expect(result.projectType).toBe('nodejs');
+      expect(result.manifestFile).toBe('package.json');
+    });
+
+    it('ignores node_modules when scanning depth-1', async () => {
+      await mkdir(join(testDir, 'node_modules'), { recursive: true });
+      await writeFile(join(testDir, 'node_modules', 'package.json'), '{}');
+      const result = await detectProjectType(testDir);
+      expect(result.projectType).toBe('unknown');
+    });
+  });
+
   describe('getProjectTypeName', () => {
     it('should return correct names for all project types', () => {
       expect(getProjectTypeName('nodejs')).toBe('Node.js/TypeScript');

--- a/src/core/services/project-detector.ts
+++ b/src/core/services/project-detector.ts
@@ -4,10 +4,15 @@
  * Detects the project type by checking for language-specific manifest files.
  */
 
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { ProjectType } from '../../types/index.js';
 import { fileExists } from '../../utils/command-helpers.js';
+
+/** Depth-1 subdirs commonly holding a nested manifest (monorepo / polyglot layout). */
+const NESTED_SCAN_IGNORE = new Set([
+  'node_modules', '.git', 'dist', 'build', 'coverage', '.openlore', 'vendor', '.venv', 'target',
+]);
 
 /**
  * Project detection result
@@ -58,8 +63,19 @@ export async function detectProjectType(rootPath: string): Promise<ProjectDetect
     }
   }
 
-  // No manifests found
+  // No manifest at the root — scan depth-1 subdirs before giving up, so a
+  // nested layout (e.g. python/pyproject.toml, backend/go.mod) is not reported
+  // as "Unknown" (Spec 26 B6A). Prefer the shallowest, highest-priority match.
   if (detectedManifests.length === 0) {
+    const nested = await detectNestedManifest(rootPath);
+    if (nested) {
+      return {
+        projectType: nested.type,
+        manifestFile: nested.file,
+        hasGit,
+        confidence: 'medium',
+      };
+    }
     return {
       projectType: 'unknown',
       manifestFile: null,
@@ -88,6 +104,36 @@ export async function detectProjectType(rootPath: string): Promise<ProjectDetect
     hasGit,
     confidence,
   };
+}
+
+/**
+ * Scan depth-1 subdirectories for a manifest when the root has none. Returns the
+ * highest-priority manifest found in the shallowest matching subdir, or null.
+ */
+async function detectNestedManifest(
+  rootPath: string
+): Promise<{ file: string; type: ProjectType } | null> {
+  let entries: string[];
+  try {
+    const dirents = await readdir(rootPath, { withFileTypes: true });
+    entries = dirents
+      .filter((d) => d.isDirectory() && !d.name.startsWith('.') && !NESTED_SCAN_IGNORE.has(d.name))
+      .map((d) => d.name);
+  } catch {
+    return null;
+  }
+
+  const hits: { file: string; type: ProjectType; priority: number }[] = [];
+  for (const sub of entries) {
+    for (const manifest of MANIFEST_MAP) {
+      if (await fileExists(join(rootPath, sub, manifest.file))) {
+        hits.push({ file: join(sub, manifest.file), type: manifest.type, priority: manifest.priority });
+      }
+    }
+  }
+  if (hits.length === 0) return null;
+  hits.sort((a, b) => a.priority - b.priority);
+  return { file: hits[0].file, type: hits[0].type };
 }
 
 /**


### PR DESCRIPTION
Implements **all of OpenLore Spec 26** (install / MCP-wiring / first-run correctness) plus one bug found by an all-specs audit sweep. Every fix is deterministic and offline.

## Wave 0 — MCP registration (the headline bug)
`openlore install --agent claude-code` wrote `mcpServers.openlore` to `.claude/settings.json`, which **Claude Code never reads for MCP** — the tools silently never loaded. Now written to **`.mcp.json`** (project scope); only the SessionStart hook stays in `settings.json`; re-running migrates a legacy entry away. New `doctor` **MCP wiring** check warns on wrong-file/duplicate registration with the exact `--force` fix.

## Wave 1 — consolidated `doctor` pass + audit fix
- **B4**: LLM/embedding checks are `warn`, not `fail` — the deterministic workflow (BM25) needs no LLM, so a no-LLM project exits **0**.
- **B7-doctor**: checks the Node *minor* version (≥22.5, required by `node:sqlite`) with an `nvm use` remediation.
- **B5-doctor**: reads the *configured* `openspecPath`.
- **Audit fix**: `layerOf` used substring matching (`filePath.includes(prefix)`) — `src/clinic/*` could be classified into the `src/cli` layer. Switched to path-boundary matching; affected `detectLayerViolations` and the spec-23 `check_architecture` `layers` rule. Regression test added.

## Wave 2 — detection correctness
- **B5**: `init` (CLI + api) detects existing `docs/specs/` or `specs/` and points `openspecPath` there instead of creating an empty `openspec/` blind to them; spec-index error distinguishes "missing" vs "present but empty".
- **B6A**: project-type detection scans depth-1 subdirs (e.g. `python/pyproject.toml`) before "Unknown".
- **B6B**: install detection biases to `claude-code` when `~/.claude` exists rather than blindly targeting AGENTS.md.

## Wave 3 — freshness ownership
- **B9**: removed the redundant full-`analyze` PostToolUse hook (fired on *every* tool call); `--watch-auto` is the sole O(change) freshness owner; setup migrates the legacy hook away.
- **B10**: when a `SCHEMA_VERSION` bump wipes the graph, the watcher schedules one detached `analyze --force` to self-heal (latched once-per-process; falls back to the note on failure).

## Wave 4 — cleanup
- **B8**: `openlore-orient` SKILL.md documents the real camelCase `orient --json` fields and points MCP detection at `.mcp.json`.
- **B3**: `ARCHITECTURE.md` lands in `.openlore/analysis/` (no repo-root churn); dropped the redundant gitignore line.
- **B2a**: `ensureGitignored` skips a child entry when a covering parent exists (slash-insensitive; `.openlore` ≠ `.openapi`).
- **B2b**: default model → `claude-sonnet-4-6`.

## All-specs audit
Four read-only agents swept specs 1–25. Specs 1–20 came back clean; the only confirmed bug was the `layerOf` one (fixed in Wave 1). Two other reported findings (orient `involvesRelevant`, structural-diff rename path) were investigated and judged **not bugs** (both endpoints are full file paths so `===` is the real match; labeling the old snapshot with the new path is intentional rename-matching).

## Verification
`lint` + `typecheck` clean; full suite **3104 passed, 2 skipped**; `build` clean. Dogfooded on this repo (`doctor` all-green; `.mcp.json` boots the local MCP server) and on a clean throwaway repo (install → migrate → uninstall). Decision `e3d3214e` recorded + synced to `openspec/specs/cli/spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)