### PR TITLE
fix(skill): keep orient perf metrics out of loaded context; add opt-in --metrics (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,18 @@ cp -R skills/openlore-orient /path/to/your-project/.claude/skills/
 
 The skill bundle ships a `SKILL.md` manifest, POSIX + PowerShell wrappers, a worked example, and a redacted real `orient()` JSON output so the model knows the response shape. See [`skills/openlore-orient/README.md`](skills/openlore-orient/README.md) for details.
 
+### What's in `skills/` — and what actually installs
+
+The `skills/` directory holds more than just `openlore-orient/`. Here's the map so nothing looks like a missing install step:
+
+| Path | What it is | How it installs |
+|---|---|---|
+| [`skills/openlore-orient/`](skills/openlore-orient/) | The **canonical** Claude Code skill — the one we recommend everyone install. | `npm run skill:install-local`, or `cp -R` into a project's `.claude/skills/` |
+| The 8 workflow skills (brainstorm, plan-refactor, execute-refactor, write-tests, review-changes, debug, implement-story, analyze-codebase) | Multi-agent **workflow** skills for Claude Code / OpenCode / Mistral Vibe. | `openlore setup` (sources them from [`examples/`](examples/) into `.claude/`, `.opencode/`, or `.vibe/`) |
+| Loose top-level `skills/*.md` (e.g. `claude-openlore.md`, `openlore-plan-refactor.md`) | **Reference prompt templates** — copy-paste starting points, not auto-installed by any command. | Manual copy if you want them |
+
+If you only install one thing, install `openlore-orient`. The workflow skills are opt-in via `openlore setup`; the loose `.md` files are just reference material.
+
 ---
 
 ## Core Features

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -322,6 +322,12 @@ The system SHALL enforce a payload-size budget guard on the MCP tools/list respo
 
 > Decision recorded: d54af0d3
 > Date: 2026-06-03
+### Requirement: KeepPerformanceMetricsOutOfAlwaysloadedSkillContextMakeOrientMeasurementOptinViaMetricsFlag
+
+The system SHALL keep performance metrics out of always-loaded skill context and provide orient measurement only via an opt-in --metrics flag.
+
+> Decision recorded: 37206feb
+> Date: 2026-06-05
 
 ## Technical Notes
 
@@ -418,3 +424,13 @@ Shallow 'who/where' lookups don't need provenance, change-coupling, insertion-po
 MCP has no server-driven lazy-schema mechanism (tools/list always returns full inputSchemas), and the dominant client (Claude Code) already defers schemas client-side. The server's only lossless lever is tool count + bytes; byte savings are ~2% because payload is dominated by irreducible per-tool schema structure. A meta-dispatcher tool was rejected (loses per-tool validation, Spec 11 annotations, discoverable selection surface, reintroduces wrong-tool round-trips). Forcing the navigation preset as install default was also rejected (hides governance tools the decision gate needs, per Spec 25 Phase B).
 
 **Consequences:** tools/list shrinks ~2% losslessly (47,037→46,118 B full; 8,121→8,002 B nav) with zero selection-quality risk. A budget-guard test regresses if surface bloats, making tool additions a conscious budget bump. Structural shallow-task prefix cost is acknowledged as client-controlled and not further reducible server-side; eager clients retain the --preset navigation lever.
+
+### Keep performance metrics out of always-loaded skill context; make orient measurement opt-in via --metrics flag
+
+**Status:** Approved
+**Date:** 2026-06-05
+**ID:** 37206feb
+
+The orient SKILL.md frontmatter description and 'Cost & latency' section embedded scorecard/benchmark numbers and relative ../../README.md links. The description loads into every agent context (pure token overhead) and the relative links break when the skill bundle is copied into a consumer's .claude/skills/. Performance transparency should remain available but opt-in, not baked into the loaded surface.
+
+**Consequences:** SKILL.md description carries no perf claims; the Cost & latency section is removed; transparency content moves to the bundle README (not loaded into context) using absolute GitHub URLs so links never break on copy. A new opt-in `openlore orient --metrics` flag reports wall time + output-size locally. agent-instructions install template drops the embedded metric sentence.

--- a/skills/openlore-orient/README.md
+++ b/skills/openlore-orient/README.md
@@ -43,6 +43,25 @@ Once OpenLore spec-01's `openlore install --agent claude-code` is shipped on npm
 | `examples/example-orient-output.json` | Real (redacted) output captured from this repo, so a reader can see the JSON shape without us writing a schema doc. |
 | `examples/example-task-prompt.md` | A short worked example of the full loop: task → orient call → output → next step. |
 
+## Performance & transparency (opt-in)
+
+`orient` is deterministic and local — no LLM, no API key, no network call. A typical call against a
+warm graph returns in well under a second; a cold first call may take a couple of seconds while the
+on-disk index loads, after which the in-memory cache serves the rest of the session.
+
+We deliberately keep these numbers **out of `SKILL.md`** so nothing is loaded into the agent's context
+unless you ask for it. If you want to measure on your own repo, the capability is built in as a flag:
+
+```sh
+openlore orient --metrics --task "your task"
+# wall time + output size are reported on stderr; the result on stdout is unchanged
+```
+
+The end-to-end, task-dependent benchmark numbers (wins *and* the small-repo loss cases) live in the
+main project README's [Value Scorecard](https://github.com/clay-good/OpenLore#value-scorecard--does-it-pay-for-itself).
+Links here use absolute URLs on purpose: copying this bundle into another project's `.claude/skills/`
+must never produce a broken relative link.
+
 ## Known limitations
 
 The `openlore orient --json --task "..."` CLI subcommand is shipped, and `orient` is also exposed as an MCP tool. The shell wrappers prefer the CLI subcommand and transparently fall back to driving `openlore mcp` over stdio JSON-RPC via the bundled [`scripts/orient-via-mcp.mjs`](scripts/orient-via-mcp.mjs) helper on older openlore versions that predate the subcommand.

--- a/skills/openlore-orient/SKILL.md
+++ b/skills/openlore-orient/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: openlore-orient
-version: 2.0
-description: Persistent architectural memory for this codebase. Call `orient(task)` before reading source files to get the relevant functions, callers, spec sections, and insertion points for any task — one structural lookup instead of file-by-file rediscovery (measured −26% agent round-trips on deep traces; see the README Value Scorecard).
+version: 2.1
+description: Persistent architectural memory for this codebase. Call `orient(task)` before reading source files to get the relevant functions, callers, spec sections, and insertion points for any task — one structural lookup instead of file-by-file rediscovery.
 ---
 
 # OpenLore — orient before you read
@@ -53,28 +53,14 @@ For a quick "who calls X" / "where is Y defined" lookup, pass **`lean: true`** (
 
 > **Note:** the `openlore orient --json --task` CLI subcommand is available, so the wrappers use it directly. The MCP fallback in the wrappers only kicks in on older openlore versions that predate the subcommand.
 
+> **Want to measure it on your own repo?** Pass `--metrics` (off by default) to have `orient` report its wall time and output size to stderr. Nothing is measured or printed unless you ask for it.
+
 ## What NOT to do
 
 - **Do not open source files before `orient` has returned.** This is the single most expensive mistake — you'll re-derive what the graph already knows.
 - **Do not call `orient` on every edit.** It's a session-start and re-orient-on-staleness tool, not a per-call helper. Respect the Epistemic Lease signal — if no prefix appears, your context is still fresh.
 - **Do not paraphrase the task** when passing it to `orient`. Use the user's words. The semantic search matches better when the query language matches the eventual prompt.
 - **Do not ignore `specDomains`.** Reading specs first is faster and more accurate than reading code first, in this repo.
-
-## Cost & latency
-
-Typical `orient()` against a warm graph in this repo:
-
-| Measurement | Value |
-|---|---|
-| Wall time | < 500 ms |
-| Output size | ~1–3k tokens of JSON |
-| Network calls | 0 (all local — no LLM, no API key required) |
-
-End-to-end agent benefit is **task-dependent and measured**, not a fixed per-call token figure:
-**−7%→−21% cost / −26% round-trips on deep traces in large repos**, but *added* overhead on small,
-familiar repos — see the [README Value Scorecard](../../README.md#value-scorecard--does-it-pay-for-itself).
-
-Cold-graph first call may take 2–4s if the on-disk index needs to be loaded; subsequent calls in the same session hit the in-memory cache. See the [main README benchmarks](../../README.md) for the published numbers.
 
 ## Failure modes
 

--- a/src/cli/commands/orient.test.ts
+++ b/src/cli/commands/orient.test.ts
@@ -40,7 +40,7 @@ describe('orient command', () => {
     // orientCommand is a module-level singleton; commander retains option
     // values between parseAsync() calls, so reset them so one test's flags
     // (e.g. --limit 0) don't bleed into the next.
-    for (const opt of ['task', 'directory', 'limit', 'json']) {
+    for (const opt of ['task', 'directory', 'limit', 'json', 'lean', 'tokenBudget', 'metrics']) {
       orientCommand.setOptionValue(opt, undefined);
     }
   });
@@ -67,6 +67,7 @@ describe('orient command', () => {
       expect(longs).toContain('--json');
       expect(longs).toContain('--directory');
       expect(longs).toContain('--limit');
+      expect(longs).toContain('--metrics');
     });
   });
 
@@ -154,6 +155,31 @@ describe('orient command', () => {
       // The stray line was redirected to stderr instead.
       const stderrText = stderrSpy.mock.calls.map(c => String(c[0])).join('');
       expect(stderrText).toContain('Successfully validated');
+      stderrSpy.mockRestore();
+    });
+  });
+
+  describe('--metrics (opt-in performance readout, Issue #128)', () => {
+    it('reports wall time and output size to stderr, leaving stdout JSON clean', async () => {
+      mockHandleOrient.mockResolvedValue({ task: 'x', searchMode: 'hybrid', relevantFunctions: [] });
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await orientCommand.parseAsync(['--json', '--metrics', '--task', 'x'], { from: 'user' });
+      const stderrText = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(stderrText).toContain('[orient:metrics]');
+      expect(stderrText).toMatch(/wall=[\d.]+ms/);
+      expect(stderrText).toMatch(/output≈\d+ tokens/);
+      // The metrics line must not leak onto stdout (wrappers parse stdout as JSON).
+      const parsed = JSON.parse(output());
+      expect(parsed.searchMode).toBe('hybrid');
+      stderrSpy.mockRestore();
+    });
+
+    it('writes no metrics line when --metrics is omitted (off by default)', async () => {
+      mockHandleOrient.mockResolvedValue({ task: 'x', searchMode: 'hybrid', relevantFunctions: [] });
+      const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+      await orientCommand.parseAsync(['--json', '--task', 'x'], { from: 'user' });
+      const stderrText = stderrSpy.mock.calls.map(c => String(c[0])).join('');
+      expect(stderrText).not.toContain('[orient:metrics]');
       stderrSpy.mockRestore();
     });
   });

--- a/src/cli/commands/orient.ts
+++ b/src/cli/commands/orient.ts
@@ -16,6 +16,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { logger } from '../../utils/logger.js';
 import { handleOrient } from '../../core/services/mcp-handlers/orient.js';
+import { estimateTokens } from '../../core/services/llm-service.js';
 import { OPENLORE_ANALYSIS_REL_PATH } from '../../constants.js';
 
 interface OrientCliOptions {
@@ -25,6 +26,21 @@ interface OrientCliOptions {
   tokenBudget?: string;
   lean?: boolean;
   json?: boolean;
+  metrics?: boolean;
+}
+
+/**
+ * Opt-in performance readout (Issue #128). Off by default — nothing is measured
+ * or printed unless the caller passes --metrics. Reported to stderr so it never
+ * corrupts the JSON on stdout that the skill wrappers parse. Local-only: wall
+ * time plus an estimate of the result's output size; no network, no LLM.
+ */
+function reportMetrics(startNs: bigint, result: Record<string, unknown>): void {
+  const wallMs = Number(process.hrtime.bigint() - startNs) / 1e6;
+  const tokens = estimateTokens(JSON.stringify(result));
+  process.stderr.write(
+    `[orient:metrics] wall=${wallMs.toFixed(1)}ms output≈${tokens} tokens (local, no network)\n`
+  );
 }
 
 /** True once `openlore analyze` has produced an llm-context artifact. */
@@ -124,6 +140,7 @@ export const orientCommand = new Command('orient')
   .option('--token-budget <n>', 'Cap relevantFunctions to ~this many tokens (Spec 25 P4); highest-scored kept, exact duplicates collapsed')
   .option('--lean', 'Return only the navigation core — drop provenance/change-coupling/insertion-points/specs/decisions enrichment (Spec 27)', false)
   .option('--json', 'Emit the full result as JSON instead of a human-readable summary', false)
+  .option('--metrics', 'Report wall time and output size to stderr (opt-in; off by default)', false)
   .addHelpText(
     'after',
     `
@@ -131,6 +148,7 @@ Examples:
   $ openlore orient --task "add a new CLI command"
   $ openlore orient --json --task "fix the analyze cache"
   $ openlore orient --json --task "auth flow" --limit 10
+  $ openlore orient --metrics --task "auth flow"   # opt-in wall-time/output-size readout
 
 Requires "openlore analyze" to have been run at least once. With no --task,
 prints a short session-start primer (used by the install SessionStart hook).
@@ -168,9 +186,11 @@ prints a short session-start primer (used by the install SessionStart hook).
       // In --json mode keep stdout clean (validateDirectory logs to stdout);
       // in human mode let diagnostics through normally.
       const lean = opts.lean ?? false;
+      const startNs = opts.metrics ? process.hrtime.bigint() : 0n;
       const result = (asJson
         ? await withQuietStdout(() => handleOrient(directory, task, limit, tokenBudget, lean))
         : await handleOrient(directory, task, limit, tokenBudget, lean)) as Record<string, unknown>;
+      if (opts.metrics) reportMetrics(startNs, result);
       // Always emit structured results (including the "no analysis" error object)
       // on stdout so wrapper scripts can parse them — mirroring the MCP tool.
       if (asJson) {

--- a/src/cli/install/templates/agent-instructions.md
+++ b/src/cli/install/templates/agent-instructions.md
@@ -3,9 +3,7 @@ This project uses OpenLore for persistent architectural memory.
 ALWAYS call `orient()` (via the openlore MCP server, or `npx openlore orient --json`)
 before reading source files when starting a new task. This returns the relevant
 functions, callers, spec sections, and insertion points for the task at hand —
-one structural lookup instead of file-by-file rediscovery. Measured benefit is
-task-dependent (−26% agent round-trips on deep traces in large repos; little to
-none on small, familiar repos).
+one structural lookup instead of file-by-file rediscovery.
 
 Re-orient whenever the Epistemic Lease indicates staleness (you'll see a prefix
 on tool responses telling you to do so).


### PR DESCRIPTION
Closes #128.

Thanks @jtlapp for the careful report — you were right on every point. The orient skill was carrying performance/scorecard prose that gets loaded into agent context for no reason, and the relative links broke when the bundle is copied. This PR removes the in-context metrics, fixes the broken links, makes measurement opt-in, and clarifies the side question about the other skills.

## What changed

### 1. Perf metrics no longer load into context
- **`SKILL.md` frontmatter `description`** — dropped the `(measured −26% agent round-trips …; see the README Value Scorecard)` parenthetical. The description loads into every agent's context, so this was pure token overhead.
- **Removed the entire `## Cost & latency` section** from `SKILL.md` (the table + scorecard/benchmark references).
- **`agent-instructions.md`** install template — removed the embedded `−26% … round-trips` sentence (another in-context surface).

### 2. Broken links fixed
The removed `Cost & latency` section was the source of the `../../README.md` relative links. When the bundle is copied into a consumer's `.claude/skills/openlore-orient/`, those resolved to a non-existent `.claude/README.md`, which is what made VS Code flag every `.claude` directory yellow (a real pain in a monorepo with one install per package). The skill bundle now has **zero `../..` relative links**. Any link that remains (in the bundle README) uses an **absolute GitHub URL** so it can never break on copy.

### 3. Measurement is now opt-in, "built in as a flag"
Performance transparency still matters, so it didn't disappear — it moved out of the always-loaded surface:
- New **`openlore orient --metrics`** flag (off by default). It reports wall time + output-size to **stderr** (stdout JSON stays clean for the wrappers). Nothing is measured or printed unless you ask for it.
  ```
  $ openlore orient --metrics --task "auth flow"
  [orient:metrics] wall=161.0ms output≈1507 tokens (local, no network)
  ```
- The transparency/benchmark prose moved to the **bundle README** (`skills/openlore-orient/README.md`), which is *not* loaded into context — it's documentation you read on demand.

### 4. Side question answered
Added a `What's in skills/ — and what actually installs` table to the main README explaining the three categories:
- `openlore-orient/` — the canonical skill (`npm run skill:install-local`)
- the 8 workflow skills — installed via `openlore setup` (sourced from `examples/`)
- loose top-level `skills/*.md` — reference prompt templates, not auto-installed

I deliberately did **not** delete the loose `.md` files in this PR (they're referenced from a few docs and that's a separable cleanup) — happy to follow up if you'd like them removed.

## Verification
- `tsc --noEmit` clean; `eslint` clean on changed files.
- `vitest run src/cli` — 485 passed (added 2 tests for `--metrics`: it writes the readout to stderr + keeps stdout JSON clean, and it's silent when omitted).
- `honesty-contract.test.ts` still green (the canonical scorecard figures live in the README, not the skill).
- Smoke-tested `--metrics` end-to-end against this repo: metrics on stderr, valid JSON on stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)