### PR TITLE
Docs current for spec 27/28 + release v2.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ The full surface is 50 tools, but day-to-day work needs a handful. Reach for the
 | Situation | Tool |
 |-----------|------|
 | Starting any task | `orient(task)` — functions, callers, specs, insertion points in one call |
+| Shallow "who calls X / where is Y?" | `orient(task, lean:true)` (CLI `orient --lean`) — navigation core only, ~40% smaller and skips the enrichment compute (Spec 27) |
 | "Which file/function handles X?" | `search_code` |
 | Call topology across many files | `get_subgraph` / `analyze_impact` |
 | "What's the blast radius if I change this?" | `analyze_impact` — risk score + up/downstream chain + **governing decisions** |
@@ -413,6 +414,8 @@ OpenLore dogfoods its own decision system. These ADRs were recorded with `record
 | **BM25 keyword retrieval is the zero-network floor** | `orient`/`search_code` work with no API key or embedding server; dense embeddings are an optional upgrade, never a requirement | `analyzer` spec · Spec 06 |
 | **SCIP is a one-way export, not a round-trip format** | The SQLite graph stays canonical; SCIP exports only the subset it can model, avoiding a lossy bidirectional contract | `cli` spec · `src/cli/export/scip.ts` |
 | **MCP exposes a curated `navigation` preset, not all 50 tools** | A lean graph-traversal surface is what wins the Spec 14 agent benchmark; the full set stays available opt-in | `cli` spec · Spec 14 |
+| **The `tools/list` prefix is trimmed losslessly + bounded by a guard, not byte-shaved** | Spec 28 measured it: MCP has no server-side schema deferral and the lossless byte-lever is ~2%; the real levers are the client (deferred schemas) and tool count, so we trim safely, guard against bloat, and report the limit | `cli` spec · Spec 28 |
+| **Lean orientation skips enrichment compute, not just its payload** | `orient --lean` returns the navigation core for shallow lookups and skips the work behind the dropped blocks (extra embedding search, manifest/git reads); the rich default is unchanged | `cli` spec · Spec 27 |
 | **Decision consolidation is serialized with a cross-process file lock** | Concurrent `record_decision` calls were losing drafts; a lock makes consolidation safe and every commit instant | `cli` spec · Spec 15 |
 
 This table is not aspirational documentation — it is the live decision log the pre-commit gate enforces and Spec 16 makes queryable. See [docs/governance-dogfooding.md](docs/governance-dogfooding.md).

--- a/docs/agent-setup.md
+++ b/docs/agent-setup.md
@@ -100,7 +100,7 @@ Wire the generated digest into your agent's context:
 
 **Claude Code — MCP config (token-efficient two-server setup)**
 
-MCP clients load all tool schemas at session start. With 45 tools, this costs ~8–77k tokens before any work begins. Claude Code supports `alwaysLoad: false` (deferred, default) — tools load only when the agent searches for them via Tool Search.
+MCP clients load all tool schemas at session start. With 50 tools, this costs ~11.5k tokens of `tools/list` before any work begins (Spec 28 measured it; the lossless server-side trim is only ~2%, so the real lever is deferral). Claude Code supports `alwaysLoad: false` (deferred, default) — tools load only when the agent searches for them via Tool Search.
 
 The recommended setup uses two server entries: one always-visible core server and one deferred full server:
 
@@ -124,7 +124,7 @@ The recommended setup uses two server entries: one always-visible core server an
 ```
 
 - **`openlore-core`** exposes 5 tools always visible in context (~500 tokens): `orient`, `search_code`, `record_decision`, `detect_changes`, `check_spec_drift`. These are the tools most likely to be called at session start.
-- **`openlore`** exposes all 45 tools deferred — loaded on demand when the agent uses Tool Search (e.g. "find tool for BFS graph traversal").
+- **`openlore`** exposes all 50 tools deferred — loaded on demand when the agent uses Tool Search (e.g. "find tool for BFS graph traversal").
 
 If you only need one server entry, use `alwaysLoad: false` (the default) with the standard `openlore mcp` command — all tools are deferred and searchable via Tool Search.
 

--- a/docs/governance-dogfooding.md
+++ b/docs/governance-dogfooding.md
@@ -27,7 +27,7 @@ evidence is the synced spec sections + ADRs.
 | EdgeStore uses SCHEMA_VERSION rebuild-on-bump instead of migrations | component | `openspec/specs/analyzer/spec.md` |
 | BM25 keyword retrieval is the zero-network floor; embeddings optional | component | `openspec/specs/analyzer/spec.md` |
 | North star: a deterministic structural context substrate for agents | system | `openspec/specs/overview/spec.md` + `openspec/decisions/adr-0001-*.md` |
-| MCP exposes a curated navigation tool preset, not all 45 tools (spec 14) | component | `openspec/specs/cli/spec.md` |
+| MCP exposes a curated navigation tool preset, not all 50 tools (spec 14) | component | `openspec/specs/cli/spec.md` |
 
 ¹ recorded as `cross-domain` but the consolidator re-scoped it to `component`.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -32,9 +32,11 @@ or for local development:
 
 **Cline / Roo Code / Kilocode** -- add the same block under `mcpServers` in the MCP settings JSON of your editor.
 
-### Recommended lean surface (cost, Spec 25 P1)
+### Recommended lean surface (cost, Spec 25 P1 · Spec 28)
 
-MCP clients send every tool's JSON Schema on every request, so tools the agent never calls are pure per-request overhead. The Spec 14 benchmark showed this is what made openlore *lose* on small repos — and that a lean, navigation-focused surface flips it to a win (see the [Value Scorecard](../README.md#value-scorecard--does-it-pay-for-itself)). Two ways to get the lean surface, in order of preference:
+MCP clients send every tool's JSON Schema on every request, so tools the agent never calls are pure per-request overhead. The full surface is **50 tools / ~46 KB / ~11.5k tokens** of `tools/list`. The Spec 14 benchmark showed this prefix is what made openlore *lose* on small repos — and that a lean, navigation-focused surface flips it to a win (see the [Value Scorecard](../README.md#value-scorecard--does-it-pay-for-itself)).
+
+**Spec 28 measured how far the *server* can shrink that prefix, honestly:** MCP has no server-driven lazy-schema mechanism (`tools/list` always returns full schemas), and the lossless server-side byte-lever is only ~2% — the payload is dominated by irreducible per-tool schema structure plus the selection text an agent needs to pick a tool. So the real lever is the *client* (deferred schemas, below) and *tool count* (`--preset`), not byte-shaving. The surface has been trimmed losslessly anyway (shared param descriptions, no boilerplate) and is now **bounded by a regression guard** so it can't silently bloat. Two ways to get the lean surface, in order of preference:
 
 1. **Deferred schemas (best — keeps every tool available).** If your client supports it (Claude Code: `alwaysLoad: false`), advertise tool *names* cheaply and load a tool's schema only when it's used. See the [two-server setup](agent-setup.md) — you keep all 50 tools without paying their schema cost up front.
 2. **`--preset navigation` (server-side, navigation-only).** Add `"args": ["mcp", "--preset", "navigation"]` for a 7-tool graph-traversal surface (orient, search_code, get_subgraph, trace_execution_path, analyze_impact, suggest_insertion_points, get_function_skeleton). This is exactly the configuration the benchmark measured (−7%→−21% cost, −26% round-trips on deep traces). Note it omits the governance tools (`record_decision`, `check_architecture`, inventories), so prefer option 1 if you use the decision gate or architecture checks during a session.
@@ -208,12 +210,18 @@ Most tools run on **pure static analysis** — no LLM quota consumed. Exceptions
 
 **`orient`**
 ```
-directory  string   Absolute path to the project directory
-task       string   Natural-language description of the task, e.g. "add rate limiting to the API"
-limit      number   Max relevant functions to return (default: 5, max: 20)
+directory    string   Absolute path to the project directory
+task         string   Natural-language description of the task, e.g. "add rate limiting to the API"
+limit        number   Max relevant functions to return (default: 5, max: 20)
+tokenBudget  number   Optional: cap relevantFunctions to ~this many tokens (Spec 25 P4) —
+                      highest-scored kept, exact duplicates collapsed; each carries an `expand` handle
+lean         boolean  Optional: return only the navigation core (relevantFunctions + callPaths +
+                      specDomains + suggestedTools), dropping enrichment (Spec 27). See below.
 ```
 
 Response includes `suggestedTools: string[]` — a ranked list of openlore tool names relevant to the task, derived from hub presence, spec domains, and task keywords. No extra I/O. Use this on clients without Tool Search (Cline, Cursor, OpenCode) to know which tools to call next without enumerating all 50.
+
+**Lean mode (Spec 27).** `lean: true` (CLI: `orient --lean`) returns only the navigation core for shallow "who calls X / where is Y" lookups — ~40% smaller than the rich default on this repo. Everything dropped (insertion points, provenance, change-coupling, inline specs, matching specs, decisions, architecture violations) is one `expand` handle or one dedicated tool call away, so it trims bytes per turn without forcing a follow-up round-trip. Lean is also **compute-lean** (Spec 27 P5): it skips the work behind those blocks — the extra spec-embedding search, manifest/spec-file reads, the decision-store load, and the git-derived joins — so the shallow path is faster, not only smaller. The rich default is unchanged; omit `lean` when you need specs, decisions, or insertion points.
 
 **`analyze_codebase`**
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlore",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlore",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "MIT",
       "dependencies": {
         "@inquirer/prompts": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlore",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Reverse-engineer OpenSpec specifications from existing codebases",
   "type": "module",
   "main": "dist/api/index.js",


### PR DESCRIPTION
Documentation refresh for the already-merged **spec 27** (lean orient compute-skip, [#124](https://github.com/clay-good/OpenLore/pull/124)) and **spec 28** (lean MCP tool surface) work, plus the **v2.0.9** version bump that the release tag guard requires.

### Docs brought current
- **README** — agent cheat-sheet gains the `orient --lean` row; the architecture-decisions table records spec 28's lossless-trim + budget-guard finding and spec 27's compute-lean deepening.
- **docs/mcp-tools.md** — `orient` params now document `lean` + `tokenBudget`; the "Recommended lean surface" section folds in spec 28's honest finding (MCP has no server-side lazy schemas; the lossless byte-lever is ~2%; the prefix is now bounded by a regression guard, so deferral + tool count are the real levers).
- **docs/agent-setup.md**, **docs/governance-dogfooding.md** — stale "45 tools" → "50 tools" (the current surface).
- Left untouched on purpose: the historical `docs/specs/*.md` (point-in-time records) and `docs/AGENT-BENCHMARKS.md`'s "~45" (accurate to when Rounds 1–2 were measured; honesty-contract pinned).

### Version
`package.json` + `package-lock.json`: 2.0.8 → 2.0.9. After merge, tagging `v2.0.9` on main triggers the release workflow (GitHub Release + npm publish via OIDC).

### Deep test pass (local, on the merged main)
- lint clean · typecheck clean · `npm audit --audit-level=high` → **0 vulnerabilities**
- build OK · unit **3148 pass / 2 skip** · integration/e2e **111 pass**
- `openlore doctor` all green · `openlore drift` in sync · `orient --lean` smoke OK on this repo
- honesty-contract test green (README figures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)