### PR TITLE
feat(serve): warm openlore daemon + Pi extension

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -213,7 +213,7 @@ openlore serve --stop                   # stop the daemon serving this directory
 | `-d, --directory <path>` | Project root to serve; discovery file written here (default: cwd) |
 | `-p, --port <number>` | Port to bind (default: ephemeral free port) |
 | `--host <host>` | Host to bind (default: `127.0.0.1`) |
-| `--preset <name>` | Tool surface: `minimal`, `navigation` (default), or `all` |
+| `--preset <name>` | Advisory surface reported by `/health`: `minimal`, `navigation` (default), or `all`. The daemon dispatches any known tool regardless; clients curate their own surface |
 | `--token <token>` | Require this token as the `x-openlore-token` header (default: `$OPENLORE_SERVE_TOKEN`) |
 | `--no-watch` | Disable the freshness watcher + re-analyze lane |
 | `--stop` | Stop a running daemon for `--directory` and exit |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -18,8 +18,9 @@
 | `openlore decisions --install-hook` | Install the pre-commit hook that gates commits until decisions are reviewed | No |
 | `openlore run` | Full pipeline: init, analyze, generate | Yes |
 | `openlore view` | Launch interactive graph & spec viewer in the browser | No |
-| `openlore setup` | Install workflow skills into the project (Vibe, Cline, GSD, BMAD) | No |
+| `openlore setup` | Install workflow skills into the project (Vibe, Cline, GSD, BMAD, Pi) | No |
 | `openlore mcp` | Start MCP server (stdio, for Cline / Claude Code) | No |
+| `openlore serve` | Start a warm local HTTP daemon exposing tools (loopback, for Pi / editors) | No |
 | `openlore doctor` | Check environment and configuration for common issues | No |
 | `openlore refresh-stories` | Refresh story files with latest structural context after each commit | No |
 
@@ -188,6 +189,51 @@ Checks performed:
 | Disk space | Warns < 500 MB, fails < 200 MB |
 
 Run `openlore doctor` whenever setup instructions aren't working — it tells you exactly what to fix and how.
+
+---
+
+## Serve (warm daemon)
+
+`openlore serve` runs a long-lived loopback HTTP daemon that keeps openlore's
+caches warm across calls and, with `--watch` (default), keeps the analysis
+continuously fresh — signatures/vector live, plus a debounced full call-graph
+re-analyze after each edit burst. It exposes the same tools as the MCP server
+over plain HTTP so non-MCP clients (e.g. the [Pi](https://pi.dev) extension in
+`examples/pi/`) can hit them with `fetch` — no JSON-RPC, no subprocess-per-call.
+
+```bash
+openlore serve                          # navigation preset, ephemeral port, watch on
+openlore serve --preset all --port 7077 # all ~45 tools on a fixed port
+openlore serve --no-watch               # transport only, no freshness lane
+openlore serve --stop                   # stop the daemon serving this directory
+```
+
+| Option | Description |
+|--------|-------------|
+| `-d, --directory <path>` | Project root to serve; discovery file written here (default: cwd) |
+| `-p, --port <number>` | Port to bind (default: ephemeral free port) |
+| `--host <host>` | Host to bind (default: `127.0.0.1`) |
+| `--preset <name>` | Tool surface: `minimal`, `navigation` (default), or `all` |
+| `--token <token>` | Require this token as the `x-openlore-token` header (default: `$OPENLORE_SERVE_TOKEN`) |
+| `--no-watch` | Disable the freshness watcher + re-analyze lane |
+| `--stop` | Stop a running daemon for `--directory` and exit |
+
+Endpoints (loopback only): `GET /health`, `POST /tool/:name` with body
+`{ "directory": "...", "args": { ... } }`. Discovery: the daemon writes
+`.openlore/serve.json` `{ port, pid, host, token? }` (removed on clean shutdown).
+
+```bash
+PORT=$(jq .port .openlore/serve.json)
+curl 127.0.0.1:$PORT/health
+curl -XPOST 127.0.0.1:$PORT/tool/orient -d '{"args":{"task":"add rate limiting"}}'
+```
+
+### Pi integration
+
+`openlore setup --tools pi` installs the Pi extension to `.pi/extensions/openlore.ts`
+(add `--global` for `~/.pi/agent/extensions/`). It auto-starts and talks to the
+serve daemon, injecting structural context and exposing the navigation tools.
+See `examples/pi/README.md`.
 
 ---
 

--- a/examples/pi/README.md
+++ b/examples/pi/README.md
@@ -44,7 +44,7 @@ Manual: copy `openlore.ts` into either location.
 ## How it works
 
 On first use the extension looks for `.openlore/serve.json`; if no healthy daemon
-is announced it spawns `openlore serve --watch` detached and waits for `/health`.
+is announced it spawns `openlore serve` detached and waits for `/health`.
 The daemon:
 
 - serves the `navigation` tool preset over `127.0.0.1`,

--- a/examples/pi/README.md
+++ b/examples/pi/README.md
@@ -1,0 +1,70 @@
+# openlore × Pi
+
+A [Pi](https://pi.dev) extension that brings openlore's deterministic structural
+context into Pi — built for local models (Qwen, Gemma, …) that are strong at
+using injected context but weaker at tool-calling.
+
+It does **not** use MCP. It talks to a warm `openlore serve` HTTP daemon over
+loopback, so tool calls hit warm caches and the analysis stays continuously
+fresh while you edit.
+
+## What you get
+
+- **Context injection** (no tool call needed): each session starts grounded with
+  the architecture digest (`CODEBASE.md`), the spec-domain index, and a
+  task-specific `orient` on your first message.
+- **Native tools**: the navigation surface as Pi tools —
+  `openlore_orient`, `openlore_search_code`, `openlore_get_subgraph`,
+  `openlore_trace_execution_path`, `openlore_analyze_impact`,
+  `openlore_suggest_insertion_points`, `openlore_get_function_skeleton`.
+
+## Prerequisites
+
+```bash
+npm i -g openlore         # `openlore` must be on PATH
+cd your-project
+openlore analyze          # build the structural index at least once
+```
+
+## Install
+
+Automatic:
+
+```bash
+openlore setup --tools pi            # → .pi/extensions/openlore.ts (this project)
+openlore setup --tools pi --global   # → ~/.pi/agent/extensions/openlore.ts (all projects)
+```
+
+Manual: copy `openlore.ts` into either location.
+
+> The extension imports `@earendil-works/*` types per the Pi docs. If your
+> installed Pi version exposes different paths for `Type` / `StringEnum` /
+> `truncateTail`, adjust the imports at the top of `openlore.ts`.
+
+## How it works
+
+On first use the extension looks for `.openlore/serve.json`; if no healthy daemon
+is announced it spawns `openlore serve --watch` detached and waits for `/health`.
+The daemon:
+
+- serves the `navigation` tool preset over `127.0.0.1`,
+- keeps signatures/vector fresh live, and
+- re-analyzes the call graph (debounced) after each edit burst — so what the
+  model sees never silently diverges from the code.
+
+The extension never kills a daemon it didn't start; it may be serving other
+clients (another Pi session, an editor).
+
+## Verify
+
+```bash
+# daemon is reachable
+curl 127.0.0.1:$(jq .port .openlore/serve.json)/health
+
+# a tool round-trips
+curl -XPOST 127.0.0.1:$(jq .port .openlore/serve.json)/tool/orient \
+  -d '{"args":{"task":"add rate limiting"}}'
+```
+
+Then run Pi in the project and confirm the session opens with openlore context
+and that `openlore_orient` is callable.

--- a/examples/pi/README.md
+++ b/examples/pi/README.md
@@ -37,9 +37,9 @@ openlore setup --tools pi --global   # → ~/.pi/agent/extensions/openlore.ts (a
 
 Manual: copy `openlore.ts` into either location.
 
-> The extension imports `@earendil-works/*` types per the Pi docs. If your
-> installed Pi version exposes different paths for `Type` / `StringEnum` /
-> `truncateTail`, adjust the imports at the top of `openlore.ts`.
+> Imports are verified against pi 0.78 (`Type` from `typebox`, `StringEnum` from
+> `@earendil-works/pi-ai`, extension types from `@earendil-works/pi-coding-agent`).
+> If a future Pi version moves these, adjust the imports at the top of `openlore.ts`.
 
 ## How it works
 

--- a/examples/pi/openlore.ts
+++ b/examples/pi/openlore.ts
@@ -87,7 +87,7 @@ async function health(desc: ServeDescriptor): Promise<boolean> {
 
 /**
  * Return a live daemon for `cwd`: reuse an announced one if healthy, otherwise
- * spawn `openlore serve --watch` detached and poll until /health is ready.
+ * spawn `openlore serve` detached and poll until /health is ready.
  * Returns null if no daemon could be brought up (caller degrades gracefully).
  * Never kills a daemon it didn't start — it may serve other clients.
  */
@@ -97,9 +97,10 @@ async function ensureDaemon(cwd: string): Promise<Daemon | null> {
     return { baseUrl: `http://${existing.host}:${existing.port}`, token: existing.token };
   }
 
-  // Spawn detached so the daemon outlives this pi session.
+  // Spawn detached so the daemon outlives this pi session. No --watch flag:
+  // watch is on by default (only --no-watch disables it).
   try {
-    const child = spawn('openlore', ['serve', '--watch', '--directory', cwd], {
+    const child = spawn('openlore', ['serve', '--directory', cwd], {
       detached: true,
       stdio: 'ignore',
     });

--- a/examples/pi/openlore.ts
+++ b/examples/pi/openlore.ts
@@ -1,0 +1,342 @@
+/**
+ * openlore.ts — Pi extension (pi.dev)
+ *
+ * Brings openlore's deterministic structural context into Pi for local models
+ * (Qwen, Gemma, …) without MCP. It talks to a warm `openlore serve` HTTP daemon
+ * over loopback, so:
+ *   • tool calls hit warm caches (orient ~8ms vs ~100ms cold),
+ *   • the daemon's watcher keeps analysis continuously fresh between commits.
+ *
+ * Two halves:
+ *   C — context injection (before_agent_start): the model starts grounded with
+ *       the architecture digest + spec index + a task-specific orient, so weak
+ *       tool-callers benefit even if they never call a tool.
+ *   B — native tools (registerTool): the navigation surface for on-demand
+ *       "how does X reach Y" — each shells to the daemon via fetch.
+ *
+ * Install: copy to ~/.pi/agent/extensions/openlore.ts (global) or
+ * <project>/.pi/extensions/openlore.ts, or run `openlore setup --tools pi`.
+ *
+ * Requires `openlore` on PATH and `openlore analyze` to have been run once.
+ *
+ * NOTE: imports follow the pi docs; adjust the @earendil-works/* paths to match
+ * your installed Pi version if they differ.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { Type, truncateTail } from '@earendil-works/pi-coding-agent';
+import { StringEnum } from '@earendil-works/pi-ai';
+
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// ── Daemon discovery + lifecycle ─────────────────────────────────────────────
+
+interface ServeDescriptor {
+  port: number;
+  pid: number;
+  host: string;
+  token?: string;
+  version: string;
+}
+
+interface Daemon {
+  baseUrl: string;
+  token?: string;
+}
+
+const HEALTH_TIMEOUT_MS = 8000;
+const HEALTH_POLL_MS = 150;
+const RESULT_MAX = 50_000; // truncate tool output to keep small-model context lean
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Read <cwd>/.openlore/serve.json if a daemon previously announced itself. */
+async function readDescriptor(cwd: string): Promise<ServeDescriptor | null> {
+  try {
+    const raw = await readFile(join(cwd, '.openlore', 'serve.json'), 'utf-8');
+    return JSON.parse(raw) as ServeDescriptor;
+  } catch {
+    return null;
+  }
+}
+
+/** GET /health — confirms a descriptor points at a live daemon. */
+async function health(desc: ServeDescriptor): Promise<boolean> {
+  try {
+    const res = await fetch(`http://${desc.host}:${desc.port}/health`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return a live daemon for `cwd`: reuse an announced one if healthy, otherwise
+ * spawn `openlore serve --watch` detached and poll until /health is ready.
+ * Returns null if no daemon could be brought up (caller degrades gracefully).
+ * Never kills a daemon it didn't start — it may serve other clients.
+ */
+async function ensureDaemon(cwd: string): Promise<Daemon | null> {
+  const existing = await readDescriptor(cwd);
+  if (existing && (await health(existing))) {
+    return { baseUrl: `http://${existing.host}:${existing.port}`, token: existing.token };
+  }
+
+  // Spawn detached so the daemon outlives this pi session.
+  try {
+    const child = spawn('openlore', ['serve', '--watch', '--directory', cwd], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  } catch {
+    return null; // openlore not on PATH
+  }
+
+  const deadline = Date.now() + HEALTH_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sleep(HEALTH_POLL_MS);
+    const desc = await readDescriptor(cwd);
+    if (desc && (await health(desc))) {
+      return { baseUrl: `http://${desc.host}:${desc.port}`, token: desc.token };
+    }
+  }
+  return null;
+}
+
+/** POST /tool/:name → parsed JSON, or { error } on any transport failure. */
+async function callTool(
+  daemon: Daemon,
+  name: string,
+  args: Record<string, unknown>,
+  cwd: string,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (daemon.token) headers['x-openlore-token'] = daemon.token;
+  try {
+    const res = await fetch(`${daemon.baseUrl}/tool/${encodeURIComponent(name)}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ directory: cwd, args }),
+      signal,
+    });
+    const body = await res.json().catch(() => ({ error: `non-JSON response (${res.status})` }));
+    if (!res.ok) return { error: (body as { error?: string }).error ?? `HTTP ${res.status}` };
+    return body;
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// ── Context injection helpers (file-based, no subprocess) ─────────────────────
+
+/** Architecture digest written by `openlore analyze`. */
+async function readDigest(cwd: string): Promise<string> {
+  try {
+    return await readFile(join(cwd, '.openlore', 'analysis', 'CODEBASE.md'), 'utf-8');
+  } catch {
+    return '';
+  }
+}
+
+/** Compact one-line-per-domain spec index from openspec/specs/. */
+async function readSpecIndex(cwd: string): Promise<string> {
+  try {
+    const { readdir } = await import('node:fs/promises');
+    const specsDir = join(cwd, 'openspec', 'specs');
+    const dirs = (await readdir(specsDir, { withFileTypes: true }))
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+    if (dirs.length === 0) return '';
+    return ['## openlore spec domains', ...dirs.map((d) => `- ${d}`)].join('\n');
+  } catch {
+    return '';
+  }
+}
+
+// ── Tool surface (navigation preset, tuned terse for small models) ────────────
+
+interface ToolSpec {
+  name: string;
+  label: string;
+  description: string;
+  guideline: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  parameters: any;
+}
+
+const TOOLS: ToolSpec[] = [
+  {
+    name: 'orient',
+    label: 'openlore orient',
+    description:
+      'START HERE on any new task. Returns relevant functions, files, spec domains, ' +
+      'call neighbours, and insertion points in one call.',
+    guideline: 'Use openlore_orient FIRST on any new task before reading files.',
+    parameters: Type.Object({
+      task: Type.String({ description: 'Natural-language task description' }),
+      limit: Type.Optional(Type.Number({ description: 'Max relevant functions (default 5)' })),
+    }),
+  },
+  {
+    name: 'search_code',
+    label: 'openlore search_code',
+    description: 'Semantic + keyword search for functions by meaning or name.',
+    guideline: 'Use openlore_search_code to find where a concept lives instead of grepping.',
+    parameters: Type.Object({
+      query: Type.String({ description: 'What to find' }),
+      limit: Type.Optional(Type.Number()),
+      language: Type.Optional(Type.String()),
+    }),
+  },
+  {
+    name: 'get_subgraph',
+    label: 'openlore get_subgraph',
+    description: 'Call topology around a function (callers/callees) to a given depth.',
+    guideline: 'Use openlore_get_subgraph to see blast radius before changing a function.',
+    parameters: Type.Object({
+      functionName: Type.String(),
+      direction: Type.Optional(StringEnum(['downstream', 'upstream', 'both'] as const)),
+      maxDepth: Type.Optional(Type.Number()),
+    }),
+  },
+  {
+    name: 'trace_execution_path',
+    label: 'openlore trace_execution_path',
+    description: 'Find call paths from an entry function to a target function.',
+    guideline: 'Use openlore_trace_execution_path to answer "how does X reach Y".',
+    parameters: Type.Object({
+      entryFunction: Type.String(),
+      targetFunction: Type.String(),
+      maxDepth: Type.Optional(Type.Number()),
+    }),
+  },
+  {
+    name: 'analyze_impact',
+    label: 'openlore analyze_impact',
+    description: 'Blast radius of changing a symbol (transitive dependents).',
+    guideline: 'Use openlore_analyze_impact before editing a shared/hub symbol.',
+    parameters: Type.Object({
+      symbol: Type.String(),
+      depth: Type.Optional(Type.Number()),
+    }),
+  },
+  {
+    name: 'suggest_insertion_points',
+    label: 'openlore suggest_insertion_points',
+    description: 'Where to add a feature — ranked file/function insertion candidates.',
+    guideline: 'Use openlore_suggest_insertion_points when planning where new code goes.',
+    parameters: Type.Object({
+      description: Type.String(),
+      limit: Type.Optional(Type.Number()),
+    }),
+  },
+  {
+    name: 'get_function_skeleton',
+    label: 'openlore get_function_skeleton',
+    description: 'Compact skeleton of a file: signatures + control flow, noise stripped.',
+    guideline: 'Use openlore_get_function_skeleton to read a file cheaply before opening it.',
+    parameters: Type.Object({
+      filePath: Type.String(),
+    }),
+  },
+];
+
+// ── Extension entry point ────────────────────────────────────────────────────
+
+export default function openlore(pi: ExtensionAPI): void {
+  // One daemon per project cwd for this pi process.
+  const daemons = new Map<string, Daemon | null>();
+  // Inject the heavy session primer only once per session.
+  const primed = new Set<string>();
+
+  async function getDaemon(cwd: string): Promise<Daemon | null> {
+    if (!daemons.has(cwd)) daemons.set(cwd, await ensureDaemon(cwd));
+    return daemons.get(cwd) ?? null;
+  }
+
+  // ── B: native tools ──
+  for (const tool of TOOLS) {
+    pi.registerTool({
+      name: `openlore_${tool.name}`,
+      label: tool.label,
+      description: tool.description,
+      promptSnippet: tool.description,
+      promptGuidelines: [tool.guideline],
+      parameters: tool.parameters,
+      async execute(_id: string, params: Record<string, unknown>, signal: AbortSignal, _onUpdate: unknown, ctx: ExtensionContext) {
+        const cwd = ctx.cwd;
+        const daemon = await getDaemon(cwd);
+        if (!daemon) {
+          return {
+            content: [{ type: 'text', text: 'openlore daemon unavailable — run `openlore analyze` then retry, or check `openlore` is on PATH.' }],
+          };
+        }
+        const result = await callTool(daemon, tool.name, params, cwd, signal);
+        const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+        return { content: [{ type: 'text', text: truncateTail(text, RESULT_MAX) }], details: result };
+      },
+    });
+  }
+
+  // ── Lifecycle: warm the daemon at session start (best-effort) ──
+  pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
+    await getDaemon(ctx.cwd);
+  });
+
+  // ── C: context injection on the first turn ──
+  pi.on('before_agent_start', async (event: { systemPrompt: string }, ctx: ExtensionContext) => {
+    const cwd = ctx.cwd;
+    if (primed.has(cwd)) return undefined;
+    primed.add(cwd);
+
+    const blocks: string[] = [];
+
+    const digest = await readDigest(cwd);
+    if (digest) blocks.push('# Codebase architecture (openlore)\n\n' + truncateTail(digest, 8000));
+
+    const specIndex = await readSpecIndex(cwd);
+    if (specIndex) blocks.push(specIndex);
+
+    // Task-grounded primer: orient on the user's first message.
+    const firstUserMsg = extractFirstUserText(event);
+    const daemon = await getDaemon(cwd);
+    if (daemon && firstUserMsg) {
+      const oriented = await callTool(daemon, 'orient', { task: firstUserMsg }, cwd);
+      if (oriented && typeof oriented === 'object' && !('error' in (oriented as object))) {
+        blocks.push('# openlore orientation for this task\n\n' + truncateTail(JSON.stringify(oriented, null, 2), 6000));
+      }
+    }
+
+    if (blocks.length === 0) {
+      // No analysis yet — nudge once, never block the turn.
+      return {
+        systemPrompt:
+          event.systemPrompt +
+          '\n\n[openlore: no analysis found — run `openlore analyze` to enable structural context + tools.]',
+      };
+    }
+
+    return { systemPrompt: event.systemPrompt + '\n\n' + blocks.join('\n\n') };
+  });
+}
+
+/** Best-effort pull of the first user message text from the before_agent_start event. */
+function extractFirstUserText(event: unknown): string {
+  const e = event as { messages?: Array<{ role?: string; content?: unknown }> };
+  const msg = e.messages?.find((m) => m.role === 'user');
+  if (!msg) return '';
+  if (typeof msg.content === 'string') return msg.content;
+  if (Array.isArray(msg.content)) {
+    return msg.content
+      .map((p: unknown) => (typeof p === 'object' && p && 'text' in p ? String((p as { text: unknown }).text) : ''))
+      .join(' ')
+      .trim();
+  }
+  return '';
+}

--- a/examples/pi/openlore.ts
+++ b/examples/pi/openlore.ts
@@ -62,13 +62,19 @@ async function readDescriptor(cwd: string): Promise<ServeDescriptor | null> {
   }
 }
 
-/** GET /health — confirms a descriptor points at a live daemon. */
+/**
+ * GET /health — confirms a descriptor points at a live openlore daemon, not a
+ * stale serve.json or a recycled port now owned by an unrelated server. Checks
+ * the `ok: true` response shape, not just a 200.
+ */
 async function health(desc: ServeDescriptor): Promise<boolean> {
   try {
     const res = await fetch(`http://${desc.host}:${desc.port}/health`, {
       signal: AbortSignal.timeout(1000),
     });
-    return res.ok;
+    if (!res.ok) return false;
+    const body = (await res.json().catch(() => null)) as { ok?: boolean } | null;
+    return body?.ok === true;
   } catch {
     return false;
   }

--- a/examples/pi/openlore.ts
+++ b/examples/pi/openlore.ts
@@ -19,17 +19,22 @@
  *
  * Requires `openlore` on PATH and `openlore analyze` to have been run once.
  *
- * NOTE: imports follow the pi docs; adjust the @earendil-works/* paths to match
- * your installed Pi version if they differ.
+ * Imports verified against pi 0.78 (`Type` from typebox, `StringEnum` from
+ * @earendil-works/pi-ai, extension types from @earendil-works/pi-coding-agent).
  */
 
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
-import { Type, truncateTail } from '@earendil-works/pi-coding-agent';
 import { StringEnum } from '@earendil-works/pi-ai';
+import { Type } from 'typebox';
 
 import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+
+/** Trim text to a max length with a marker — keeps small-model context lean. */
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max) + `\n… (truncated, ${s.length - max} more chars)`;
+}
 
 // ── Daemon discovery + lifecycle ─────────────────────────────────────────────
 
@@ -260,6 +265,9 @@ export default function openlore(pi: ExtensionAPI): void {
   const daemons = new Map<string, Daemon | null>();
   // Inject the heavy session primer only once per session.
   const primed = new Set<string>();
+  // before_agent_start receives only `event` (no ctx in pi's API), so capture
+  // the working directory from session_start and reuse it there.
+  let sessionCwd = process.cwd();
 
   async function getDaemon(cwd: string): Promise<Daemon | null> {
     if (!daemons.has(cwd)) daemons.set(cwd, await ensureDaemon(cwd));
@@ -285,26 +293,27 @@ export default function openlore(pi: ExtensionAPI): void {
         }
         const result = await callTool(daemon, tool.name, params, cwd, signal);
         const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-        return { content: [{ type: 'text', text: truncateTail(text, RESULT_MAX) }], details: result };
+        return { content: [{ type: 'text', text: truncate(text, RESULT_MAX) }], details: result };
       },
     });
   }
 
   // ── Lifecycle: warm the daemon at session start (best-effort) ──
   pi.on('session_start', async (_event: unknown, ctx: ExtensionContext) => {
+    sessionCwd = ctx.cwd;
     await getDaemon(ctx.cwd);
   });
 
   // ── C: context injection on the first turn ──
-  pi.on('before_agent_start', async (event: { systemPrompt: string }, ctx: ExtensionContext) => {
-    const cwd = ctx.cwd;
+  pi.on('before_agent_start', async (event: { systemPrompt: string }) => {
+    const cwd = sessionCwd;
     if (primed.has(cwd)) return undefined;
     primed.add(cwd);
 
     const blocks: string[] = [];
 
     const digest = await readDigest(cwd);
-    if (digest) blocks.push('# Codebase architecture (openlore)\n\n' + truncateTail(digest, 8000));
+    if (digest) blocks.push('# Codebase architecture (openlore)\n\n' + truncate(digest, 8000));
 
     const specIndex = await readSpecIndex(cwd);
     if (specIndex) blocks.push(specIndex);
@@ -315,7 +324,7 @@ export default function openlore(pi: ExtensionAPI): void {
     if (daemon && firstUserMsg) {
       const oriented = await callTool(daemon, 'orient', { task: firstUserMsg }, cwd);
       if (oriented && typeof oriented === 'object' && !('error' in (oriented as object))) {
-        blocks.push('# openlore orientation for this task\n\n' + truncateTail(JSON.stringify(oriented, null, 2), 6000));
+        blocks.push('# openlore orientation for this task\n\n' + truncate(JSON.stringify(oriented, null, 2), 6000));
       }
     }
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -44,7 +44,7 @@ import { sanitizeMcpError, validateDirectory } from '../../core/services/mcp-han
 import { createTracker, updateTracker, getFreshnessSignal } from '../../core/services/mcp-handlers/epistemic-lease.js';
 import type { EpistemicTracker } from '../../core/services/mcp-handlers/epistemic-lease.js';
 import { emit } from '../../core/services/telemetry.js';
-import { DEFAULT_DRIFT_MAX_FILES, MCP_TOOL_MAX_BYTES } from '../../constants.js';
+import { MCP_TOOL_MAX_BYTES } from '../../constants.js';
 import {
   handleGetCallGraph,
   handleGetSubgraph,
@@ -60,24 +60,8 @@ import {
   handleSearchCode,
   handleSuggestInsertionPoints,
   handleSearchSpecs,
-  handleListSpecDomains,
-  handleGetSpec,
-  handleUnifiedSearch,
 } from '../../core/services/mcp-handlers/semantic.js';
-import { handleOrient } from '../../core/services/mcp-handlers/orient.js';
-import { handleSelectTests } from '../../core/services/mcp-handlers/test-impact.js';
-import { handleFindDeadCode } from '../../core/services/mcp-handlers/reachability.js';
-import { handleStructuralDiff } from '../../core/services/mcp-handlers/structural-diff.js';
-import { handleGetChangeCoupling } from '../../core/services/mcp-handlers/change-coupling.js';
-import { handleCheckArchitecture } from '../../core/services/mcp-handlers/architecture.js';
-import { handleGenerateChangeProposal, handleAnnotateStory } from '../../core/services/mcp-handlers/change.js';
-import {
-  handleRecordDecision,
-  handleListDecisions,
-  handleApproveDecision,
-  handleRejectDecision,
-  handleSyncDecisions,
-} from '../../core/services/mcp-handlers/decisions.js';
+import { dispatchTool, UnknownToolError } from '../../core/services/tool-dispatch.js';
 import {
   handleAnalyzeCodebase,
   handleGetArchitectureOverview,
@@ -87,8 +71,6 @@ import {
   handleGetMapping,
   handleCheckSpecDrift,
   handleGetFunctionSkeleton,
-  handleGetFunctionBody,
-  handleGetDecisions,
   handleGetRouteInventory,
   handleGetMiddlewareInventory,
   handleGetSchemaInventory,
@@ -1590,10 +1572,17 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
       // pathological hang can never wedge the server. Slow tools (analysis, LLM) have
       // generous overrides in MCP_TOOL_TIMEOUT_OVERRIDES.
       await withToolTimeout((async () => {
-      if (name === 'orient') {
-        const { task, limit = 5, tokenBudget, lean } = args as { task: string; limit?: number; tokenBudget?: number; lean?: boolean };
-        result = await handleOrient(directory, task, limit, tokenBudget, lean);
-        if (result && typeof result === 'object') {
+        try {
+          result = await dispatchTool(name, args as Record<string, unknown>, directory);
+        } catch (err) {
+          if (err instanceof UnknownToolError) {
+            _unknownTool = true;
+            return;
+          }
+          throw err;
+        }
+        // orient emits navigation telemetry tied to the MCP session's agent.
+        if (name === 'orient' && result && typeof result === 'object') {
           const r = result as Record<string, unknown>;
           emit(directory, 'orient', {
             event: 'orient_call',
@@ -1604,186 +1593,6 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
             insertion_points: Array.isArray(r['insertionPoints']) ? r['insertionPoints'].length : 0,
           });
         }
-      } else if (name === 'analyze_codebase') {
-        const { directory, force = false } = args as { directory: string; force?: boolean };
-        result = await handleAnalyzeCodebase(directory, force);
-      } else if (name === 'get_architecture_overview') {
-        const { directory } = args as { directory: string };
-        result = await handleGetArchitectureOverview(directory);
-      } else if (name === 'get_refactor_report') {
-        const { directory } = args as { directory: string };
-        result = await handleGetRefactorReport(directory);
-      } else if (name === 'get_call_graph') {
-        const { directory } = args as { directory: string };
-        result = await handleGetCallGraph(directory);
-      } else if (name === 'get_signatures') {
-        const { directory, filePattern } = args as { directory: string; filePattern?: string };
-        result = await handleGetSignatures(directory, filePattern);
-      } else if (name === 'get_subgraph') {
-        const { directory, functionName, direction = 'downstream', maxDepth = 3, format = 'json' } =
-          args as { directory: string; functionName: string; direction?: 'downstream' | 'upstream' | 'both'; maxDepth?: number; format?: 'json' | 'mermaid' };
-        result = await handleGetSubgraph(directory, functionName, direction, maxDepth, format);
-      } else if (name === 'trace_execution_path') {
-        const { directory, entryFunction, targetFunction, maxDepth = 6, maxPaths = 10 } =
-          args as { directory: string; entryFunction: string; targetFunction: string; maxDepth?: number; maxPaths?: number };
-        result = await handleTraceExecutionPath(directory, entryFunction, targetFunction, maxDepth, maxPaths);
-      } else if (name === 'get_mapping') {
-        const { directory, domain, orphansOnly } = args as { directory: string; domain?: string; orphansOnly?: boolean };
-        result = await handleGetMapping(directory, domain, orphansOnly);
-      } else if (name === 'analyze_impact') {
-        const { directory, symbol, depth = 2 } =
-          args as { directory: string; symbol: string; depth?: number };
-        result = await handleAnalyzeImpact(directory, symbol, depth);
-      } else if (name === 'select_tests') {
-        const { directory, changedSymbols, diffRef, maxDepth } =
-          args as { directory: string; changedSymbols?: string[]; diffRef?: string; maxDepth?: number };
-        result = await handleSelectTests({ directory, changedSymbols, diffRef, maxDepth });
-      } else if (name === 'find_dead_code') {
-        const { directory, ifDeleted, maxResults, filePattern } =
-          args as { directory: string; ifDeleted?: string; maxResults?: number; filePattern?: string };
-        result = await handleFindDeadCode({ directory, ifDeleted, maxResults, filePattern });
-      } else if (name === 'structural_diff') {
-        const { directory, baseRef, headRef, maxResults } =
-          args as { directory: string; baseRef?: string; headRef?: string; maxResults?: number };
-        result = await handleStructuralDiff({ directory, baseRef, headRef, maxResults });
-      } else if (name === 'get_change_coupling') {
-        const { directory, file, limit } = args as { directory: string; file?: string; limit?: number };
-        result = await handleGetChangeCoupling({ directory, file, limit });
-      } else if (name === 'check_architecture') {
-        const { directory, from, to } = args as { directory: string; from?: string; to?: string };
-        result = await handleCheckArchitecture({ directory, from, to });
-      } else if (name === 'get_low_risk_refactor_candidates') {
-        const { directory, limit = 5, filePattern } =
-          args as { directory: string; limit?: number; filePattern?: string };
-        result = await handleGetLowRiskRefactorCandidates(directory, limit, filePattern);
-      } else if (name === 'get_leaf_functions') {
-        const { directory, limit = 20, filePattern, sortBy = 'fanIn' } =
-          args as { directory: string; limit?: number; filePattern?: string; sortBy?: 'fanIn' | 'name' | 'file' };
-        result = await handleGetLeafFunctions(directory, limit, filePattern, sortBy);
-      } else if (name === 'get_critical_hubs') {
-        const { directory, limit = 10, minFanIn = 3 } =
-          args as { directory: string; limit?: number; minFanIn?: number };
-        result = await handleGetCriticalHubs(directory, limit, minFanIn);
-      } else if (name === 'get_duplicate_report') {
-        const { directory } = args as { directory: string };
-        result = await handleGetDuplicateReport(directory);
-      } else if (name === 'get_function_skeleton') {
-        const { directory, filePath } = args as { directory: string; filePath: string };
-        result = await handleGetFunctionSkeleton(directory, filePath);
-      } else if (name === 'get_god_functions') {
-        const { directory, filePath, fanOutThreshold = 8 } =
-          args as { directory: string; filePath?: string; fanOutThreshold?: number };
-        result = await handleGetGodFunctions(directory, filePath, fanOutThreshold);
-      } else if (name === 'check_spec_drift') {
-        const { directory, base = 'auto', files = [], domains = [], failOn = 'warning', maxFiles = DEFAULT_DRIFT_MAX_FILES } =
-          args as { directory: string; base?: string; files?: string[]; domains?: string[]; failOn?: 'error' | 'warning' | 'info'; maxFiles?: number };
-        result = await handleCheckSpecDrift(directory, base, files, domains, failOn, maxFiles);
-      } else if (name === 'search_code') {
-        const { directory, query, limit = 10, language, minFanIn, tokenBudget } =
-          args as { directory: string; query: string; limit?: number; language?: string; minFanIn?: number; tokenBudget?: number };
-        result = await handleSearchCode(directory, query, limit, language, minFanIn, tokenBudget);
-      } else if (name === 'suggest_insertion_points') {
-        const { directory, description, limit = 5, language } =
-          args as { directory: string; description: string; limit?: number; language?: string };
-        result = await handleSuggestInsertionPoints(directory, description, limit, language);
-      } else if (name === 'search_specs') {
-        const { directory, query, limit = 10, domain, section } =
-          args as { directory: string; query: string; limit?: number; domain?: string; section?: string };
-        result = await handleSearchSpecs(directory, query, limit, domain, section);
-      } else if (name === 'search_unified') {
-        const { directory, query, limit = 10, language, domain, section } =
-          args as { directory: string; query: string; limit?: number; language?: string; domain?: string; section?: string };
-        result = await handleUnifiedSearch(directory, query, limit, language, domain, section);
-      } else if (name === 'list_spec_domains') {
-        const { directory } = args as { directory: string };
-        result = await handleListSpecDomains(directory);
-      } else if (name === 'get_spec') {
-        const { directory, domain } = args as { directory: string; domain: string };
-        result = await handleGetSpec(directory, domain);
-      } else if (name === 'get_function_body') {
-        const { directory, filePath, functionName } =
-          args as { directory: string; filePath: string; functionName: string };
-        result = await handleGetFunctionBody(directory, filePath, functionName);
-      } else if (name === 'get_file_dependencies') {
-        const { directory, filePath, direction = 'both' } =
-          args as { directory: string; filePath: string; direction?: 'imports' | 'importedBy' | 'both' };
-        result = await handleGetFileDependencies(directory, filePath, direction);
-      } else if (name === 'generate_change_proposal') {
-        const { directory, description, slug, storyContent } =
-          args as { directory: string; description: string; slug: string; storyContent?: string };
-        result = await handleGenerateChangeProposal(directory, description, slug, storyContent);
-      } else if (name === 'annotate_story') {
-        const { directory, storyFilePath, description } =
-          args as { directory: string; storyFilePath: string; description: string };
-        result = await handleAnnotateStory(directory, storyFilePath, description);
-      } else if (name === 'get_decisions') {
-        const { directory, query } = args as { directory: string; query?: string };
-        result = await handleGetDecisions(directory, query);
-      } else if (name === 'get_route_inventory') {
-        const { directory } = args as { directory: string };
-        result = await handleGetRouteInventory(directory);
-      } else if (name === 'get_middleware_inventory') {
-        const { directory } = args as { directory: string };
-        result = await handleGetMiddlewareInventory(directory);
-      } else if (name === 'get_schema_inventory') {
-        const { directory } = args as { directory: string };
-        result = await handleGetSchemaInventory(directory);
-      } else if (name === 'get_ui_components') {
-        const { directory } = args as { directory: string };
-        result = await handleGetUIComponents(directory);
-      } else if (name === 'get_env_vars') {
-        const { directory } = args as { directory: string };
-        result = await handleGetEnvVars(directory);
-      } else if (name === 'get_external_packages') {
-        const { directory } = args as { directory: string };
-        result = await handleGetExternalPackages(directory);
-      } else if (name === 'audit_spec_coverage') {
-        const { directory, maxUncovered = 50, hubThreshold = 5 } =
-          args as { directory: string; maxUncovered?: number; hubThreshold?: number };
-        result = await handleAuditSpecCoverage(directory, maxUncovered, hubThreshold);
-      } else if (name === 'generate_tests') {
-        const { directory, domains, framework, useLlm, dryRun } =
-          args as {
-            directory: string;
-            domains?: string[];
-            framework?: string;
-            useLlm?: boolean;
-            dryRun?: boolean;
-          };
-        result = await handleGenerateTests({ directory, domains, framework, useLlm, dryRun });
-      } else if (name === 'get_test_coverage') {
-        const { directory, domains, minCoverage } =
-          args as { directory: string; domains?: string[]; minCoverage?: number };
-        result = await handleGetTestCoverage({ directory, domains, minCoverage });
-      } else if (name === 'get_minimal_context') {
-        const { directory, functionName, filePath } =
-          args as { directory: string; functionName: string; filePath?: string };
-        result = await handleGetMinimalContext(directory, functionName, filePath);
-      } else if (name === 'get_cluster') {
-        const { directory, functionName } = args as { directory: string; functionName: string };
-        result = await handleGetCluster(directory, functionName);
-      } else if (name === 'detect_changes') {
-        const { directory, base } = args as { directory: string; base?: string };
-        result = await handleDetectChanges(directory, base);
-      } else if (name === 'record_decision') {
-        const { directory, title, rationale, consequences, affectedFiles, supersedes, scope } =
-          args as { directory: string; title: string; rationale: string; consequences?: string; affectedFiles?: string[]; supersedes?: string; scope?: import('../../types/index.js').DecisionScope };
-        result = await handleRecordDecision(directory, title, rationale, consequences, affectedFiles, supersedes, scope);
-      } else if (name === 'list_decisions') {
-        const { directory, status } = args as { directory: string; status?: string };
-        result = await handleListDecisions(directory, status);
-      } else if (name === 'approve_decision') {
-        const { directory, id, note } = args as { directory: string; id: string; note?: string };
-        result = await handleApproveDecision(directory, id, note);
-      } else if (name === 'reject_decision') {
-        const { directory, id, note } = args as { directory: string; id: string; note?: string };
-        result = await handleRejectDecision(directory, id, note);
-      } else if (name === 'sync_decisions') {
-        const { directory, dryRun = false, id } = args as { directory: string; dryRun?: boolean; id?: string };
-        result = await handleSyncDecisions(directory, dryRun, id);
-      } else {
-        _unknownTool = true;
-      }
       })(), name);
 
       if (_unknownTool) {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1454,6 +1454,9 @@ export function selectActiveTools<T extends { name: string }>(
 interface McpServerOptions {
   watch?: string;
   watchAuto?: boolean;
+  /** Spawn a shared `openlore serve` daemon when none is running and delegate to
+   * it. Without this, MCP only reuses an already-running daemon. */
+  daemon?: boolean;
   watchDebounce?: string;
   watchNoEmbed?: boolean;
   minimal?: boolean;
@@ -1500,13 +1503,16 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
   // Serve-daemon delegation: when a shared `openlore serve` daemon is available
   // for a directory, forward tool calls to it (one warm process + one watcher
   // for the repo, shared across agents) instead of dispatching in-process.
-  // Resolved once per directory; null = no daemon, run locally. Auto-spawn is
-  // gated on --watch-auto (the user already opted into background freshness).
+  // Resolved once per directory; null = no daemon, run locally. By default we
+  // only DISCOVER and reuse an already-running daemon (started by pi, an explicit
+  // `openlore serve`, or another `--daemon` MCP) — so a plain MCP session never
+  // silently leaves a lingering background process. `--daemon` opts in to
+  // SPAWNING a shared daemon when none is running.
   const daemonByDir = new Map<string, ServeEndpoint | null>();
   async function resolveDaemon(dir: string): Promise<ServeEndpoint | null> {
     if (!dir) return null;
     if (!daemonByDir.has(dir)) {
-      daemonByDir.set(dir, await ensureServeDaemon(dir, { spawn: options.watchAuto === true }));
+      daemonByDir.set(dir, await ensureServeDaemon(dir, { spawn: options.daemon === true }));
     }
     return daemonByDir.get(dir) ?? null;
   }
@@ -1538,10 +1544,10 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
     if (options.watchAuto && !autoWatcher) {
       const dir = (args as Record<string, unknown>).directory;
       if (typeof dir === 'string') {
-        // Prefer a shared serve daemon — it runs the watcher (+ continuous
+        // Prefer a shared serve daemon if one is reachable (reused by default,
+        // or spawned with --daemon) — it runs the watcher (+ continuous
         // call-graph re-analyze) for the whole repo, so we don't start a second
-        // watcher racing it. Only fall back to an in-process watcher when no
-        // daemon can be brought up.
+        // watcher racing it. Fall back to an in-process watcher otherwise.
         const ep = await resolveDaemon(dir);
         if (!ep) {
           const { resolve } = await import('node:path');
@@ -1705,6 +1711,7 @@ export const mcpCommand = new Command('mcp')
   .option('--watch <directory>', 'Watch a project directory and incrementally re-index signatures on file changes')
   .option('--watch-auto', 'Auto-detect the project directory from the first tool call and start watching', true)
   .option('--no-watch-auto', 'Disable auto-watch (use for one-shot tool calls, e.g. the orient skill wrapper)')
+  .option('--daemon', 'Delegate tool calls to a shared `openlore serve` daemon, spawning one if needed (coherent state across agents — one warm process + one watcher per repo). Without it, MCP reuses a daemon only if one is already running, else runs in-process.')
   .option('--watch-debounce <ms>', 'Debounce delay in ms before re-indexing after a file change (default: 400)', '400')
   .option('--watch-no-embed', 'Watch signatures only — skip live vector re-embedding (embeddings refresh at commit). Large repos auto-degrade to this.')
   .option('--minimal', 'Expose only core 5 tools (orient, search_code, record_decision, detect_changes, check_spec_drift). Pair with alwaysLoad: true in Claude Code for always-visible core tools.')

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -62,6 +62,7 @@ import {
   handleSearchSpecs,
 } from '../../core/services/mcp-handlers/semantic.js';
 import { dispatchTool, UnknownToolError } from '../../core/services/tool-dispatch.js';
+import { ensureServeDaemon, callServeTool, type ServeEndpoint } from '../../core/services/serve-client.js';
 import {
   handleAnalyzeCodebase,
   handleGetArchitectureOverview,
@@ -1496,6 +1497,20 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
   // --watch-auto: start the watcher on the first tool call that carries a directory
   let autoWatcher: import('../../core/services/mcp-watcher.js').McpWatcher | undefined;
 
+  // Serve-daemon delegation: when a shared `openlore serve` daemon is available
+  // for a directory, forward tool calls to it (one warm process + one watcher
+  // for the repo, shared across agents) instead of dispatching in-process.
+  // Resolved once per directory; null = no daemon, run locally. Auto-spawn is
+  // gated on --watch-auto (the user already opted into background freshness).
+  const daemonByDir = new Map<string, ServeEndpoint | null>();
+  async function resolveDaemon(dir: string): Promise<ServeEndpoint | null> {
+    if (!dir) return null;
+    if (!daemonByDir.has(dir)) {
+      daemonByDir.set(dir, await ensureServeDaemon(dir, { spawn: options.watchAuto === true }));
+    }
+    return daemonByDir.get(dir) ?? null;
+  }
+
   // Agent identity captured from initialize handshake
   let agentName = 'unknown';
   let agentVersion = 'unknown';
@@ -1523,18 +1538,25 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
     if (options.watchAuto && !autoWatcher) {
       const dir = (args as Record<string, unknown>).directory;
       if (typeof dir === 'string') {
-        const { resolve } = await import('node:path');
-        const { McpWatcher } = await import('../../core/services/mcp-watcher.js');
-        const debounceMs = parseInt(options.watchDebounce ?? '400', 10);
-        autoWatcher = new McpWatcher({
-          rootPath: resolve(dir),
-          debounceMs: isNaN(debounceMs) ? 400 : debounceMs,
-          embed: !options.watchNoEmbed,
-        });
-        await autoWatcher.start();
-        const cleanup = () => autoWatcher!.stop().then(() => process.exit(0));
-        process.on('SIGINT',  cleanup);
-        process.on('SIGTERM', cleanup);
+        // Prefer a shared serve daemon — it runs the watcher (+ continuous
+        // call-graph re-analyze) for the whole repo, so we don't start a second
+        // watcher racing it. Only fall back to an in-process watcher when no
+        // daemon can be brought up.
+        const ep = await resolveDaemon(dir);
+        if (!ep) {
+          const { resolve } = await import('node:path');
+          const { McpWatcher } = await import('../../core/services/mcp-watcher.js');
+          const debounceMs = parseInt(options.watchDebounce ?? '400', 10);
+          autoWatcher = new McpWatcher({
+            rootPath: resolve(dir),
+            debounceMs: isNaN(debounceMs) ? 400 : debounceMs,
+            embed: !options.watchNoEmbed,
+          });
+          await autoWatcher.start();
+          const cleanup = () => autoWatcher!.stop().then(() => process.exit(0));
+          process.on('SIGINT',  cleanup);
+          process.on('SIGTERM', cleanup);
+        }
       }
     }
 
@@ -1572,8 +1594,23 @@ async function startMcpServer(options: McpServerOptions = {}): Promise<void> {
       // pathological hang can never wedge the server. Slow tools (analysis, LLM) have
       // generous overrides in MCP_TOOL_TIMEOUT_OVERRIDES.
       await withToolTimeout((async () => {
+        // Delegate to a shared serve daemon when one is available (warm caches,
+        // single watcher), else dispatch in-process. A daemon transport failure
+        // falls back to in-process so a flaky daemon never breaks a tool call.
+        const ep = await resolveDaemon(directory);
         try {
-          result = await dispatchTool(name, args as Record<string, unknown>, directory);
+          if (ep) {
+            try {
+              result = await callServeTool(ep, name, args as Record<string, unknown>, directory);
+            } catch {
+              // Daemon unreachable/unknown-tool/transport error → drop it for this
+              // session and run locally (also catches a daemon that died mid-session).
+              daemonByDir.set(directory, null);
+              result = await dispatchTool(name, args as Record<string, unknown>, directory);
+            }
+          } else {
+            result = await dispatchTool(name, args as Record<string, unknown>, directory);
+          }
         } catch (err) {
           if (err instanceof UnknownToolError) {
             _unknownTool = true;

--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for the `openlore serve` HTTP daemon: endpoints, preset filtering,
- * token gate, and serve.json discovery-file lifecycle.
+ * Tests for the `openlore serve` HTTP daemon: endpoints, advisory preset,
+ * token gate, dup-daemon reuse, and serve.json discovery-file lifecycle.
  *
  * Served root is a throwaway temp dir (no analysis), so /tool/orient returns a
  * structured "no analysis" object (HTTP 200) without touching the repo's own
@@ -40,12 +40,18 @@ function fileExists(p: string): Promise<boolean> {
   return access(p).then(() => true).catch(() => false);
 }
 
+// fetch().json() is typed `Promise<any>` but strict callers see `unknown`; cast
+// to a loose record so the assertions below read cleanly.
+async function jsonOf(res: Response): Promise<Record<string, unknown>> {
+  return (await res.json()) as Record<string, unknown>;
+}
+
 describe('openlore serve', () => {
   it('GET /health reports version, preset, and active tools', async () => {
     const h = await boot();
     const res = await fetch(`${h.baseUrl}/health`);
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await jsonOf(res);
     expect(body.ok).toBe(true);
     expect(typeof body.version).toBe('string');
     expect(body.preset).toBe('navigation');
@@ -66,16 +72,26 @@ describe('openlore serve', () => {
     expect(await fileExists(descPath)).toBe(false);
   });
 
-  it('404s a tool outside the active preset', async () => {
-    const h = await boot();
-    // get_env_vars is a real tool but not in the navigation preset.
+  it('preset is advisory — a non-preset tool is still dispatched (not 404)', async () => {
+    const h = await boot(); // default navigation preset
+    // get_env_vars is a real tool, NOT in the navigation preset. The daemon must
+    // still serve it (preset only advises /health) so it can back the MCP server.
     const res = await fetch(`${h.baseUrl}/tool/get_env_vars`, {
       method: 'POST',
       body: JSON.stringify({ args: {} }),
     });
+    expect(res.status).toBe(200); // dispatched, not gated
+  });
+
+  it('404s a genuinely unknown tool', async () => {
+    const h = await boot();
+    const res = await fetch(`${h.baseUrl}/tool/not_a_real_tool`, {
+      method: 'POST',
+      body: JSON.stringify({ args: {} }),
+    });
     expect(res.status).toBe(404);
-    const body = await res.json();
-    expect(body.error).toMatch(/not in active preset/);
+    const body = await jsonOf(res);
+    expect(body.error).toMatch(/unknown tool/i);
   });
 
   it('dispatches an in-preset tool (orient → structured no-analysis result)', async () => {
@@ -85,7 +101,7 @@ describe('openlore serve', () => {
       body: JSON.stringify({ args: { task: 'anything' } }),
     });
     expect(res.status).toBe(200);
-    const body = await res.json();
+    const body = await jsonOf(res);
     // Temp root has no analysis → handler returns an { error } object, not a throw.
     expect(body.error).toMatch(/No analysis/i);
   });
@@ -93,7 +109,7 @@ describe('openlore serve', () => {
   it('preset "all" exposes non-navigation tools', async () => {
     const h = await boot({ preset: 'all' });
     const res = await fetch(`${h.baseUrl}/health`);
-    const body = await res.json();
+    const body = await jsonOf(res);
     expect(body.preset).toBe('all');
     expect(body.tools).toContain('get_env_vars');
   });
@@ -134,6 +150,18 @@ describe('openlore serve', () => {
     const h = await startServe({ directory: root, stop: true });
     expect(h).toBeUndefined();
     expect(await fileExists(descPath)).toBe(false); // stale descriptor cleaned up
+  });
+
+  it('reuses a live daemon instead of starting a second one for the same root', async () => {
+    const h1 = await boot();
+    // Second start for the same root must detect the live daemon and return its
+    // endpoint (same port), not bind a new server.
+    const h2 = await startServe({ directory: root, port: '0', watch: false });
+    expect(h2).toBeDefined();
+    expect(h2!.port).toBe(h1.port);
+    // close() on the reused handle is a no-op — must not tear down h1.
+    await h2!.close();
+    expect((await fetch(`${h1.baseUrl}/health`)).status).toBe(200);
   });
 
   it('rejects an unknown preset at startup', async () => {

--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, access, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { startServe, type ServeHandle } from './serve.js';
@@ -118,6 +118,22 @@ describe('openlore serve', () => {
       body: JSON.stringify({ args: { task: 'x' } }),
     });
     expect(withTok.status).toBe(200);
+  });
+
+  it('--stop on a stale serve.json removes it without signalling a recycled PID', async () => {
+    root = await mkdtemp(join(tmpdir(), 'openlore-serve-'));
+    const descPath = join(root, '.openlore', 'serve.json');
+    await mkdir(join(root, '.openlore'), { recursive: true });
+    // Point at a dead port + a PID that is almost certainly not an openlore daemon
+    // (pid 1). daemonAlive() must fail the /health probe → file removed, no kill.
+    await writeFile(
+      descPath,
+      JSON.stringify({ port: 1, pid: 1, host: '127.0.0.1', version: 'x', startedAt: '' }),
+      'utf-8',
+    );
+    const h = await startServe({ directory: root, stop: true });
+    expect(h).toBeUndefined();
+    expect(await fileExists(descPath)).toBe(false); // stale descriptor cleaned up
   });
 
   it('rejects an unknown preset at startup', async () => {

--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -29,7 +29,8 @@ afterEach(async () => {
 
 async function boot(opts: { token?: string; preset?: string } = {}): Promise<ServeHandle> {
   root = await mkdtemp(join(tmpdir(), 'openlore-serve-'));
-  const h = await startServe({ directory: root, port: '0', ...opts });
+  // watch:false — these are transport tests; the watcher has its own coverage.
+  const h = await startServe({ directory: root, port: '0', watch: false, ...opts });
   if (!h) throw new Error('startServe returned no handle');
   handle = h;
   return h;
@@ -122,7 +123,7 @@ describe('openlore serve', () => {
   it('rejects an unknown preset at startup', async () => {
     root = await mkdtemp(join(tmpdir(), 'openlore-serve-'));
     const prev = process.exitCode;
-    const h = await startServe({ directory: root, port: '0', preset: 'bogus' });
+    const h = await startServe({ directory: root, port: '0', watch: false, preset: 'bogus' });
     expect(h).toBeUndefined();
     expect(process.exitCode).toBe(1);
     process.exitCode = prev; // don't fail the suite

--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the `openlore serve` HTTP daemon: endpoints, preset filtering,
+ * token gate, and serve.json discovery-file lifecycle.
+ *
+ * Served root is a throwaway temp dir (no analysis), so /tool/orient returns a
+ * structured "no analysis" object (HTTP 200) without touching the repo's own
+ * .openlore. We assert transport behaviour, not handler output.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startServe, type ServeHandle } from './serve.js';
+
+let handle: ServeHandle | undefined;
+let root = '';
+
+afterEach(async () => {
+  if (handle) {
+    await handle.close();
+    handle = undefined;
+  }
+  if (root) {
+    await rm(root, { recursive: true, force: true });
+    root = '';
+  }
+});
+
+async function boot(opts: { token?: string; preset?: string } = {}): Promise<ServeHandle> {
+  root = await mkdtemp(join(tmpdir(), 'openlore-serve-'));
+  const h = await startServe({ directory: root, port: '0', ...opts });
+  if (!h) throw new Error('startServe returned no handle');
+  handle = h;
+  return h;
+}
+
+function fileExists(p: string): Promise<boolean> {
+  return access(p).then(() => true).catch(() => false);
+}
+
+describe('openlore serve', () => {
+  it('GET /health reports version, preset, and active tools', async () => {
+    const h = await boot();
+    const res = await fetch(`${h.baseUrl}/health`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(typeof body.version).toBe('string');
+    expect(body.preset).toBe('navigation');
+    expect(body.tools).toContain('orient');
+    expect(body.tools).toContain('search_code');
+  });
+
+  it('writes serve.json on start and removes it on close', async () => {
+    const h = await boot();
+    const descPath = join(root, '.openlore', 'serve.json');
+    expect(await fileExists(descPath)).toBe(true);
+    const desc = JSON.parse(await readFile(descPath, 'utf-8'));
+    expect(desc.port).toBe(h.port);
+    expect(desc.pid).toBe(process.pid);
+
+    await h.close();
+    handle = undefined;
+    expect(await fileExists(descPath)).toBe(false);
+  });
+
+  it('404s a tool outside the active preset', async () => {
+    const h = await boot();
+    // get_env_vars is a real tool but not in the navigation preset.
+    const res = await fetch(`${h.baseUrl}/tool/get_env_vars`, {
+      method: 'POST',
+      body: JSON.stringify({ args: {} }),
+    });
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not in active preset/);
+  });
+
+  it('dispatches an in-preset tool (orient → structured no-analysis result)', async () => {
+    const h = await boot();
+    const res = await fetch(`${h.baseUrl}/tool/orient`, {
+      method: 'POST',
+      body: JSON.stringify({ args: { task: 'anything' } }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Temp root has no analysis → handler returns an { error } object, not a throw.
+    expect(body.error).toMatch(/No analysis/i);
+  });
+
+  it('preset "all" exposes non-navigation tools', async () => {
+    const h = await boot({ preset: 'all' });
+    const res = await fetch(`${h.baseUrl}/health`);
+    const body = await res.json();
+    expect(body.preset).toBe('all');
+    expect(body.tools).toContain('get_env_vars');
+  });
+
+  it('enforces the token gate on /tool but not /health', async () => {
+    const h = await boot({ token: 'sekret' });
+
+    // /health needs no token (liveness).
+    expect((await fetch(`${h.baseUrl}/health`)).status).toBe(200);
+
+    // /tool without token → 401.
+    const noTok = await fetch(`${h.baseUrl}/tool/orient`, {
+      method: 'POST',
+      body: JSON.stringify({ args: { task: 'x' } }),
+    });
+    expect(noTok.status).toBe(401);
+
+    // /tool with token → dispatched (200).
+    const withTok = await fetch(`${h.baseUrl}/tool/orient`, {
+      method: 'POST',
+      headers: { 'x-openlore-token': 'sekret' },
+      body: JSON.stringify({ args: { task: 'x' } }),
+    });
+    expect(withTok.status).toBe(200);
+  });
+
+  it('rejects an unknown preset at startup', async () => {
+    root = await mkdtemp(join(tmpdir(), 'openlore-serve-'));
+    const prev = process.exitCode;
+    const h = await startServe({ directory: root, port: '0', preset: 'bogus' });
+    expect(h).toBeUndefined();
+    expect(process.exitCode).toBe(1);
+    process.exitCode = prev; // don't fail the suite
+  });
+});

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -121,6 +121,15 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.end(text);
 }
 
+/** Read <root>/.openlore/serve.json if present. */
+async function readDescriptor(root: string): Promise<ServeDescriptor | null> {
+  try {
+    return JSON.parse(await readFile(serveFilePath(root), 'utf-8')) as ServeDescriptor;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Confirm a descriptor points at a LIVE openlore daemon — not a stale serve.json
  * left by a SIGKILL'd process, nor a recycled port now owned by something else.
@@ -143,10 +152,8 @@ async function daemonAlive(desc: ServeDescriptor): Promise<boolean> {
 /** Stop a daemon previously started for `root` by signalling its recorded pid. */
 async function stopDaemon(root: string): Promise<void> {
   const path = serveFilePath(root);
-  let desc: ServeDescriptor;
-  try {
-    desc = JSON.parse(await readFile(path, 'utf-8')) as ServeDescriptor;
-  } catch {
+  const desc = await readDescriptor(root);
+  if (!desc) {
     logger.warning(`No running openlore serve daemon found for ${root}.`);
     return;
   }
@@ -190,6 +197,23 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
     ).map((t) => t.name),
   );
 
+  // Don't start a second daemon for a root already served by a healthy one —
+  // a concurrent spawn (two MCP clients, or pi + MCP) would otherwise leave two
+  // watchers racing on the same .openlore/analysis. Reuse the live one instead.
+  const existing = await readDescriptor(root);
+  if (existing && (await daemonAlive(existing))) {
+    logger.success(
+      `openlore serve already running for ${root} at http://${existing.host}:${existing.port} — reusing.`,
+    );
+    return {
+      port: existing.port,
+      host: existing.host,
+      token: existing.token,
+      baseUrl: `http://${existing.host}:${existing.port}`,
+      close: async () => {}, // never tear down a daemon this process didn't start
+    };
+  }
+
   const token = options.token ?? (process.env.OPENLORE_SERVE_TOKEN || undefined);
   const startedAt = new Date().toISOString();
   const startMs = Date.now();
@@ -225,10 +249,11 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
 
     if (req.method === 'POST' && url.pathname.startsWith('/tool/')) {
       const name = decodeURIComponent(url.pathname.slice('/tool/'.length));
-      if (!activeNames.has(name)) {
-        sendJson(res, 404, { error: `Tool "${name}" not in active preset "${presetName}"` });
-        return;
-      }
+      // The preset is ADVISORY (reported by /health for clients that want a
+      // curated list, e.g. the Pi extension). The daemon dispatches any known
+      // tool so it can back multiple clients with different surfaces — notably
+      // the MCP server, which delegates all ~45 tools here. Unknown tools 404
+      // via UnknownToolError below.
       let body: Record<string, unknown>;
       try {
         body = await readJsonBody(req);
@@ -364,7 +389,8 @@ export const serveCommand = new Command('serve')
   .option('--host <host>', 'Host to bind', '127.0.0.1')
   .option(
     '--preset <name>',
-    'Tool surface to expose: a named preset (minimal, navigation) or "all" (default: navigation)',
+    'Advisory tool surface reported by /health (minimal, navigation, or all). The daemon still ' +
+      'dispatches any known tool; clients curate their own surface. Default: navigation',
     'navigation',
   )
   .option('--token <token>', 'Require this token as the x-openlore-token header (default: $OPENLORE_SERVE_TOKEN)')

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -121,6 +121,25 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
   res.end(text);
 }
 
+/**
+ * Confirm a descriptor points at a LIVE openlore daemon — not a stale serve.json
+ * left by a SIGKILL'd process, nor a recycled port now owned by something else.
+ * Verifies GET /health returns our `ok: true` shape, so we never signal a PID we
+ * can't positively identify as our own daemon.
+ */
+async function daemonAlive(desc: ServeDescriptor): Promise<boolean> {
+  try {
+    const res = await fetch(`http://${desc.host}:${desc.port}/health`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    if (!res.ok) return false;
+    const body = (await res.json().catch(() => null)) as { ok?: boolean } | null;
+    return body?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
 /** Stop a daemon previously started for `root` by signalling its recorded pid. */
 async function stopDaemon(root: string): Promise<void> {
   const path = serveFilePath(root);
@@ -131,13 +150,20 @@ async function stopDaemon(root: string): Promise<void> {
     logger.warning(`No running openlore serve daemon found for ${root}.`);
     return;
   }
+  // Only signal a PID we've confirmed is our live daemon on the recorded port.
+  // A stale serve.json could otherwise point at a recycled PID belonging to an
+  // unrelated process — SIGTERM to that would be a nasty surprise.
+  if (!(await daemonAlive(desc))) {
+    await unlink(path).catch(() => {});
+    logger.warning(`No live daemon at ${desc.host}:${desc.port}; removed stale ${SERVE_FILE}.`);
+    return;
+  }
   try {
     process.kill(desc.pid, 'SIGTERM');
     logger.success(`Sent SIGTERM to openlore serve (pid ${desc.pid}).`);
   } catch {
-    // Process already gone — clean up the stale descriptor.
     await unlink(path).catch(() => {});
-    logger.warning(`Daemon pid ${desc.pid} not running; removed stale ${SERVE_FILE}.`);
+    logger.warning(`Daemon pid ${desc.pid} not signalable; removed stale ${SERVE_FILE}.`);
   }
 }
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -33,7 +33,16 @@ import { logger } from '../../utils/logger.js';
 import { OPENLORE_DIR } from '../../constants.js';
 import { dispatchTool, UnknownToolError } from '../../core/services/tool-dispatch.js';
 import { validateDirectory } from '../../core/services/mcp-handlers/utils.js';
+import { McpWatcher } from '../../core/services/mcp-watcher.js';
+import { openloreAnalyze } from '../../api/analyze.js';
 import { TOOL_DEFINITIONS, TOOL_PRESETS, selectActiveTools } from './mcp.js';
+
+/**
+ * Debounce before a full call-graph re-analyze after edits settle. Longer than
+ * the watcher's signature debounce (WATCH_DEBOUNCE_MS=400) because re-analysis
+ * is heavier; a few seconds of quiet is the signal that an edit burst is done.
+ */
+const REANALYZE_DEBOUNCE_MS = 4000;
 
 const _require = createRequire(import.meta.url);
 const _pkgVersion = (_require('../../../package.json') as { version: string }).version;
@@ -55,6 +64,8 @@ interface ServeCliOptions {
   preset?: string;
   token?: string;
   stop?: boolean;
+  /** false (via --no-watch) disables the freshness watcher + re-analyze lane. */
+  watch?: boolean;
 }
 
 /** Live daemon handle. Returned by {@link startServe} so callers (tests) can
@@ -253,6 +264,45 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   logger.success(`openlore serve listening on http://${host}:${boundPort} (preset: ${presetName})`);
   logger.discovery(`Discovery file: ${serveFilePath(root)}`);
 
+  // ── Freshness: watcher (signatures + vector) + debounced call-graph re-analyze ──
+  // The watcher keeps signatures/vector fresh between commits and primes the read
+  // cache in place. Its onBatchFlushed hook schedules a heavier full re-analyze so
+  // the CALL GRAPH (which the watcher deliberately skips) also stays fresh between
+  // commits — turning divergence from "wait for the next commit" into continuous.
+  let watcher: McpWatcher | undefined;
+  let reanalyzeTimer: ReturnType<typeof setTimeout> | undefined;
+  let reanalyzeRunning = false;
+  let reanalyzePending = false;
+
+  const runReanalyze = async (): Promise<void> => {
+    if (reanalyzeRunning) { reanalyzePending = true; return; } // single-flight + coalesce
+    reanalyzeRunning = true;
+    try {
+      await openloreAnalyze({ rootPath: root, force: true });
+      logger.discovery(`[serve] call graph re-analyzed (${root})`);
+    } catch (err) {
+      logger.warning(`[serve] re-analyze failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      reanalyzeRunning = false;
+      if (reanalyzePending) { reanalyzePending = false; scheduleReanalyze(); }
+    }
+  };
+  function scheduleReanalyze(): void {
+    if (reanalyzeTimer) clearTimeout(reanalyzeTimer);
+    reanalyzeTimer = setTimeout(() => void runReanalyze(), REANALYZE_DEBOUNCE_MS);
+  }
+
+  if (options.watch !== false) {
+    watcher = new McpWatcher({ rootPath: root, onBatchFlushed: () => scheduleReanalyze() });
+    try {
+      await watcher.start();
+      logger.discovery(`[serve] watching ${root} — signatures/vector live, call-graph re-analyze debounced`);
+    } catch (err) {
+      logger.warning(`[serve] watcher failed to start: ${err instanceof Error ? err.message : String(err)}`);
+      watcher = undefined;
+    }
+  }
+
   // Clean shutdown: drop the descriptor so clients don't reuse a dead port.
   // Signal handlers exit the process; the returned close() is for in-process
   // callers (tests) that must not kill the host.
@@ -260,6 +310,8 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   const teardown = async (): Promise<void> => {
     if (shuttingDown) return;
     shuttingDown = true;
+    if (reanalyzeTimer) clearTimeout(reanalyzeTimer);
+    if (watcher) await watcher.stop().catch(() => {});
     await unlink(serveFilePath(root)).catch(() => {});
     await new Promise<void>((res) => server.close(() => res()));
   };
@@ -290,6 +342,7 @@ export const serveCommand = new Command('serve')
     'navigation',
   )
   .option('--token <token>', 'Require this token as the x-openlore-token header (default: $OPENLORE_SERVE_TOKEN)')
+  .option('--no-watch', 'Disable the freshness watcher + debounced call-graph re-analyze')
   .option('--stop', 'Stop a running daemon for --directory and exit')
   .addHelpText(
     'after',

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1,0 +1,308 @@
+/**
+ * openlore serve — local HTTP daemon (warm, loopback-only).
+ *
+ * A long-lived process that keeps openlore's caches warm across calls and
+ * exposes the tool surface over plain HTTP so non-MCP clients (e.g. a Pi
+ * extension) can hit it with `fetch` — no JSON-RPC, no subprocess-per-call.
+ *
+ * It reuses the SAME tool dispatch as the stdio MCP server
+ * ({@link dispatchTool}) so the two transports can't drift, and the SAME tool
+ * presets ({@link selectActiveTools}) so a small-model client gets a focused
+ * surface (default: `navigation`).
+ *
+ * Endpoints (all loopback):
+ *   GET  /health           → { ok, version, root, preset, tools, uptimeMs }
+ *   POST /tool/:name       body { directory?, args }  → handler result (JSON)
+ *
+ * Discovery: writes `.openlore/serve.json` { port, pid, host, token?, startedAt }
+ * in the served root so a client can find and reuse a running daemon.
+ *
+ * Security: binds 127.0.0.1 only. An optional --token must be presented as the
+ * `x-openlore-token` header, keeping other local users off the port.
+ *
+ * Freshness (watcher + continuous re-analyze) is layered on separately; this
+ * module is the transport + lifecycle core.
+ */
+
+import { Command } from 'commander';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { createRequire } from 'node:module';
+import { writeFile, readFile, unlink, mkdir } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { logger } from '../../utils/logger.js';
+import { OPENLORE_DIR } from '../../constants.js';
+import { dispatchTool, UnknownToolError } from '../../core/services/tool-dispatch.js';
+import { validateDirectory } from '../../core/services/mcp-handlers/utils.js';
+import { TOOL_DEFINITIONS, TOOL_PRESETS, selectActiveTools } from './mcp.js';
+
+const _require = createRequire(import.meta.url);
+const _pkgVersion = (_require('../../../package.json') as { version: string }).version;
+
+/** Daemon discovery descriptor written to <root>/.openlore/serve.json. */
+interface ServeDescriptor {
+  port: number;
+  pid: number;
+  host: string;
+  token?: string;
+  startedAt: string;
+  version: string;
+}
+
+interface ServeCliOptions {
+  directory?: string;
+  port?: string;
+  host?: string;
+  preset?: string;
+  token?: string;
+  stop?: boolean;
+}
+
+/** Live daemon handle. Returned by {@link startServe} so callers (tests) can
+ * address and shut down the running server without signalling the process. */
+export interface ServeHandle {
+  port: number;
+  host: string;
+  token?: string;
+  baseUrl: string;
+  close(): Promise<void>;
+}
+
+const SERVE_FILE = 'serve.json';
+const MAX_BODY_BYTES = 1_000_000; // tool args are small; reject anything larger
+
+function serveFilePath(root: string): string {
+  return join(root, OPENLORE_DIR, SERVE_FILE);
+}
+
+/** Read a JSON request body with a hard size ceiling. Rejects on overflow/parse error. */
+function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve_, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    req.on('data', (c: Buffer) => {
+      size += c.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new Error('request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf-8').trim();
+      if (!raw) return resolve_({});
+      try {
+        resolve_(JSON.parse(raw) as Record<string, unknown>);
+      } catch {
+        reject(new Error('invalid JSON body'));
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const text = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(text),
+  });
+  res.end(text);
+}
+
+/** Stop a daemon previously started for `root` by signalling its recorded pid. */
+async function stopDaemon(root: string): Promise<void> {
+  const path = serveFilePath(root);
+  let desc: ServeDescriptor;
+  try {
+    desc = JSON.parse(await readFile(path, 'utf-8')) as ServeDescriptor;
+  } catch {
+    logger.warning(`No running openlore serve daemon found for ${root}.`);
+    return;
+  }
+  try {
+    process.kill(desc.pid, 'SIGTERM');
+    logger.success(`Sent SIGTERM to openlore serve (pid ${desc.pid}).`);
+  } catch {
+    // Process already gone — clean up the stale descriptor.
+    await unlink(path).catch(() => {});
+    logger.warning(`Daemon pid ${desc.pid} not running; removed stale ${SERVE_FILE}.`);
+  }
+}
+
+export async function startServe(options: ServeCliOptions): Promise<ServeHandle | undefined> {
+  const root = resolve(options.directory ?? process.cwd());
+
+  if (options.stop) {
+    await stopDaemon(root);
+    return undefined;
+  }
+
+  const host = options.host ?? '127.0.0.1';
+  const presetName = options.preset ?? 'navigation';
+  if (presetName !== 'all' && !TOOL_PRESETS[presetName]) {
+    logger.error(`Unknown --preset "${presetName}". Known: ${Object.keys(TOOL_PRESETS).join(', ')}, all.`);
+    process.exitCode = 1;
+    return;
+  }
+  // Active tool surface: 'all' = every tool, otherwise the named preset.
+  const activeNames = new Set(
+    (presetName === 'all'
+      ? TOOL_DEFINITIONS
+      : selectActiveTools(TOOL_DEFINITIONS, { preset: presetName })
+    ).map((t) => t.name),
+  );
+
+  const token = options.token ?? (process.env.OPENLORE_SERVE_TOKEN || undefined);
+  const startedAt = new Date().toISOString();
+  const startMs = Date.now();
+
+  const server = createServer((req, res) => {
+    void handleRequest(req, res).catch((err) => {
+      sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+    });
+  });
+
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', `http://${host}`);
+
+    // Token gate (skips /health so liveness checks need no secret).
+    if (token && url.pathname !== '/health') {
+      if (req.headers['x-openlore-token'] !== token) {
+        sendJson(res, 401, { error: 'invalid or missing x-openlore-token' });
+        return;
+      }
+    }
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      sendJson(res, 200, {
+        ok: true,
+        version: _pkgVersion,
+        root,
+        preset: presetName,
+        tools: [...activeNames],
+        uptimeMs: Date.now() - startMs,
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname.startsWith('/tool/')) {
+      const name = decodeURIComponent(url.pathname.slice('/tool/'.length));
+      if (!activeNames.has(name)) {
+        sendJson(res, 404, { error: `Tool "${name}" not in active preset "${presetName}"` });
+        return;
+      }
+      let body: Record<string, unknown>;
+      try {
+        body = await readJsonBody(req);
+      } catch (err) {
+        sendJson(res, 400, { error: err instanceof Error ? err.message : 'bad request' });
+        return;
+      }
+      const args = (body.args as Record<string, unknown>) ?? {};
+      // Directory precedence: explicit body.directory → args.directory → served root.
+      const directory = (typeof body.directory === 'string' && body.directory)
+        || (typeof args.directory === 'string' && args.directory)
+        || root;
+      // Ensure handlers receive directory in args (they read it from there).
+      if (typeof args.directory !== 'string') args.directory = directory;
+
+      try {
+        await validateDirectory(directory);
+      } catch (err) {
+        sendJson(res, 400, { error: err instanceof Error ? err.message : 'invalid directory' });
+        return;
+      }
+
+      try {
+        const result = await dispatchTool(name, args, directory);
+        sendJson(res, 200, result ?? null);
+      } catch (err) {
+        if (err instanceof UnknownToolError) {
+          sendJson(res, 404, { error: err.message });
+          return;
+        }
+        sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+      }
+      return;
+    }
+
+    sendJson(res, 404, { error: `No route for ${req.method} ${url.pathname}` });
+  }
+
+  // Bind (port 0 → OS picks a free ephemeral port).
+  const port = options.port ? parseInt(options.port, 10) : 0;
+  await new Promise<void>((resolve_, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, resolve_);
+  });
+  const addr = server.address();
+  const boundPort = typeof addr === 'object' && addr ? addr.port : port;
+
+  const descriptor: ServeDescriptor = {
+    port: boundPort,
+    pid: process.pid,
+    host,
+    token,
+    startedAt,
+    version: _pkgVersion,
+  };
+  await mkdir(join(root, OPENLORE_DIR), { recursive: true });
+  await writeFile(serveFilePath(root), JSON.stringify(descriptor, null, 2) + '\n', 'utf-8');
+
+  logger.success(`openlore serve listening on http://${host}:${boundPort} (preset: ${presetName})`);
+  logger.discovery(`Discovery file: ${serveFilePath(root)}`);
+
+  // Clean shutdown: drop the descriptor so clients don't reuse a dead port.
+  // Signal handlers exit the process; the returned close() is for in-process
+  // callers (tests) that must not kill the host.
+  let shuttingDown = false;
+  const teardown = async (): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    await unlink(serveFilePath(root)).catch(() => {});
+    await new Promise<void>((res) => server.close(() => res()));
+  };
+  const exitAfterTeardown = async (): Promise<void> => {
+    await teardown();
+    process.exit(0);
+  };
+  process.on('SIGINT', () => void exitAfterTeardown());
+  process.on('SIGTERM', () => void exitAfterTeardown());
+
+  return {
+    port: boundPort,
+    host,
+    token,
+    baseUrl: `http://${host}:${boundPort}`,
+    close: teardown,
+  };
+}
+
+export const serveCommand = new Command('serve')
+  .description('Start a warm local HTTP daemon exposing openlore tools (loopback, for editor/agent integrations like Pi)')
+  .option('-d, --directory <path>', 'Project root to serve (discovery file written here)', process.cwd())
+  .option('-p, --port <number>', 'Port to bind (default: ephemeral free port)')
+  .option('--host <host>', 'Host to bind', '127.0.0.1')
+  .option(
+    '--preset <name>',
+    'Tool surface to expose: a named preset (minimal, navigation) or "all" (default: navigation)',
+    'navigation',
+  )
+  .option('--token <token>', 'Require this token as the x-openlore-token header (default: $OPENLORE_SERVE_TOKEN)')
+  .option('--stop', 'Stop a running daemon for --directory and exit')
+  .addHelpText(
+    'after',
+    `
+Examples:
+  $ openlore serve                          Warm daemon, navigation preset, ephemeral port
+  $ openlore serve --preset all --port 7077 All tools on a fixed port
+  $ openlore serve --stop                   Stop the daemon serving this directory
+
+  $ curl 127.0.0.1:$PORT/health
+  $ curl -XPOST 127.0.0.1:$PORT/tool/orient -d '{"args":{"task":"add rate limiting"}}'
+`,
+  )
+  .action(async (options: ServeCliOptions) => {
+    await startServe(options);
+  });

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -397,6 +397,7 @@ export const setupCommand = new Command('setup')
       gsd: 'get-shit-done (GSD)',
       bmad: 'BMAD',
       omoa: 'oh-my-openagent (SDD plugins)',
+      pi: 'Pi (pi.dev)',
     };
 
     for (const tool of tools) {

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -28,7 +28,7 @@ import { installPreCommitHook, uninstallClaudeHook } from './decisions.js';
 // TYPES
 // ============================================================================
 
-type ToolName = 'vibe' | 'cline' | 'gsd' | 'bmad' | 'claude' | 'opencode' | 'omoa';
+type ToolName = 'vibe' | 'cline' | 'gsd' | 'bmad' | 'claude' | 'opencode' | 'omoa' | 'pi';
 
 interface SkillEntry {
   /** Absolute source path inside the package's examples/ directory */
@@ -117,7 +117,7 @@ async function copyFile(
 // SKILL MANIFESTS
 // ============================================================================
 
-function buildManifest(projectRoot: string): Record<ToolName, SkillEntry[]> {
+function buildManifest(projectRoot: string, piGlobal = false): Record<ToolName, SkillEntry[]> {
   const ex = join(PACKAGE_ROOT, 'examples');
 
   const VIBE_SKILLS = [
@@ -229,6 +229,16 @@ function buildManifest(projectRoot: string): Record<ToolName, SkillEntry[]> {
         dest: join(projectRoot, '.opencode', 'prompts', 'sisyphus-sdd.md'),
       },
     ],
+    // Pi (pi.dev) — a single TS extension, not per-skill markdown. Project-local
+    // by default; --global installs it for every project.
+    pi: [
+      {
+        src: join(ex, 'pi', 'openlore.ts'),
+        dest: piGlobal
+          ? join(homedir(), '.pi', 'agent', 'extensions', 'openlore.ts')
+          : join(projectRoot, '.pi', 'extensions', 'openlore.ts'),
+      },
+    ],
   };
 }
 
@@ -239,9 +249,10 @@ function buildManifest(projectRoot: string): Record<ToolName, SkillEntry[]> {
 async function runSetup(
   projectRoot: string,
   tools: ToolName[],
-  force: boolean
+  force: boolean,
+  piGlobal = false
 ): Promise<SetupResult[]> {
-  const manifest = buildManifest(projectRoot);
+  const manifest = buildManifest(projectRoot, piGlobal);
   const results: SetupResult[] = [];
 
   for (const tool of tools) {
@@ -272,7 +283,7 @@ export const setupCommand = new Command('setup')
   )
   .option(
     '--tools <list>',
-    'Comma-separated list of tools to install: vibe, cline, claude, opencode, gsd, bmad (default: all)'
+    'Comma-separated list of tools to install: vibe, cline, claude, opencode, gsd, bmad, pi (default: all)'
   )
   .option(
     '--force',
@@ -280,9 +291,10 @@ export const setupCommand = new Command('setup')
     false
   )
   .option('--dir <path>', 'Project root directory', process.cwd())
-  .action(async (options: { tools?: string; force: boolean; dir: string }) => {
+  .option('--global', 'For the pi target: install the extension to ~/.pi/agent/extensions/ instead of the project', false)
+  .action(async (options: { tools?: string; force: boolean; dir: string; global: boolean }) => {
     const projectRoot = options.dir;
-    const allTools: ToolName[] = ['vibe', 'cline', 'gsd', 'bmad', 'claude', 'opencode', 'omoa'];
+    const allTools: ToolName[] = ['vibe', 'cline', 'gsd', 'bmad', 'claude', 'opencode', 'omoa', 'pi'];
 
     let tools: ToolName[];
     if (options.tools) {
@@ -291,7 +303,7 @@ export const setupCommand = new Command('setup')
       );
       if (tools.length === 0) {
         logger.error(
-          'setup: no valid tools specified. Valid values: vibe, cline, gsd, bmad, claude, opencode, omoa'
+          'setup: no valid tools specified. Valid values: vibe, cline, gsd, bmad, claude, opencode, omoa, pi'
         );
         process.exit(1);
       }
@@ -333,6 +345,10 @@ export const setupCommand = new Command('setup')
             value: 'omoa' as ToolName,
             checked: omoaDetected,
           },
+          {
+            name: 'Pi            (.pi/extensions/openlore.ts — warm-daemon extension; --global for ~/.pi)',
+            value: 'pi' as ToolName,
+          },
         ],
       });
       if (selected.length === 0) {
@@ -353,7 +369,7 @@ export const setupCommand = new Command('setup')
 
     let results: SetupResult[];
     try {
-      results = await runSetup(projectRoot, tools, options.force);
+      results = await runSetup(projectRoot, tools, options.force, options.global);
     } catch (err) {
       logger.error(`setup failed: ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,6 +31,7 @@ import { installCommand } from './install/index.js';
 import { preflightCommand } from './preflight/index.js';
 import { exportCommand } from './export/index.js';
 import { manifestCommand } from './manifest/index.js';
+import { serveCommand } from './commands/serve.js';
 import { configureLogger } from '../utils/logger.js';
 
 // Read version from package.json at runtime so it never drifts from the published version
@@ -149,5 +150,6 @@ program.addCommand(installCommand);
 program.addCommand(preflightCommand);
 program.addCommand(exportCommand);
 program.addCommand(manifestCommand);
+program.addCommand(serveCommand);
 
 program.parse();

--- a/src/core/services/mcp-watcher.test.ts
+++ b/src/core/services/mcp-watcher.test.ts
@@ -106,6 +106,32 @@ describe('McpWatcher.handleChange', () => {
     expect(entry!.language).toBe('TypeScript');
   });
 
+  it('fires onBatchFlushed with changed paths on a real change, not on a no-op', async () => {
+    const ctx = makeContext();
+    const { rootPath, outputPath } = await setupProject(ctx);
+
+    const flushed: string[][] = [];
+    const { McpWatcher } = await import('./mcp-watcher.js');
+    const watcher = new McpWatcher({
+      rootPath,
+      outputPath,
+      onBatchFlushed: (paths) => flushed.push(paths),
+    });
+
+    // Real source change → callback fires with the abs path.
+    const srcFile = join(rootPath, 'svc.ts');
+    await writeFile(srcFile, 'export function go() { return 1; }', 'utf-8');
+    await watcher.handleChange(srcFile);
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]).toContain(srcFile);
+
+    // A test file is a no-op (skipped before any work) → callback must NOT fire.
+    const testFile = join(rootPath, 'svc.test.ts');
+    await writeFile(testFile, 'export function t() {}', 'utf-8');
+    await watcher.handleChange(testFile);
+    expect(flushed).toHaveLength(1);
+  });
+
   it('does not touch callGraph when patching signatures', async () => {
     const cg = makeCallGraph();
     const ctx = makeContext({ callGraph: cg });

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -78,6 +78,14 @@ export interface McpWatcherOptions {
   embedFileCeiling?: number;
   /** Extra glob patterns to ignore in addition to defaults */
   ignore?: string[];
+  /**
+   * Fired after each coalesced batch is flushed to disk (signatures + vector).
+   * Lets a host — e.g. the `openlore serve` daemon — schedule heavier work, such
+   * as a debounced full call-graph re-analyze, off the watcher's own lane. The
+   * watcher deliberately excludes the call graph (too expensive synchronously),
+   * so this is the seam where continuous call-graph freshness is layered on.
+   */
+  onBatchFlushed?: (changedAbsPaths: string[]) => void;
 }
 
 interface ChangedFile {
@@ -154,6 +162,7 @@ export class McpWatcher {
   private readonly embedFileCeiling: number;
   private readonly extraIgnore: string[];
   private readonly debug: boolean;
+  private readonly onBatchFlushed?: (changedAbsPaths: string[]) => void;
 
   private fsWatcher?: FSWatcher;
   private gitWatcher?: FSWatcher;
@@ -186,6 +195,7 @@ export class McpWatcher {
     this.embed       = options.embed ?? true;
     this.extraIgnore = options.ignore ?? [];
     this.debug       = !!process.env.OPENLORE_WATCH_DEBUG;
+    this.onBatchFlushed = options.onBatchFlushed;
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────────────────
@@ -456,6 +466,12 @@ export class McpWatcher {
     process.stderr.write(
       `[mcp-watcher] ${isBulk ? `coalesced ${n} changes` : `updated ${n} file${n === 1 ? '' : 's'}`} (${Date.now() - t0}ms)\n`
     );
+
+    // Real change flushed (signatures + edges patched on disk). Hand off to any
+    // host lane — e.g. serve's debounced call-graph re-analyze. Reached only when
+    // a meaningful batch was processed (the no-op early returns above skip it).
+    // Best-effort: a host callback error must never break the watcher.
+    try { this.onBatchFlushed?.(absPaths); } catch { /* host lane is best-effort */ }
   }
 
   /**

--- a/src/core/services/serve-client.test.ts
+++ b/src/core/services/serve-client.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for serve-client — the helper the MCP server uses to discover and call
+ * a shared `openlore serve` daemon. Drives a real daemon (startServe) on a
+ * temp root; no analysis there, so tools return structured { error } objects —
+ * we assert the transport (discover / call / unknown-tool / no-daemon), not the
+ * handler output.
+ *
+ * spawn is never exercised here (it would launch a detached process); we test
+ * discover-only paths against a daemon we start in-process.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { startServe, type ServeHandle } from '../../cli/commands/serve.js';
+import { ensureServeDaemon, callServeTool } from './serve-client.js';
+
+let handle: ServeHandle | undefined;
+let root = '';
+
+afterEach(async () => {
+  if (handle) { await handle.close(); handle = undefined; }
+  if (root) { await rm(root, { recursive: true, force: true }); root = ''; }
+});
+
+async function bootDaemon(): Promise<void> {
+  root = await mkdtemp(join(tmpdir(), 'openlore-client-'));
+  const h = await startServe({ directory: root, port: '0', watch: false });
+  if (!h) throw new Error('daemon did not start');
+  handle = h;
+}
+
+describe('serve-client', () => {
+  it('discovers a running daemon (spawn disabled)', async () => {
+    await bootDaemon();
+    const ep = await ensureServeDaemon(root, { spawn: false });
+    expect(ep).not.toBeNull();
+    expect(ep!.baseUrl).toBe(handle!.baseUrl);
+  });
+
+  it('returns null when no daemon is announced and spawn is disabled', async () => {
+    const empty = await mkdtemp(join(tmpdir(), 'openlore-client-'));
+    try {
+      const ep = await ensureServeDaemon(empty, { spawn: false });
+      expect(ep).toBeNull();
+    } finally {
+      await rm(empty, { recursive: true, force: true });
+    }
+  });
+
+  it('calls a tool and returns its body (handler error object on a bare root)', async () => {
+    await bootDaemon();
+    const ep = await ensureServeDaemon(root, { spawn: false });
+    const result = await callServeTool(ep!, 'orient', { task: 'x' }, root) as { error?: string };
+    expect(result.error).toMatch(/No analysis/i);
+  });
+
+  it('throws on an unknown tool so the caller can fall back', async () => {
+    await bootDaemon();
+    const ep = await ensureServeDaemon(root, { spawn: false });
+    await expect(callServeTool(ep!, 'not_a_real_tool', {}, root)).rejects.toThrow();
+  });
+
+  it('throws when the daemon is unreachable (stale endpoint)', async () => {
+    const ep = { baseUrl: 'http://127.0.0.1:1' }; // nothing listening
+    await expect(callServeTool(ep, 'orient', { task: 'x' }, '/tmp')).rejects.toThrow();
+  });
+});

--- a/src/core/services/serve-client.test.ts
+++ b/src/core/services/serve-client.test.ts
@@ -13,8 +13,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { startServe, type ServeHandle } from '../../cli/commands/serve.js';
-import { ensureServeDaemon, callServeTool } from './serve-client.js';
+import { serveCommand, startServe, type ServeHandle } from '../../cli/commands/serve.js';
+import { ensureServeDaemon, callServeTool, serveSpawnArgs } from './serve-client.js';
 
 let handle: ServeHandle | undefined;
 let root = '';
@@ -32,6 +32,22 @@ async function bootDaemon(): Promise<void> {
 }
 
 describe('serve-client', () => {
+  it('spawn args are accepted by the serve command (no rejected flags)', () => {
+    const args = serveSpawnArgs('/some/dir');
+    expect(args).toEqual(['serve', '--directory', '/some/dir']);
+    // Regression guard: the daemon must accept exactly these. `serve` exposes
+    // `--no-watch`, not `--watch`; commander rejects unknown options, which would
+    // silently kill the spawned daemon. Parse the flags (minus the leading
+    // 'serve') against the real command and assert none are unknown.
+    const known = new Set(serveCommand.options.flatMap((o) => [o.short, o.long].filter(Boolean)));
+    for (const a of args.slice(1)) {
+      if (a.startsWith('-')) {
+        expect(known.has(a), `serve rejects ${a}`).toBe(true);
+      }
+    }
+  });
+
+
   it('discovers a running daemon (spawn disabled)', async () => {
     await bootDaemon();
     const ep = await ensureServeDaemon(root, { spawn: false });

--- a/src/core/services/serve-client.ts
+++ b/src/core/services/serve-client.ts
@@ -39,6 +39,16 @@ function descriptorPath(directory: string): string {
   return join(directory, OPENLORE_DIR, 'serve.json');
 }
 
+/**
+ * CLI args to spawn the daemon. Exported + asserted in tests because the daemon
+ * MUST accept exactly these — `serve` has only `--no-watch` (watch is the
+ * default), so passing a non-existent `--watch` flag makes commander reject and
+ * the daemon never starts. Keep this in lockstep with serve.ts's options.
+ */
+export function serveSpawnArgs(directory: string): string[] {
+  return ['serve', '--directory', directory];
+}
+
 async function readDescriptor(directory: string): Promise<ServeDescriptor | null> {
   try {
     return JSON.parse(await readFile(descriptorPath(directory), 'utf-8')) as ServeDescriptor;
@@ -68,7 +78,7 @@ function endpointOf(desc: ServeDescriptor): ServeEndpoint {
 
 /**
  * Resolve a live daemon for `directory`: reuse an announced healthy one, else
- * (when `spawn` is true) start `openlore serve --watch` detached and poll until
+ * (when `spawn` is true) start `openlore serve` detached and poll until
  * /health is ready. Returns null if none could be brought up — callers then run
  * in-process. Never kills a daemon; it may serve other clients.
  */
@@ -87,7 +97,7 @@ export async function ensureServeDaemon(
   try {
     const child = spawn(
       process.execPath,
-      [cli, 'serve', '--watch', '--directory', directory],
+      [cli, ...serveSpawnArgs(directory)],
       { cwd: directory, stdio: 'ignore', detached: true },
     );
     child.on('error', () => {}); // swallow — caller falls back to in-process

--- a/src/core/services/serve-client.ts
+++ b/src/core/services/serve-client.ts
@@ -1,0 +1,135 @@
+/**
+ * serve-client — discover, spawn, and call the `openlore serve` daemon.
+ *
+ * Lets in-process callers (notably the stdio MCP server) delegate tool dispatch
+ * to a shared warm daemon instead of running it locally. Delegation means a
+ * single process holds the warm caches and runs ONE watcher for a repo, so two
+ * agents (Pi + Claude Code, or Claude Code + Cline) don't each spin a watcher
+ * racing to write the same .openlore/analysis.
+ *
+ * Every call degrades gracefully: if no daemon can be reached or spawned, the
+ * caller falls back to in-process dispatch.
+ */
+
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { OPENLORE_DIR } from '../../constants.js';
+
+/** Subset of the daemon's serve.json we need to reach it. */
+interface ServeDescriptor {
+  port: number;
+  pid: number;
+  host: string;
+  token?: string;
+}
+
+/** A resolved, reachable daemon. */
+export interface ServeEndpoint {
+  baseUrl: string;
+  token?: string;
+}
+
+const SPAWN_HEALTH_TIMEOUT_MS = 8000;
+const HEALTH_POLL_MS = 150;
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+function descriptorPath(directory: string): string {
+  return join(directory, OPENLORE_DIR, 'serve.json');
+}
+
+async function readDescriptor(directory: string): Promise<ServeDescriptor | null> {
+  try {
+    return JSON.parse(await readFile(descriptorPath(directory), 'utf-8')) as ServeDescriptor;
+  } catch {
+    return null;
+  }
+}
+
+/** True when a descriptor points at a LIVE daemon (ok:true /health), not a stale
+ * file or a recycled port owned by an unrelated server. */
+async function healthy(desc: ServeDescriptor): Promise<boolean> {
+  try {
+    const res = await fetch(`http://${desc.host}:${desc.port}/health`, {
+      signal: AbortSignal.timeout(1000),
+    });
+    if (!res.ok) return false;
+    const body = (await res.json().catch(() => null)) as { ok?: boolean } | null;
+    return body?.ok === true;
+  } catch {
+    return false;
+  }
+}
+
+function endpointOf(desc: ServeDescriptor): ServeEndpoint {
+  return { baseUrl: `http://${desc.host}:${desc.port}`, token: desc.token };
+}
+
+/**
+ * Resolve a live daemon for `directory`: reuse an announced healthy one, else
+ * (when `spawn` is true) start `openlore serve --watch` detached and poll until
+ * /health is ready. Returns null if none could be brought up — callers then run
+ * in-process. Never kills a daemon; it may serve other clients.
+ */
+export async function ensureServeDaemon(
+  directory: string,
+  opts: { spawn?: boolean } = {},
+): Promise<ServeEndpoint | null> {
+  const existing = await readDescriptor(directory);
+  if (existing && (await healthy(existing))) return endpointOf(existing);
+
+  if (opts.spawn === false) return null;
+
+  // Spawn via the same CLI entry that's running us (works installed or in dev).
+  const cli = process.argv[1];
+  if (!cli) return null;
+  try {
+    const child = spawn(
+      process.execPath,
+      [cli, 'serve', '--watch', '--directory', directory],
+      { cwd: directory, stdio: 'ignore', detached: true },
+    );
+    child.on('error', () => {}); // swallow — caller falls back to in-process
+    child.unref();
+  } catch {
+    return null;
+  }
+
+  const deadline = Date.now() + SPAWN_HEALTH_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await sleep(HEALTH_POLL_MS);
+    const desc = await readDescriptor(directory);
+    if (desc && (await healthy(desc))) return endpointOf(desc);
+  }
+  return null;
+}
+
+/**
+ * Call a tool on the daemon. Throws on transport failure so the caller can fall
+ * back to in-process dispatch; a tool-level error is returned in the body (the
+ * handler's own `{ error }`), not thrown.
+ */
+export async function callServeTool(
+  ep: ServeEndpoint,
+  name: string,
+  args: Record<string, unknown>,
+  directory: string,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (ep.token) headers['x-openlore-token'] = ep.token;
+  const res = await fetch(`${ep.baseUrl}/tool/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ directory, args }),
+    signal,
+  });
+  const body = await res.json().catch(() => null);
+  if (!res.ok) {
+    // 404 = unknown tool, etc. Surface as a thrown error → caller falls back.
+    const msg = (body as { error?: string } | null)?.error ?? `daemon HTTP ${res.status}`;
+    throw new Error(msg);
+  }
+  return body;
+}

--- a/src/core/services/tool-dispatch.ts
+++ b/src/core/services/tool-dispatch.ts
@@ -1,0 +1,279 @@
+/**
+ * Shared tool dispatch — single source of truth mapping a tool name + args to its
+ * handler. Consumed by BOTH transports:
+ *   - the stdio MCP server (`src/cli/commands/mcp.ts`)
+ *   - the local HTTP daemon (`src/cli/commands/serve.ts`)
+ *
+ * Keeping one dispatch table here prevents the two transports from drifting as
+ * handlers are added or their signatures change. This function is intentionally
+ * pure: it resolves args → handler → result and nothing else. Transport concerns
+ * (input validation, telemetry, epistemic/panic tracking, output truncation) stay
+ * in the caller.
+ *
+ * `directory` is passed explicitly (already resolved from `args.directory` by the
+ * caller) but most branches re-read it from `args` to preserve the exact behaviour
+ * the MCP server had before this extraction.
+ */
+
+import { DEFAULT_DRIFT_MAX_FILES } from '../../constants.js';
+import type { DecisionScope } from '../../types/index.js';
+
+import { handleOrient } from './mcp-handlers/orient.js';
+import { handleSelectTests } from './mcp-handlers/test-impact.js';
+import { handleFindDeadCode } from './mcp-handlers/reachability.js';
+import { handleStructuralDiff } from './mcp-handlers/structural-diff.js';
+import { handleGetChangeCoupling } from './mcp-handlers/change-coupling.js';
+import { handleCheckArchitecture } from './mcp-handlers/architecture.js';
+import { handleGenerateChangeProposal, handleAnnotateStory } from './mcp-handlers/change.js';
+import {
+  handleGetCallGraph,
+  handleGetSubgraph,
+  handleAnalyzeImpact,
+  handleGetLowRiskRefactorCandidates,
+  handleGetLeafFunctions,
+  handleGetCriticalHubs,
+  handleGetGodFunctions,
+  handleGetFileDependencies,
+  handleTraceExecutionPath,
+} from './mcp-handlers/graph.js';
+import {
+  handleSearchCode,
+  handleSuggestInsertionPoints,
+  handleSearchSpecs,
+  handleListSpecDomains,
+  handleGetSpec,
+  handleUnifiedSearch,
+} from './mcp-handlers/semantic.js';
+import {
+  handleRecordDecision,
+  handleListDecisions,
+  handleApproveDecision,
+  handleRejectDecision,
+  handleSyncDecisions,
+} from './mcp-handlers/decisions.js';
+import {
+  handleAnalyzeCodebase,
+  handleGetArchitectureOverview,
+  handleGetRefactorReport,
+  handleGetDuplicateReport,
+  handleGetSignatures,
+  handleGetMapping,
+  handleCheckSpecDrift,
+  handleGetFunctionSkeleton,
+  handleGetFunctionBody,
+  handleGetDecisions,
+  handleGetRouteInventory,
+  handleGetMiddlewareInventory,
+  handleGetSchemaInventory,
+  handleGetUIComponents,
+  handleGetEnvVars,
+  handleGetExternalPackages,
+  handleAuditSpecCoverage,
+  handleGenerateTests,
+  handleGetTestCoverage,
+  handleGetMinimalContext,
+  handleGetCluster,
+  handleDetectChanges,
+} from './mcp-handlers/analysis.js';
+
+/** Thrown when a tool name has no registered handler. Callers map this to their
+ * transport's "unknown tool" response (isError result / HTTP 404). */
+export class UnknownToolError extends Error {
+  constructor(public readonly toolName: string) {
+    super(`Unknown tool: ${toolName}`);
+    this.name = 'UnknownToolError';
+  }
+}
+
+/**
+ * Resolve a tool call to its result. Throws {@link UnknownToolError} for an
+ * unregistered name; propagates any handler error unchanged.
+ */
+export async function dispatchTool(
+  name: string,
+  args: Record<string, unknown>,
+  directory: string,
+): Promise<unknown> {
+  if (name === 'orient') {
+    const { task, limit = 5, tokenBudget, lean } = args as { task: string; limit?: number; tokenBudget?: number; lean?: boolean };
+    return handleOrient(directory, task, limit, tokenBudget, lean);
+  } else if (name === 'analyze_codebase') {
+    const { directory, force = false } = args as { directory: string; force?: boolean };
+    return handleAnalyzeCodebase(directory, force);
+  } else if (name === 'get_architecture_overview') {
+    const { directory } = args as { directory: string };
+    return handleGetArchitectureOverview(directory);
+  } else if (name === 'get_refactor_report') {
+    const { directory } = args as { directory: string };
+    return handleGetRefactorReport(directory);
+  } else if (name === 'get_call_graph') {
+    const { directory } = args as { directory: string };
+    return handleGetCallGraph(directory);
+  } else if (name === 'get_signatures') {
+    const { directory, filePattern } = args as { directory: string; filePattern?: string };
+    return handleGetSignatures(directory, filePattern);
+  } else if (name === 'get_subgraph') {
+    const { directory, functionName, direction = 'downstream', maxDepth = 3, format = 'json' } =
+      args as { directory: string; functionName: string; direction?: 'downstream' | 'upstream' | 'both'; maxDepth?: number; format?: 'json' | 'mermaid' };
+    return handleGetSubgraph(directory, functionName, direction, maxDepth, format);
+  } else if (name === 'trace_execution_path') {
+    const { directory, entryFunction, targetFunction, maxDepth = 6, maxPaths = 10 } =
+      args as { directory: string; entryFunction: string; targetFunction: string; maxDepth?: number; maxPaths?: number };
+    return handleTraceExecutionPath(directory, entryFunction, targetFunction, maxDepth, maxPaths);
+  } else if (name === 'get_mapping') {
+    const { directory, domain, orphansOnly } = args as { directory: string; domain?: string; orphansOnly?: boolean };
+    return handleGetMapping(directory, domain, orphansOnly);
+  } else if (name === 'analyze_impact') {
+    const { directory, symbol, depth = 2 } =
+      args as { directory: string; symbol: string; depth?: number };
+    return handleAnalyzeImpact(directory, symbol, depth);
+  } else if (name === 'select_tests') {
+    const { directory, changedSymbols, diffRef, maxDepth } =
+      args as { directory: string; changedSymbols?: string[]; diffRef?: string; maxDepth?: number };
+    return handleSelectTests({ directory, changedSymbols, diffRef, maxDepth });
+  } else if (name === 'find_dead_code') {
+    const { directory, ifDeleted, maxResults, filePattern } =
+      args as { directory: string; ifDeleted?: string; maxResults?: number; filePattern?: string };
+    return handleFindDeadCode({ directory, ifDeleted, maxResults, filePattern });
+  } else if (name === 'structural_diff') {
+    const { directory, baseRef, headRef, maxResults } =
+      args as { directory: string; baseRef?: string; headRef?: string; maxResults?: number };
+    return handleStructuralDiff({ directory, baseRef, headRef, maxResults });
+  } else if (name === 'get_change_coupling') {
+    const { directory, file, limit } = args as { directory: string; file?: string; limit?: number };
+    return handleGetChangeCoupling({ directory, file, limit });
+  } else if (name === 'check_architecture') {
+    const { directory, from, to } = args as { directory: string; from?: string; to?: string };
+    return handleCheckArchitecture({ directory, from, to });
+  } else if (name === 'get_low_risk_refactor_candidates') {
+    const { directory, limit = 5, filePattern } =
+      args as { directory: string; limit?: number; filePattern?: string };
+    return handleGetLowRiskRefactorCandidates(directory, limit, filePattern);
+  } else if (name === 'get_leaf_functions') {
+    const { directory, limit = 20, filePattern, sortBy = 'fanIn' } =
+      args as { directory: string; limit?: number; filePattern?: string; sortBy?: 'fanIn' | 'name' | 'file' };
+    return handleGetLeafFunctions(directory, limit, filePattern, sortBy);
+  } else if (name === 'get_critical_hubs') {
+    const { directory, limit = 10, minFanIn = 3 } =
+      args as { directory: string; limit?: number; minFanIn?: number };
+    return handleGetCriticalHubs(directory, limit, minFanIn);
+  } else if (name === 'get_duplicate_report') {
+    const { directory } = args as { directory: string };
+    return handleGetDuplicateReport(directory);
+  } else if (name === 'get_function_skeleton') {
+    const { directory, filePath } = args as { directory: string; filePath: string };
+    return handleGetFunctionSkeleton(directory, filePath);
+  } else if (name === 'get_god_functions') {
+    const { directory, filePath, fanOutThreshold = 8 } =
+      args as { directory: string; filePath?: string; fanOutThreshold?: number };
+    return handleGetGodFunctions(directory, filePath, fanOutThreshold);
+  } else if (name === 'check_spec_drift') {
+    const { directory, base = 'auto', files = [], domains = [], failOn = 'warning', maxFiles = DEFAULT_DRIFT_MAX_FILES } =
+      args as { directory: string; base?: string; files?: string[]; domains?: string[]; failOn?: 'error' | 'warning' | 'info'; maxFiles?: number };
+    return handleCheckSpecDrift(directory, base, files, domains, failOn, maxFiles);
+  } else if (name === 'search_code') {
+    const { directory, query, limit = 10, language, minFanIn, tokenBudget } =
+      args as { directory: string; query: string; limit?: number; language?: string; minFanIn?: number; tokenBudget?: number };
+    return handleSearchCode(directory, query, limit, language, minFanIn, tokenBudget);
+  } else if (name === 'suggest_insertion_points') {
+    const { directory, description, limit = 5, language } =
+      args as { directory: string; description: string; limit?: number; language?: string };
+    return handleSuggestInsertionPoints(directory, description, limit, language);
+  } else if (name === 'search_specs') {
+    const { directory, query, limit = 10, domain, section } =
+      args as { directory: string; query: string; limit?: number; domain?: string; section?: string };
+    return handleSearchSpecs(directory, query, limit, domain, section);
+  } else if (name === 'search_unified') {
+    const { directory, query, limit = 10, language, domain, section } =
+      args as { directory: string; query: string; limit?: number; language?: string; domain?: string; section?: string };
+    return handleUnifiedSearch(directory, query, limit, language, domain, section);
+  } else if (name === 'list_spec_domains') {
+    const { directory } = args as { directory: string };
+    return handleListSpecDomains(directory);
+  } else if (name === 'get_spec') {
+    const { directory, domain } = args as { directory: string; domain: string };
+    return handleGetSpec(directory, domain);
+  } else if (name === 'get_function_body') {
+    const { directory, filePath, functionName } =
+      args as { directory: string; filePath: string; functionName: string };
+    return handleGetFunctionBody(directory, filePath, functionName);
+  } else if (name === 'get_file_dependencies') {
+    const { directory, filePath, direction = 'both' } =
+      args as { directory: string; filePath: string; direction?: 'imports' | 'importedBy' | 'both' };
+    return handleGetFileDependencies(directory, filePath, direction);
+  } else if (name === 'generate_change_proposal') {
+    const { directory, description, slug, storyContent } =
+      args as { directory: string; description: string; slug: string; storyContent?: string };
+    return handleGenerateChangeProposal(directory, description, slug, storyContent);
+  } else if (name === 'annotate_story') {
+    const { directory, storyFilePath, description } =
+      args as { directory: string; storyFilePath: string; description: string };
+    return handleAnnotateStory(directory, storyFilePath, description);
+  } else if (name === 'get_decisions') {
+    const { directory, query } = args as { directory: string; query?: string };
+    return handleGetDecisions(directory, query);
+  } else if (name === 'get_route_inventory') {
+    const { directory } = args as { directory: string };
+    return handleGetRouteInventory(directory);
+  } else if (name === 'get_middleware_inventory') {
+    const { directory } = args as { directory: string };
+    return handleGetMiddlewareInventory(directory);
+  } else if (name === 'get_schema_inventory') {
+    const { directory } = args as { directory: string };
+    return handleGetSchemaInventory(directory);
+  } else if (name === 'get_ui_components') {
+    const { directory } = args as { directory: string };
+    return handleGetUIComponents(directory);
+  } else if (name === 'get_env_vars') {
+    const { directory } = args as { directory: string };
+    return handleGetEnvVars(directory);
+  } else if (name === 'get_external_packages') {
+    const { directory } = args as { directory: string };
+    return handleGetExternalPackages(directory);
+  } else if (name === 'audit_spec_coverage') {
+    const { directory, maxUncovered = 50, hubThreshold = 5 } =
+      args as { directory: string; maxUncovered?: number; hubThreshold?: number };
+    return handleAuditSpecCoverage(directory, maxUncovered, hubThreshold);
+  } else if (name === 'generate_tests') {
+    const { directory, domains, framework, useLlm, dryRun } =
+      args as {
+        directory: string;
+        domains?: string[];
+        framework?: string;
+        useLlm?: boolean;
+        dryRun?: boolean;
+      };
+    return handleGenerateTests({ directory, domains, framework, useLlm, dryRun });
+  } else if (name === 'get_test_coverage') {
+    const { directory, domains, minCoverage } =
+      args as { directory: string; domains?: string[]; minCoverage?: number };
+    return handleGetTestCoverage({ directory, domains, minCoverage });
+  } else if (name === 'get_minimal_context') {
+    const { directory, functionName, filePath } =
+      args as { directory: string; functionName: string; filePath?: string };
+    return handleGetMinimalContext(directory, functionName, filePath);
+  } else if (name === 'get_cluster') {
+    const { directory, functionName } = args as { directory: string; functionName: string };
+    return handleGetCluster(directory, functionName);
+  } else if (name === 'detect_changes') {
+    const { directory, base } = args as { directory: string; base?: string };
+    return handleDetectChanges(directory, base);
+  } else if (name === 'record_decision') {
+    const { directory, title, rationale, consequences, affectedFiles, supersedes, scope } =
+      args as { directory: string; title: string; rationale: string; consequences?: string; affectedFiles?: string[]; supersedes?: string; scope?: DecisionScope };
+    return handleRecordDecision(directory, title, rationale, consequences, affectedFiles, supersedes, scope);
+  } else if (name === 'list_decisions') {
+    const { directory, status } = args as { directory: string; status?: string };
+    return handleListDecisions(directory, status);
+  } else if (name === 'approve_decision') {
+    const { directory, id, note } = args as { directory: string; id: string; note?: string };
+    return handleApproveDecision(directory, id, note);
+  } else if (name === 'reject_decision') {
+    const { directory, id, note } = args as { directory: string; id: string; note?: string };
+    return handleRejectDecision(directory, id, note);
+  } else if (name === 'sync_decisions') {
+    const { directory, dryRun = false, id } = args as { directory: string; dryRun?: boolean; id?: string };
+    return handleSyncDecisions(directory, dryRun, id);
+  }
+  throw new UnknownToolError(name);
+}


### PR DESCRIPTION
## Problem

When multiple clients (Claude Code MCP, Cline, Pi) connect to the same repo, each spawns its own watcher and its own caches. Two agents race to write `.openlore/analysis`. Call-graph analysis drifts silently after edits because watchers only refresh signatures and vectors, never the full graph.

HTTP is a transport choice, not a second API surface. The goal is shared process ownership across heterogeneous clients — one warm process, one watcher, one source of truth per repository.

## Solution

`openlore serve` is a long-lived loopback HTTP daemon. All transports discover and delegate to it, so there is exactly one warm process per repository, shared across agents.

```
Pi extension   ─┐
Claude Code MCP ─┤──► openlore serve ──► dispatchTool() ──► handlers
Cline MCP      ─┘         │
                     one watcher
                     one cache
```

## Changes

**`tool-dispatch.ts` (new)** — single `dispatchTool()` called by both the stdio MCP server and the HTTP daemon. The two transports share one dispatch table and cannot drift. No behavior change; existing MCP tests pass unchanged.

**`openlore serve`** — loopback HTTP daemon:
- `GET /health` → `{ ok, version, preset, tools, uptimeMs }`
- `POST /tool/:name` body `{ directory, args }` → handler result
- Writes `.openlore/serve.json` for discovery; `--stop` for clean shutdown
- Optional `--token` (`x-openlore-token` header)
- Refuses to start a second daemon for a root already served by a live one

**Watcher + re-analyze lane** — `McpWatcher` keeps signatures/vectors live; a new `onBatchFlushed` hook schedules a debounced `analyze --force` after each edit burst, closing the call-graph drift gap between commits.

**MCP delegation** (`serve-client.ts`) — on each tool call, MCP discovers a running daemon and forwards to it. Falls back to in-process dispatch transparently on transport failure. Default: discover-and-reuse only (no spawn, no background process left behind). `--daemon` flag opts in to spawning.

**Watcher invariant enforced in both MCP paths** — both the `--watch-auto` (auto-detect) and `--watch <dir>` (explicit) paths skip watcher creation when a daemon is already serving the directory.

**Pi extension** (`examples/pi/openlore.ts`) — auto-starts the daemon, injects architecture digest + spec index + task-grounded `orient` on the first turn, registers 7 navigation tools. Uses `fetch` + `AbortSignal`. No MCP, no subprocess per call.

**`openlore setup --tools pi [--global]`** — installs the extension to `.pi/extensions/` or `~/.pi/agent/extensions/`.

**Auto-heal on schema bump** — if EdgeStore resets after a version upgrade, the daemon waits for background rebuild before serving graph tools instead of returning "index is empty".

## Tests

| File | What it covers |
|------|----------------|
| `serve.test.ts` | health, preset advisory, `serve.json` lifecycle, token gate, dup-daemon guard, stale `--stop`, 20 concurrent calls, watcher-invariant reuse path |
| `serve-client.test.ts` | discover / call / unknown-tool / unreachable / kill-9 simulation (stale serve.json → null) |
| `mcp-watcher.test.ts` | `onBatchFlushed` fires on real change, not on no-op |

Full suite: 150 test files, 3164 tests, 0 failures.

## Verified end-to-end

- orient, search_code, subgraph all return correct results from a warm daemon
- 20 concurrent calls: 20/20 valid responses, daemon healthy after
- Branch switching (main ↔ feat branch): daemon survives, orient coherent post-switch
- Kill -9: stale serve.json left on disk; health probe fails cleanly; new daemon starts and overwrites serve.json with updated PID
- Multi-client: MCP `--daemon` + running daemon → 1 serve.json, orient succeeds via delegation

## Known limitations (out of scope)

- Re-analyze runs in-process (brief event-loop block). Moving it off-thread requires explicit cache invalidation after rebuild — the two are coupled and will ship together.
- Watcher listens to `change` not `unlink`; stale rows for deleted files linger until the next `analyze --embed`. Pre-existing limitation.