### PR TITLE
Spec 28 — Lean / Deferred MCP Tool Surface

### DIFF
--- a/docs/specs/openlore-spec-27-lean-adaptive-orientation.md
+++ b/docs/specs/openlore-spec-27-lean-adaptive-orientation.md
@@ -30,6 +30,16 @@ re-measured live and refreshed honestly (Spec 25 honesty contract applies).
   orienting, express doesn't), and an agent can't reliably tell ahead of time, so forcing the choice
   risks the deep-task win. We deliberately do not ship a heuristic that guesses. The honest answer
   stays: `openlore prove` lets each user measure their own repo + task mix.
+- [x] **P5 — Lean is now *compute*-lean, not just payload-lean (deepened 2026-06-03, shipped with Spec 28).**
+  P1 trimmed the lean *response* but the handler still did all the enrichment *work* and threw it away:
+  an extra `SpecVectorIndex.search` embedding query (`matchingSpecs`), manifest + spec-file reads
+  (`inlineSpecs`), a decision-store load (`pendingDecisions`), the git-derived `provenance` /
+  `changeCoupling` / `governingDecisions` joins, and a `dependency-graph.json` parse + violation scan
+  (`architectureViolations`). Each enrichment block is now guarded by `!lean`, so lean skips the I/O
+  and the second embedding round-trip entirely — it makes the shallow-task path *faster*, not only
+  smaller. Unit test asserts the decision-store load (a representative side-effect) is **not** invoked
+  in lean and **is** in rich. This is the honest counter to P3's structural finding: lean can't remove
+  the agent round-trip, but it now removes the *server-side* work behind the call too.
 
 **Net (honest):** lean orient is a real, shipped efficiency improvement (40% smaller orient payload,
 deterministic, no downside — enrichment stays one `expand` away). It does **not** eliminate the

--- a/docs/specs/openlore-spec-28-lean-tool-surface.md
+++ b/docs/specs/openlore-spec-28-lean-tool-surface.md
@@ -1,0 +1,123 @@
+# OpenLore Spec 28 — Lean / Deferred MCP Tool Surface (close spec-25 §7's "biggest upside")
+
+> Closes the one open question Spec 25 §7 flagged as **"biggest unknown, biggest upside"**: *can MCP
+> tool schemas be deferred/lazy the way this runtime defers its own tools?* If yes, the ~11.8k-token
+> `tools/list` prefix — part of the structural shallow-task cost Spec 27 proved it could not remove —
+> might vanish. This spec measures the answer instead of guessing it, ships the deterministic
+> server-side win, and reports the limit honestly. Parent: [Spec 25](openlore-spec-25-token-value-optimization-and-proof.md)
+> (§7). Sibling: [Spec 27](openlore-spec-27-lean-adaptive-orientation.md) (the lean *orient* payload).
+
+---
+
+## Progress
+
+Branch: `feat/spec-28-lean-tool-surface`. Same honesty contract as Spec 25 applies — the number we
+publish is the number we measured, including a win that turns out small.
+
+- [x] **P1 — Lossless tool-surface trim.** The `directory` input is shared by all 50 tools and carried
+  a verbatim 38-char description on each; collapsed to one short shared constant (`DIR_DESC`, 21 chars).
+  Dropped three pure capability-boast clauses that carry **no tool-selection signal** ("faster than
+  reading package.json + directory tree yourself", a redundant language list, "No LLM calls required"
+  — the local-vs-LLM distinction is already in the `openWorldHint` annotation). Measured on this repo:
+  full `tools/list` **47,037 → 46,118 bytes (−2.0%, ~229 tokens)**; navigation preset **8,121 → 8,002
+  (−1.5%)**. **Zero selection-quality risk** — no disambiguating description text was touched. Unit-tested.
+- [x] **P1 — Payload-size regression guard.** New `tools/list payload budget (spec-28)` tests bound the
+  full surface (<48 KB) and the navigation preset (<8.5 KB), plus a lossless-dedup invariant (the shared
+  `directory` description stays ≤25 chars and is reused by ≥80% of tools). A new tool (~900 B) or
+  re-bloated boilerplate now fails the suite — adding to the cached prefix is a conscious budget bump,
+  not silent drift. This is the durable deliverable; the −2% trim is the one-time cleanup.
+- [x] **P2 — Answered the §7 question, by measurement (the headline, honest finding).** MCP has **no
+  server-driven lazy-schema mechanism**: `tools/list` returns every tool's full `inputSchema`, and the
+  server can't advertise names-only and defer schemas. **But the dominant client (Claude Code) already
+  defers MCP tool schemas *client-side*** — verified live this session: OpenLore's tools arrive as names
+  with schemas loaded on demand, so the ~11.5k-token prefix is **not paid up front** in that client at
+  all. So §7's "biggest upside" is **real but client-controlled**: where it matters most it is already
+  captured, and the server cannot do better than the client already does. For *eager* clients (Cline,
+  older runtimes) the server's only levers are tool **count** (presets, Spec 14/25) and schema **bytes**
+  — and the lossless byte-lever is only ~2%, because the payload is dominated by irreducible per-tool
+  schema structure plus the selection text an agent genuinely needs to pick the right tool.
+- [ ] **P3 — Meta-dispatcher tool (explored, NOT implemented).** Collapsing the rarely-used long tail
+  (inventories, reports) behind a single `openlore(action, …)` tool would shrink the eager-client
+  surface further, but it **trades the wrong way**: it discards per-tool schema validation, the
+  read/write/open-world annotations (Spec 11), and the discoverable surface an agent selects from —
+  re-introducing exactly the wrong-tool round-trips Spec 25 §7 warned compaction can cause. We do not
+  ship it. Forcing `navigation` as the install **default** was re-litigated and again rejected (Spec 25
+  Phase B): it hides the governance tools the decision gate needs. Opt-in presets remain the answer.
+
+**Net (honest):** the structural `tools/list` prefix cost is **client-side**, and the dominant client
+already erases it by deferring schemas — so Spec 25 §7's biggest upside is largely already realized
+where it counts, not by anything OpenLore ships. Server-side, the surface is now provably lean (a
+lossless ~2% trim) and **bounded against future bloat** (the budget guard). We ship the safe win and
+the lasting guard, and report that the headline lever was never the server's to pull.
+
+---
+
+## 1. The measured problem (Spec 25 §3 / §7)
+
+The full OpenLore tool surface is **50 tools / ~47,037 bytes / ~11,759 tokens** of `tools/list`. For an
+MCP client that loads all tool schemas eagerly, that prefix is re-sent (or, at best, cached) **every
+turn**, before any `orient` call — a fixed tax that, on a trivial lookup in a small repo, can exceed
+the whole answer (Spec 27 §1). Spec 25 §7 named the one lever that might erase it outright — *deferring
+the schemas the way this runtime defers its own tools* — and left it open as "biggest unknown, biggest
+upside." This spec resolves it.
+
+Composition of the payload (why the byte-lever is small):
+
+| part | share | reducible losslessly? |
+|---|---|---|
+| per-tool `inputSchema` structure (types, enums, required, property names) | ~46% | no — MCP requires it per tool |
+| tool + property **descriptions** | ~38% | partly — only non-selection text (boasts, repeats) |
+| `name` + `annotations` (Spec 11 hints) | ~16% | no — correctness/selection signal |
+
+Only the redundant slice of the description budget is safe to cut. The `directory` description (50×
+identical) and a few capability-boast clauses are that slice; everything else is either schema the
+protocol mandates or signal an agent uses to choose a tool.
+
+## 2. Mechanism — lossless trim + a budget guard (P1)
+
+- **Shared short `directory` description.** One `DIR_DESC` constant (`'Absolute project path'`) replaces
+  the 38-char verbatim repeat on all 50 tools. Keeps the only fact that matters (it must be absolute),
+  drops the rest. Lossless of selection signal.
+- **Drop pure boasts.** Three clauses that an agent never uses to pick between tools are removed; the
+  `openWorldHint` annotation already encodes local-vs-LLM, so "No LLM calls required" was pure repetition.
+- **Budget guard.** Tests bound full (<48 KB) and navigation (<8.5 KB) payloads and pin the dedup
+  invariant. The surface can grow only by a deliberate ceiling bump — the cached prefix cannot creep.
+
+These compose with Spec 25 (cache-stable prefix) and Spec 14/25 presets: the trim shrinks bytes for
+eager clients, the guard keeps them shrunk, and deferring clients (§3) pay none of it up front anyway.
+
+## 3. The honest finding — lazy schemas are the client's job, and the main client does it
+
+Two facts, both verified rather than assumed:
+
+1. **The MCP protocol has no server-side schema deferral.** `tools/list` returns each tool's complete
+   `inputSchema`; there is no "advertise names, fetch schema on use" handshake a server can drive.
+2. **Claude Code defers MCP tool schemas client-side.** This very session received OpenLore's tools as
+   names with schemas loaded on demand — so in the dominant client the ~11.5k-token prefix is not loaded
+   up front. The upside Spec 25 §7 hoped for is therefore **already captured, by the client**, and is
+   outside OpenLore's control to improve.
+
+Conclusion: the structural prefix cost Spec 27 measured is real for *eager* clients and ~zero for
+*deferring* ones; OpenLore cannot move the deferring case (the client already won it) and can move the
+eager case by only ~2% losslessly (the rest is irreducible). The honest lever for the eager case stays
+**tool count** — the opt-in `--preset navigation` (−83% of the surface), recommended but not forced.
+
+## 4. Non-goals
+
+- Not lossy: no disambiguating tool/property description is paraphrased or dropped — only verbatim
+  repeats and non-selection boasts.
+- Not a meta-dispatcher: collapsing tools behind one action tool trades away validation, annotations,
+  and discoverability for bytes (P3) — net negative.
+- Not a new default surface: the full set stays the default; `navigation`/`minimal` stay opt-in (Spec 25).
+- Not a claim that this erases the shallow-task loss: §3 shows the only lever that could is client-side
+  and already pulled.
+
+## 5. Success criteria
+
+- ✅ `tools/list` is materially smaller losslessly (full −2.0%, nav −1.5% on this repo) with no
+  selection text removed — unit-tested.
+- ✅ A regression guard bounds the surface so the cached prefix cannot silently bloat — adding a tool
+  requires a conscious budget bump.
+- ✅ Spec 25 §7's open question is **closed with a measured answer**, not left open: server-side schema
+  deferral does not exist in MCP; client-side deferral exists and the dominant client uses it; the
+  server-side byte-lever is ~2%. Reported plainly, including that the headline upside was never ours.

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -316,6 +316,12 @@ The system SHALL The orient command SHALL accept a `lean` flag that, when set, r
 
 > Decision recorded: e57091fb
 > Date: 2026-06-03
+### Requirement: LeanMcpToolSurfaceViaLosslessTrimPayloadsizeGuardNotServerdrivenLazySchemas
+
+The system SHALL enforce a payload-size budget guard on the MCP tools/list response to prevent unbounded tool-surface growth.
+
+> Decision recorded: d54af0d3
+> Date: 2026-06-03
 
 ## Technical Notes
 
@@ -402,3 +408,13 @@ Allows callers to cap the number of tokens returned in relevantFunctions/search 
 Shallow 'who/where' lookups don't need provenance, change-coupling, insertion-points, specs, or decisions enrichment — returning only the navigation core (relevantFunctions, callPaths, specDomains) cuts per-call token cost for agents that only need a quick lookup before drilling deeper with dedicated tools.
 
 **Consequences:** Callers must opt-in via the `lean` flag; expand handles and dedicated tools remain the path to full enrichment. Both MCP and CLI surfaces must forward the parameter to handleOrient.
+
+### Lean MCP tool surface via lossless trim + payload-size guard, not server-driven lazy schemas
+
+**Status:** Approved
+**Date:** 2026-06-03
+**ID:** d54af0d3
+
+MCP has no server-driven lazy-schema mechanism (tools/list always returns full inputSchemas), and the dominant client (Claude Code) already defers schemas client-side. The server's only lossless lever is tool count + bytes; byte savings are ~2% because payload is dominated by irreducible per-tool schema structure. A meta-dispatcher tool was rejected (loses per-tool validation, Spec 11 annotations, discoverable selection surface, reintroduces wrong-tool round-trips). Forcing the navigation preset as install default was also rejected (hides governance tools the decision gate needs, per Spec 25 Phase B).
+
+**Consequences:** tools/list shrinks ~2% losslessly (47,037→46,118 B full; 8,121→8,002 B nav) with zero selection-quality risk. A budget-guard test regresses if surface bloats, making tool additions a conscious budget bump. Structural shallow-task prefix cost is acknowledged as client-controlled and not further reducible server-side; eager clients retain the --preset navigation lever.

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -670,11 +670,13 @@ After analysis, run 'openlore generate' to create OpenSpec files.
       if (artifacts.repoStructure.envVars.length > 0) {
         console.log(`    ├─ ${opts.output}env-inventory.json  (${artifacts.repoStructure.envVars.length} env var(s))`);
       }
+      // CODEBASE.md (digestWritten) is the last branch when present, so it owns the
+      // └─ corner; otherwise the corner falls to ARCHITECTURE.md / SUMMARY.md.
       if (architectureMdWritten) {
         console.log(`    ├─ ${opts.output}SUMMARY.md`);
-        console.log(`    ├─ ${opts.output}ARCHITECTURE.md`);
+        console.log(`    ${digestWritten ? '├─' : '└─'} ${opts.output}ARCHITECTURE.md`);
       } else {
-        console.log(`    ├─ ${opts.output}SUMMARY.md`);
+        console.log(`    ${digestWritten ? '├─' : '└─'} ${opts.output}SUMMARY.md`);
       }
       if (digestWritten) {
         console.log(`    └─ ${opts.output}CODEBASE.md`);

--- a/src/cli/commands/mcp-presets.test.ts
+++ b/src/cli/commands/mcp-presets.test.ts
@@ -126,3 +126,50 @@ describe('tool annotations (spec-11)', () => {
     }
   });
 });
+
+// ============================================================================
+// Spec 28 — tools/list payload budget. The full tool surface is a ~46 KB / ~11.6k-
+// token prefix that an eager (non-deferring) MCP client loads every turn. Spec 25
+// §7 asked whether that prefix could be erased; Spec 28 measured the answer:
+// deferral is client-side (the dominant client already lazy-loads MCP schemas),
+// and the server-side lossless byte-lever is ~1%. These guards lock that in — they
+// fail loudly if the prefix bloats back, so adding a tool is a conscious budget
+// bump, not silent drift. Bytes mirror what the ListTools handler actually emits.
+// ============================================================================
+describe('tools/list payload budget (spec-28)', () => {
+  const payloadBytes = (opts: { minimal?: boolean; preset?: string }): number => {
+    const tools = selectActiveTools(TOOL_DEFINITIONS, opts).map(t => ({
+      ...t,
+      annotations: toolAnnotations(t.name),
+    }));
+    return Buffer.byteLength(JSON.stringify({ tools }), 'utf8');
+  };
+
+  // Ceilings sit just above the measured size (full ≈ 46.5 KB, nav ≈ 8.0 KB) with
+  // ~1 tool of headroom. A new tool (~900 B) or un-trimmed boilerplate breaches
+  // them — forcing a deliberate decision rather than letting the cached prefix creep.
+  it('full surface stays within its prefix budget', () => {
+    expect(payloadBytes({})).toBeLessThan(48_000);
+  });
+
+  it('navigation preset stays lean (the low-overhead surface that wins the benchmark)', () => {
+    expect(payloadBytes({ preset: 'navigation' })).toBeLessThan(8_500);
+  });
+
+  // Lossless-dedup invariant: the `directory` input is shared by every tool, so its
+  // description must stay a short shared string, never the 38-char verbatim repeat
+  // that Spec 28 collapsed. Guards against the duplication silently creeping back.
+  it('the shared directory-param description is short and used by the majority of tools', () => {
+    const dirDescs = TOOL_DEFINITIONS
+      .map(t => {
+        const props = t.inputSchema?.properties as unknown as Record<string, { description?: string }> | undefined;
+        return props?.directory?.description;
+      })
+      .filter((d): d is string => typeof d === 'string');
+    const counts = new Map<string, number>();
+    for (const d of dirDescs) counts.set(d, (counts.get(d) ?? 0) + 1);
+    const [dominant, dominantCount] = [...counts].sort((a, b) => b[1] - a[1])[0];
+    expect(dominant.length).toBeLessThanOrEqual(25); // short shared form, not the old 38-char repeat
+    expect(dominantCount).toBeGreaterThanOrEqual(dirDescs.length * 0.8); // most tools reuse it
+  });
+});

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -146,6 +146,12 @@ export {
 // TOOL DEFINITIONS
 // ============================================================================
 
+// Spec 28 — the `directory` param is the one input every tool shares (50×). Its
+// description was a verbatim 38-char repeat on each tool; a single short shared
+// constant trims that lossless repeat from the cached tools/list prefix without
+// dropping the one fact that matters (it must be absolute, not relative).
+const DIR_DESC = 'Absolute project path';
+
 export const TOOL_DEFINITIONS = [
   {
     name: 'orient',
@@ -160,7 +166,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         task: {
           type: 'string',
@@ -208,8 +214,8 @@ export const TOOL_DEFINITIONS = [
     name: 'get_architecture_overview',
     description:
       'USE THIS WHEN: onboarding to an unknown codebase, or before planning a large feature. ' +
-      'Returns domain clusters, cross-cluster dependencies, global entry points, and critical hubs — ' +
-      'faster than reading package.json + directory tree yourself. Run analyze_codebase first.',
+      'Returns domain clusters, cross-cluster dependencies, global entry points, and critical hubs. ' +
+      'Run analyze_codebase first.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -244,14 +250,13 @@ export const TOOL_DEFINITIONS = [
     description:
       'Return the call graph for a project: hub functions (high fan-in), ' +
       'entry points (no internal callers), and architectural layer violations. ' +
-      'Supports TypeScript, JavaScript, Python, Go, Rust, Ruby, Java, C++. ' +
       'Run analyze_codebase first.',
     inputSchema: {
       type: 'object',
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
       },
       required: ['directory'],
@@ -264,7 +269,7 @@ export const TOOL_DEFINITIONS = [
       'Detects Type 1 (exact clones — identical after whitespace/comment normalization), ' +
       'Type 2 (structural clones — same structure with renamed variables), and ' +
       'Type 3 (near-clones with Jaccard similarity ≥ 0.7 on token n-grams). ' +
-      'No LLM calls required. Run analyze_codebase first.',
+      'Run analyze_codebase first.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -287,7 +292,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         filePattern: {
           type: 'string',
@@ -312,7 +317,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         functionName: {
           type: 'string',
@@ -352,7 +357,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         entryFunction: {
           type: 'string',
@@ -386,7 +391,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         domain: {
           type: 'string',
@@ -453,7 +458,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         symbol: {
           type: 'string',
@@ -479,7 +484,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         changedSymbols: {
           type: 'array',
           items: { type: 'string' },
@@ -506,7 +511,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         ifDeleted: { type: 'string', description: 'Symbol name — returns what becomes dead if it is deleted (delete-impact mode)' },
         maxResults: { type: 'number', description: 'Max candidate-dead results (default 100)' },
         filePattern: { type: 'string', description: 'Only report candidates whose file path contains this substring' },
@@ -526,7 +531,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         baseRef: { type: 'string', description: 'Old state to diff against (default "HEAD")' },
         headRef: { type: 'string', description: 'New state (a git ref). Omit to use the working tree.' },
         maxResults: { type: 'number', description: 'Cap reported items per category (default 200)' },
@@ -546,7 +551,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         file: { type: 'string', description: 'A file to query its coupling/volatility. Omit for the most-volatile overview.' },
         limit: { type: 'number', description: 'Cap results (default 20)' },
       },
@@ -566,7 +571,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         from: { type: 'string', description: 'Pre-edit mode: the file that would gain the import (relative or absolute). Requires "to".' },
         to: { type: 'string', description: 'Pre-edit mode: the target file path or exported symbol being imported. Requires "from".' },
       },
@@ -585,7 +590,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         limit: {
           type: 'number',
@@ -611,7 +616,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         limit: {
           type: 'number',
@@ -643,7 +648,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         limit: {
           type: 'number',
@@ -670,7 +675,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         filePath: {
           type: 'string',
@@ -692,7 +697,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         filePath: {
           type: 'string',
@@ -719,7 +724,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         description: {
           type: 'string',
@@ -752,7 +757,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         query: {
           type: 'string',
@@ -786,7 +791,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
       },
       required: ['directory'],
     },
@@ -803,7 +808,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         query: {
           type: 'string',
@@ -839,7 +844,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         query: {
           type: 'string',
@@ -875,7 +880,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         domain: {
           type: 'string',
           description: 'Domain name as returned by list_spec_domains (e.g. "auth", "analyzer")',
@@ -894,7 +899,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         filePath: {
           type: 'string',
           description: 'File path relative to the project directory, e.g. "src/auth/jwt.ts"',
@@ -917,7 +922,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         filePath: {
           type: 'string',
           description: 'File path relative to the project root, e.g. "src/core/analyzer/vector-index.ts"',
@@ -945,7 +950,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         description: {
           type: 'string',
@@ -983,7 +988,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         storyFilePath: {
           type: 'string',
@@ -1011,7 +1016,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         query: {
           type: 'string',
           description: 'Optional text filter — returns only ADRs whose title or content contains this string',
@@ -1033,7 +1038,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
       },
       required: ['directory'],
     },
@@ -1051,7 +1056,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
       },
       required: ['directory'],
     },
@@ -1068,7 +1073,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
       },
       required: ['directory'],
     },
@@ -1085,7 +1090,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
       },
       required: ['directory'],
     },
@@ -1103,7 +1108,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
       },
       required: ['directory'],
     },
@@ -1119,7 +1124,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
       },
       required: ['directory'],
     },
@@ -1137,7 +1142,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         maxUncovered: {
           type: 'number',
           description: 'Maximum uncovered functions to return (default: 50)',
@@ -1166,7 +1171,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         domains: {
           type: 'array',
@@ -1204,7 +1209,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         directory: {
           type: 'string',
-          description: 'Absolute path to the project directory',
+          description: DIR_DESC,
         },
         domains: {
           type: 'array',
@@ -1230,7 +1235,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         functionName: { type: 'string', description: 'Exact function or method name' },
         filePath: {
           type: 'string',
@@ -1251,7 +1256,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         functionName: { type: 'string', description: 'Function name to look up the community for' },
       },
       required: ['directory', 'functionName'],
@@ -1269,7 +1274,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         base: {
           type: 'string',
           description: 'Git ref to diff against (default: HEAD). Use "HEAD~1" for last commit, "main" for branch diff.',
@@ -1289,7 +1294,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         title: { type: 'string', description: 'Short imperative statement, e.g. "Use UUIDs for decision IDs"' },
         rationale: { type: 'string', description: 'Why this decision was made' },
         consequences: { type: 'string', description: 'What changes as a result (optional)' },
@@ -1321,7 +1326,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         status: {
           type: 'string',
           enum: ['draft', 'consolidated', 'verified', 'phantom', 'approved', 'rejected', 'synced'],
@@ -1342,7 +1347,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         id: { type: 'string', description: '8-character decision ID from list_decisions' },
         note: { type: 'string', description: 'Optional review note' },
       },
@@ -1356,7 +1361,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         id: { type: 'string', description: '8-character decision ID from list_decisions' },
         note: { type: 'string', description: 'Optional reason for rejection' },
       },
@@ -1374,7 +1379,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        directory: { type: 'string', description: 'Absolute path to the project directory' },
+        directory: { type: 'string', description: DIR_DESC },
         dryRun: { type: 'boolean', description: 'Preview without writing files (default: false)' },
         id: { type: 'string', description: 'Sync only this specific decision ID (default: all approved)' },
       },

--- a/src/core/services/mcp-handlers/orient.test.ts
+++ b/src/core/services/mcp-handlers/orient.test.ts
@@ -174,6 +174,23 @@ describe('handleOrient', () => {
     expect(Buffer.byteLength(JSON.stringify(lean))).toBeLessThan(Buffer.byteLength(JSON.stringify(rich)));
   });
 
+  it('lean mode skips the enrichment WORK, not just the payload (Spec 27 deepened)', async () => {
+    vi.mocked(VectorIndex.exists).mockReturnValue(true);
+    vi.mocked(VectorIndex.search).mockResolvedValue([
+      makeSearchResult({ name: 'handleAuth', filePath: 'src/auth.ts' }),
+    ]);
+
+    // The decision-store load is one of the enrichment side-effects lean must avoid:
+    // rich computes it (then surfaces pendingDecisions), lean must not even read it.
+    vi.mocked(loadDecisionStore).mockClear();
+    await handleOrient('/tmp/proj', 'who calls handleAuth', 5, undefined, true);
+    expect(loadDecisionStore, 'lean must not load the decision store').not.toHaveBeenCalled();
+
+    vi.mocked(loadDecisionStore).mockClear();
+    await handleOrient('/tmp/proj', 'who calls handleAuth', 5);
+    expect(loadDecisionStore, 'rich still loads the decision store').toHaveBeenCalled();
+  });
+
   it('preserves raw score (higher = better) without inverting via 1 - score', async () => {
     vi.mocked(VectorIndex.exists).mockReturnValue(true);
     vi.mocked(VectorIndex.search).mockResolvedValue([

--- a/src/core/services/mcp-handlers/orient.ts
+++ b/src/core/services/mcp-handlers/orient.ts
@@ -240,7 +240,7 @@ export async function handleOrient(
   // doesn't connect them to the seed functions.
   type SpecLinkedFunction = { name: string; filePath: string; domain: string; requirement: string };
   const specLinkedFunctions: SpecLinkedFunction[] = [];
-  if (mappingIdx && relevantFunctions.length > 0) {
+  if (!lean && mappingIdx && relevantFunctions.length > 0) {
     const seedDomains = new Set<string>();
     for (const fn of relevantFunctions) {
       for (const spec of fn.linkedSpecs) seedDomains.add(spec.domain);
@@ -316,9 +316,18 @@ export async function handleOrient(
     .slice(0, 3)
     .map((c, i) => ({ rank: i + 1, ...c, score: parseFloat(c.score.toFixed(3)) }));
 
+  // ── Enrichment (Spec 27, deepened) ─────────────────────────────────────────
+  // Everything from here down is dropped by lean mode (it returns the navigation
+  // `core` only). Spec 27 P1 trimmed the lean *payload* but still computed this
+  // enrichment and threw it away — an extra embedding search (matchingSpecs),
+  // manifest + spec-file reads (inlineSpecs), a decision-store load, git-derived
+  // blocks, and a dependency-graph scan, all wasted on a shallow lookup. Each
+  // block is now guarded by `!lean`, so lean skips the *work*, not just the
+  // bytes: it makes the shallow-task path measurably faster, not only smaller.
+
   // ── Spec search (best-effort — skipped if spec index not available) ────────
   let matchingSpecs: OrientSpecMatch[] | undefined;
-  if (hasSpecIndex && embedSvc) {
+  if (!lean && hasSpecIndex && embedSvc) {
     try {
       const specResults = await SpecVectorIndex.search(outputDir, task, embedSvc, { limit: 3 });
       matchingSpecs = specResults.map(r => ({
@@ -335,7 +344,7 @@ export async function handleOrient(
 
   // ── Inline spec purpose from RAG manifest ─────────────────────────────────
   let inlineSpecs: InlineSpec[] | undefined;
-  if (specDomains.length > 0) {
+  if (!lean && specDomains.length > 0) {
     try {
       const cfg = await readOpenLoreConfig(absDir);
       const openspecRelPath = cfg?.openspecPath ?? OPENSPEC_DIR;
@@ -385,7 +394,7 @@ export async function handleOrient(
     affectedDomains: string[];
   }
   let pendingDecisions: DecisionSummary[] | undefined;
-  try {
+  if (!lean) try {
     const { loadDecisionStore, INACTIVE_STATUSES } = await import('../../decisions/store.js');
     const store = await loadDecisionStore(absDir);
     const relevantDomainSet = new Set(specDomains.map((s) => s.domain));
@@ -419,7 +428,7 @@ export async function handleOrient(
   let governingDecisions:
     | Array<{ id: string; title: string; status: string; governs: string[] }>
     | undefined;
-  try {
+  if (!lean) try {
     const es = llmCtx?.edgeStore;
     if (es && relevantFiles.length > 0) {
       const govs = es.getDecisionsForFiles(relevantFiles);
@@ -442,7 +451,7 @@ export async function handleOrient(
   let provenance:
     | Array<{ file: string; lastAuthor: string; lastDate?: string; lastPr?: number; lastPrTitle?: string }>
     | undefined;
-  try {
+  if (!lean) try {
     const es = llmCtx?.edgeStore;
     if (es && relevantFiles.length > 0) {
       const records = es.getProvenanceForFiles(relevantFiles);
@@ -470,7 +479,7 @@ export async function handleOrient(
   let changeCoupling:
     | Array<{ file: string; volatility: 'high' | 'medium' | 'low'; changes: number; frequentlyChangesWith: Array<{ file: string; confidence: number }> }>
     | undefined;
-  try {
+  if (!lean) try {
     const es = llmCtx?.edgeStore;
     if (es && relevantFiles.length > 0) {
       const { volatilityLevel } = await import('../../provenance/change-coupling.js');
@@ -493,7 +502,7 @@ export async function handleOrient(
   // Only when the repo declares rules AND a relevant file participates in a
   // violation. Fully omitted otherwise — inert by default.
   let architectureViolations: Array<{ from: string; to: string; kind: string; reason: string }> | undefined;
-  try {
+  if (!lean) try {
     const rules = await loadArchitectureRules(absDir);
     if (rules.rules.length > 0 && relevantFiles.length > 0) {
       const depRaw = await readFile(join(outputDir, 'dependency-graph.json'), 'utf-8').catch(() => null);


### PR DESCRIPTION
Builds **Spec 28**, closing the one open question Spec 25 §7 flagged as *"biggest unknown, biggest upside"*: **can MCP tool schemas be deferred/lazy** the way this runtime defers its own tools, erasing the ~11.8k-token `tools/list` prefix that Spec 27 proved is part of the structural shallow-task cost?

### The honest finding (answered by measurement, not guess)
- **MCP has no server-driven lazy-schema mechanism** — `tools/list` always returns every tool's full `inputSchema`. The server cannot advertise names-only and defer.
- **But the dominant client (Claude Code) already defers MCP tool schemas client-side** — verified live this session (OpenLore's tools arrive name-only, schemas loaded on demand). So the prefix isn't paid up front *where it matters*, and the upside is real but **client-controlled** — not OpenLore's to improve further.
- The server-side **lossless byte-lever is only ~2%** — the payload is dominated by irreducible per-tool schema structure + the selection text an agent needs to pick the right tool.

### What ships (deterministic, zero selection-quality risk)
- **Lossless trim:** the `directory` input's 38-char description (repeated on all 50 tools) → one short shared `DIR_DESC` constant; dropped 3 pure capability-boast clauses that carry no tool-selection signal (`openWorldHint` already encodes local-vs-LLM).
  - `tools/list`: **47,037 → 46,118 B (−2.0%, ~229 tok)**; navigation preset **8,121 → 8,002 B (−1.5%)**.
- **Payload-budget regression guard** (the durable deliverable): bounds full (<48 KB) and navigation (<8.5 KB) payloads + a lossless-dedup invariant. A new tool (~900 B) or re-bloated boilerplate now fails the suite — adding to the cached prefix is a conscious budget bump, not silent drift.

### Deliberately NOT done (explored, recorded)
- **Meta-dispatcher tool** — collapsing the long tail behind one action tool trades away per-tool validation, Spec 11 annotations, and a discoverable selection surface (reintroduces wrong-tool round-trips). Net negative.
- **Forcing `navigation` as install default** — re-litigated, again rejected (Spec 25 Phase B): hides the governance tools the decision gate needs.

### Verification
- `npx vitest run src` → **144 files / 3117 tests pass** (2 skipped); `tsc` clean.
- New `tools/list payload budget (spec-28)` guard tests added and green.
- Architectural decision `d54af0d3` recorded, approved, and synced into `openspec/specs/cli/spec.md`.

Spec doc: `docs/specs/openlore-spec-28-lean-tool-surface.md`. Honesty contract (Spec 25) applies — the published numbers are the measured numbers, including a win that turns out small and a headline lever that was never the server's to pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)