### PR TITLE
fix: post-PR-131 correctness pass — serve schema-reset stall + repo-wide bug fixes

### DIFF
--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -330,7 +330,7 @@ The system SHALL keep performance metrics out of always-loaded skill context and
 > Date: 2026-06-05
 ### Requirement: ServeDaemonOwnsSchemaresetRebuildTrigger
 
-The system SHALL The serve daemon SHALL trigger a background `analyze --force` rebuild whenever a schema-version reset is detected, deduplicating concurrent rebuilds per directory.
+The system SHALL trigger a background `analyze --force` rebuild from the serve daemon whenever a schema-version reset is detected, deduplicating concurrent rebuilds per directory.
 
 > Decision recorded: 55d797b9
 > Date: 2026-06-07

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -334,6 +334,12 @@ The system SHALL The serve daemon SHALL trigger a background `analyze --force` r
 
 > Decision recorded: 55d797b9
 > Date: 2026-06-07
+### Requirement: UnifySchemaresetAndWatcherRebuildsThroughASingleflightCoordinator
+
+The system SHALL ensure that at most one forced graph rebuild runs per directory at a time, coalescing additional triggers into a single follow-up run.
+
+> Decision recorded: f0885af9
+> Date: 2026-06-07
 
 ## Technical Notes
 
@@ -450,3 +456,13 @@ The orient SKILL.md frontmatter description and 'Cost & latency' section embedde
 EdgeStore.open() consumes the wasReset flag on first open, so the watcher's self-heal (which also keys off wasReset) never fires; the serve daemon must initiate `analyze --force` itself or waitForGraphRebuild polls an empty store until timeout
 
 **Consequences:** Serve now carries a deduplication Set and spawns background analyze processes; if the analyze binary is unavailable the daemon logs a warning but requests hang until timeout
+
+### Unify schema-reset and watcher rebuilds through a single-flight coordinator
+
+**Status:** Approved
+**Date:** 2026-06-07
+**ID:** f0885af9
+
+Two independent code paths (schema-reset healer and watcher-debounced re-analyze) both invoked `openloreAnalyze --force` on the same directory, risking concurrent non-atomic EdgeStore clear+repopulate that could tear the graph. Merging them into one coordinator with a running/pending state machine eliminates the race.
+
+**Consequences:** All forced rebuilds in serve now share one lock per directory; a trigger arriving mid-rebuild is coalesced into exactly one follow-up run. The served root directory re-enters the debounce path to avoid back-to-back analyzes under sustained editing, while per-request directories re-run immediately.

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -328,6 +328,12 @@ The system SHALL keep performance metrics out of always-loaded skill context and
 
 > Decision recorded: 37206feb
 > Date: 2026-06-05
+### Requirement: ServeDaemonOwnsSchemaresetRebuildTrigger
+
+The system SHALL The serve daemon SHALL trigger a background `analyze --force` rebuild whenever a schema-version reset is detected, deduplicating concurrent rebuilds per directory.
+
+> Decision recorded: 55d797b9
+> Date: 2026-06-07
 
 ## Technical Notes
 
@@ -434,3 +440,13 @@ MCP has no server-driven lazy-schema mechanism (tools/list always returns full i
 The orient SKILL.md frontmatter description and 'Cost & latency' section embedded scorecard/benchmark numbers and relative ../../README.md links. The description loads into every agent context (pure token overhead) and the relative links break when the skill bundle is copied into a consumer's .claude/skills/. Performance transparency should remain available but opt-in, not baked into the loaded surface.
 
 **Consequences:** SKILL.md description carries no perf claims; the Cost & latency section is removed; transparency content moves to the bundle README (not loaded into context) using absolute GitHub URLs so links never break on copy. A new opt-in `openlore orient --metrics` flag reports wall time + output-size locally. agent-instructions install template drops the embedded metric sentence.
+
+### Serve daemon owns schema-reset rebuild trigger
+
+**Status:** Approved
+**Date:** 2026-06-07
+**ID:** 55d797b9
+
+EdgeStore.open() consumes the wasReset flag on first open, so the watcher's self-heal (which also keys off wasReset) never fires; the serve daemon must initiate `analyze --force` itself or waitForGraphRebuild polls an empty store until timeout
+
+**Consequences:** Serve now carries a deduplication Set and spawns background analyze processes; if the analyze binary is unavailable the daemon logs a warning but requests hang until timeout

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -68,6 +68,8 @@ import { createProgress } from '../../utils/progress.js';
 interface ExtendedGenerateOptions extends GenerateOptions {
   merge?: boolean;
   noOverwrite?: boolean;
+  /** Commander's storage key for `--no-overwrite` (default true; false when passed). */
+  overwrite?: boolean;
   yes?: boolean;
   outputDir?: string;
   force?: boolean;
@@ -199,8 +201,7 @@ export const generateCommand = new Command('generate')
   )
   .option(
     '--no-overwrite',
-    'Skip any existing spec files',
-    false
+    'Skip any existing spec files'
   )
   .option(
     '-y, --yes',
@@ -281,7 +282,8 @@ Each spec.md follows OpenSpec conventions:
       adr: options.adr ?? false,
       adrOnly: options.adrOnly ?? false,
       merge: options.merge ?? false,
-      noOverwrite: options.noOverwrite ?? false,
+      // commander stores `--no-overwrite` under the `overwrite` key (default true).
+      noOverwrite: options.overwrite === false,
       yes: options.yes ?? false,
       outputDir: options.outputDir,
       quiet: false,

--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -11,7 +11,11 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtemp, rm, readFile, access, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { startServe, type ServeHandle } from './serve.js';
+import { EdgeStore } from '../../core/services/edge-store.js';
+import { openloreAnalyze } from '../../api/analyze.js';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR } from '../../constants.js';
 
 let handle: ServeHandle | undefined;
 let root = '';
@@ -163,6 +167,60 @@ describe('openlore serve', () => {
     await h2!.close();
     expect((await fetch(`${h1.baseUrl}/health`)).status).toBe(200);
   });
+
+  it('repopulates the graph after a schema-version reset instead of stalling', async () => {
+    // Regression for the schema-reset auto-heal: EdgeStore.open() reports wasReset
+    // exactly ONCE (it rewrites the on-disk version on that first open), so the
+    // watcher's wasReset-keyed self-heal never fires once serve's startup open has
+    // consumed the flag. Serve must therefore kick `analyze --force` itself —
+    // otherwise every graph request polls an empty store until the 60s timeout.
+    root = await mkdtemp(join(tmpdir(), 'openlore-serve-reset-'));
+    await mkdir(join(root, OPENLORE_DIR), { recursive: true });
+    await mkdir(join(root, 'openspec', 'specs'), { recursive: true });
+    await writeFile(
+      join(root, OPENLORE_DIR, 'config.json'),
+      JSON.stringify({
+        version: '1.0.0', projectType: 'unknown', openspecPath: './openspec',
+        analysis: { maxFiles: 100000, includePatterns: [], excludePatterns: [] },
+        generation: { model: 'claude-sonnet-4-6', domains: 'auto' },
+        createdAt: new Date().toISOString(), lastRun: null,
+      }, null, 2),
+      'utf-8',
+    );
+    await writeFile(
+      join(root, 'index.js'),
+      'export function add(a, b) { return a + b; }\nexport function main() { return add(1, 2); }\n',
+      'utf-8',
+    );
+
+    // Build a real, populated graph, then simulate a post-upgrade schema bump by
+    // forcing the on-disk version stale so the next open() wipes + flags wasReset.
+    await openloreAnalyze({ rootPath: root, force: true });
+    const analysisDir = join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+    const dbFile = EdgeStore.dbPath(analysisDir);
+    {
+      const probe = EdgeStore.open(dbFile);
+      expect(probe.countNodes()).toBeGreaterThan(0); // sanity: analyze populated it
+      probe.close();
+    }
+    const raw = new DatabaseSync(dbFile);
+    raw.exec('UPDATE schema_version SET version = 0');
+    raw.close();
+
+    // Start serve (watch:false so the ONLY possible healer is serve's own trigger).
+    handle = await startServe({ directory: root, port: '0', watch: false });
+    expect(handle).toBeDefined();
+
+    // The startup open consumed wasReset and wiped the DB; the fix must rebuild it.
+    let nodes = 0;
+    for (let i = 0; i < 100 && nodes === 0; i++) {
+      await new Promise((r) => setTimeout(r, 100));
+      const es = EdgeStore.open(dbFile);
+      nodes = es.countNodes();
+      es.close();
+    }
+    expect(nodes).toBeGreaterThan(0); // rebuilt, not left empty
+  }, 30_000);
 
   it('rejects an unknown preset at startup', async () => {
     root = await mkdtemp(join(tmpdir(), 'openlore-serve-'));

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -224,24 +224,38 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   // re-open EdgeStore. Uses a Map because the daemon can serve multiple dirs.
   const schemaResetByDir = new Map<string, boolean>();
 
-  // In-flight schema-reset rebuilds, keyed by directory, so we kick exactly one
-  // `analyze --force` per reset and never stack duplicates across requests.
-  const rebuildingDirs = new Set<string>();
-
-  // A schema-version bump makes EdgeStore.open() wipe the DB and report wasReset
-  // ONCE (the on-disk version is rewritten on that first open, so every later
-  // open reports false). We consume that flag at startup / on the first request,
-  // which means the watcher's own self-heal (which keys off wasReset) never sees
-  // it — so serve MUST start the rebuild itself, or waitForGraphRebuild() below
-  // would poll an empty store until it times out.
-  function triggerSchemaRebuild(directory: string): void {
-    if (rebuildingDirs.has(directory)) return;
-    rebuildingDirs.add(directory);
-    logger.discovery(`[serve] schema reset detected — rebuilding graph index (${directory})`);
+  // Single forced-rebuild coordinator, keyed by directory. BOTH the schema-reset
+  // healer (below) and the watcher's debounced re-analyze (further down) funnel
+  // through here, so at most one `analyze --force` ever runs per directory at a
+  // time — two concurrent ones would clear+repopulate the same EdgeStore
+  // non-atomically and could tear the graph. A trigger that arrives mid-rebuild
+  // is coalesced into a single follow-up run rather than dropped or stacked.
+  //
+  // Why serve must drive this at all: a schema-version bump makes EdgeStore.open()
+  // wipe the DB and report wasReset ONCE (the on-disk version is rewritten on that
+  // first open, so every later open reports false). serve consumes that flag at
+  // startup / first request, so the watcher's wasReset-keyed self-heal never sees
+  // it; without an explicit trigger, waitForGraphRebuild() would poll an empty
+  // store until it times out.
+  const rebuildRunning = new Set<string>();
+  const rebuildPending = new Set<string>();
+  function triggerRebuild(directory: string): void {
+    if (rebuildRunning.has(directory)) { rebuildPending.add(directory); return; }
+    rebuildRunning.add(directory);
+    logger.discovery(`[serve] rebuilding graph index (${directory})`);
     void openloreAnalyze({ rootPath: directory, force: true })
-      .then(() => logger.discovery(`[serve] schema-reset rebuild complete (${directory})`))
-      .catch((err) => logger.warning(`[serve] schema-reset rebuild failed: ${err instanceof Error ? err.message : String(err)}`))
-      .finally(() => rebuildingDirs.delete(directory));
+      .then(() => logger.discovery(`[serve] graph index rebuilt (${directory})`))
+      .catch((err) => logger.warning(`[serve] graph rebuild failed: ${err instanceof Error ? err.message : String(err)}`))
+      .finally(() => {
+        rebuildRunning.delete(directory);
+        if (rebuildPending.delete(directory)) {
+          // Re-run for the coalesced trigger. For the served root, go back through
+          // the debounce so sustained editing doesn't spin back-to-back analyzes;
+          // other dirs (per-request schema heal) re-run immediately.
+          if (directory === root) scheduleReanalyze();
+          else triggerRebuild(directory);
+        }
+      });
   }
 
   const server = createServer((req, res) => {
@@ -321,9 +335,9 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
       }
       if (schemaResetByDir.get(directory)) {
         logger.debug(`[serve] Schema mismatch — waiting for graph rebuild before dispatching…`);
-        // Kick the rebuild ourselves (deduped) — nothing else will, because the
+        // Kick the rebuild ourselves (coalesced) — nothing else will, because the
         // wasReset flag has already been consumed by the open above.
-        triggerSchemaRebuild(directory);
+        triggerRebuild(directory);
         // waitForGraphRebuild polls readCachedContext until edgeStore is
         // non-null. readCachedContext invalidates on llm-context.json mtime,
         // which openloreAnalyze rewrites as its last step — so the poll sees
@@ -389,7 +403,7 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
         // Actually start the rebuild — the warning above is only honest if
         // something kicks `analyze --force`. The watcher won't: its self-heal
         // keys off wasReset, which this startup open just consumed.
-        triggerSchemaRebuild(root);
+        triggerRebuild(root);
       }
     } else {
       schemaResetByDir.set(root, false);
@@ -406,25 +420,12 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   // commits — turning divergence from "wait for the next commit" into continuous.
   let watcher: McpWatcher | undefined;
   let reanalyzeTimer: ReturnType<typeof setTimeout> | undefined;
-  let reanalyzeRunning = false;
-  let reanalyzePending = false;
 
-  const runReanalyze = async (): Promise<void> => {
-    if (reanalyzeRunning) { reanalyzePending = true; return; } // single-flight + coalesce
-    reanalyzeRunning = true;
-    try {
-      await openloreAnalyze({ rootPath: root, force: true });
-      logger.discovery(`[serve] call graph re-analyzed (${root})`);
-    } catch (err) {
-      logger.warning(`[serve] re-analyze failed: ${err instanceof Error ? err.message : String(err)}`);
-    } finally {
-      reanalyzeRunning = false;
-      if (reanalyzePending) { reanalyzePending = false; scheduleReanalyze(); }
-    }
-  };
+  // Debounced call-graph re-analyze. Routes through triggerRebuild so it shares
+  // the single-flight lock with the schema-reset healer (no concurrent --force).
   function scheduleReanalyze(): void {
     if (reanalyzeTimer) clearTimeout(reanalyzeTimer);
-    reanalyzeTimer = setTimeout(() => void runReanalyze(), REANALYZE_DEBOUNCE_MS);
+    reanalyzeTimer = setTimeout(() => triggerRebuild(root), REANALYZE_DEBOUNCE_MS);
   }
 
   if (options.watch !== false) {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -224,6 +224,26 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   // re-open EdgeStore. Uses a Map because the daemon can serve multiple dirs.
   const schemaResetByDir = new Map<string, boolean>();
 
+  // In-flight schema-reset rebuilds, keyed by directory, so we kick exactly one
+  // `analyze --force` per reset and never stack duplicates across requests.
+  const rebuildingDirs = new Set<string>();
+
+  // A schema-version bump makes EdgeStore.open() wipe the DB and report wasReset
+  // ONCE (the on-disk version is rewritten on that first open, so every later
+  // open reports false). We consume that flag at startup / on the first request,
+  // which means the watcher's own self-heal (which keys off wasReset) never sees
+  // it — so serve MUST start the rebuild itself, or waitForGraphRebuild() below
+  // would poll an empty store until it times out.
+  function triggerSchemaRebuild(directory: string): void {
+    if (rebuildingDirs.has(directory)) return;
+    rebuildingDirs.add(directory);
+    logger.discovery(`[serve] schema reset detected — rebuilding graph index (${directory})`);
+    void openloreAnalyze({ rootPath: directory, force: true })
+      .then(() => logger.discovery(`[serve] schema-reset rebuild complete (${directory})`))
+      .catch((err) => logger.warning(`[serve] schema-reset rebuild failed: ${err instanceof Error ? err.message : String(err)}`))
+      .finally(() => rebuildingDirs.delete(directory));
+  }
+
   const server = createServer((req, res) => {
     void handleRequest(req, res).catch((err) => {
       sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
@@ -301,6 +321,9 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
       }
       if (schemaResetByDir.get(directory)) {
         logger.debug(`[serve] Schema mismatch — waiting for graph rebuild before dispatching…`);
+        // Kick the rebuild ourselves (deduped) — nothing else will, because the
+        // wasReset flag has already been consumed by the open above.
+        triggerSchemaRebuild(directory);
         // waitForGraphRebuild polls readCachedContext until edgeStore is
         // non-null. readCachedContext invalidates on llm-context.json mtime,
         // which openloreAnalyze rewrites as its last step — so the poll sees
@@ -363,6 +386,10 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
           `[serve] Schema version mismatch detected — graph index is being rebuilt in the background. ` +
           `Graph-dependent tools will wait for completion on first request.`
         );
+        // Actually start the rebuild — the warning above is only honest if
+        // something kicks `analyze --force`. The watcher won't: its self-heal
+        // keys off wasReset, which this startup open just consumed.
+        triggerSchemaRebuild(root);
       }
     } else {
       schemaResetByDir.set(root, false);

--- a/src/core/analyzer/artifact-generator.ts
+++ b/src/core/analyzer/artifact-generator.ts
@@ -31,30 +31,11 @@ import type { RouteInventory } from './http-route-parser.js';
 import type { MiddlewareEntry } from './middleware-extractor.js';
 import type { EnvVar } from './env-extractor.js';
 
-/**
- * Heuristic to detect test/spec files across languages.
- * Excludes them from call graph analysis — test helpers inflate fanIn,
- * and test functions are never "unreachable" by definition.
- *
- * Patterns covered:
- *   TypeScript/JS: *.test.ts, *.spec.ts, *.test.tsx, __tests__/*, test_*.ts
- *   Python:        test_*.py, *_test.py, tests/*.py
- *   Go:            *_test.go
- *   Rust:          files with #[cfg(test)] (not detectable here — excluded by directory pattern)
- *   Java/Kotlin:   *Test.java, *Spec.kt
- */
-export function isTestFile(filePath: string): boolean {
-  const name = filePath.replace(/\\/g, '/');
-  return (
-    /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(name) ||   // JS/TS: foo.test.ts
-    /(^|\/)__tests__\//.test(name) ||                          // JS/TS: __tests__/
-    /(^|\/)test_[^/]+\.(ts|js|py)$/.test(name) ||             // Python/TS: test_foo.py
-    /[^/]+_test\.(py|go)$/.test(name) ||                      // Python/Go: foo_test.py, foo_test.go
-    /(^|\/)tests?\/[^/]+\.(py|ts|js|rb|php)$/.test(name) ||  // tests/ directory
-    /[A-Z][a-zA-Z0-9]*Test\.(java|kt|scala)$/.test(name) ||  // Java: FooTest.java
-    /[A-Z][a-zA-Z0-9]*Spec\.(kt|scala|rb)$/.test(name)       // Kotlin/Ruby: FooSpec.kt
-  );
-}
+// Canonical cross-language test-file predicate. Re-exported here for the many
+// existing importers (e.g. spec-pipeline); the call-graph builder imports the
+// same shared definition so the two can no longer drift.
+export { isTestFile } from './test-file.js';
+import { isTestFile } from './test-file.js';
 
 // ============================================================================
 // TYPES

--- a/src/core/analyzer/call-graph.ts
+++ b/src/core/analyzer/call-graph.ts
@@ -20,6 +20,7 @@ import { inferTypesFromSource, resolveViaTypeInference } from './type-inference-
 import { extractAllHttpEdges } from './http-route-parser.js';
 import { buildProjectedIac } from './iac/index.js';
 import { isIacLanguage } from './iac/types.js';
+import { isTestFile } from './test-file.js';
 import { logger } from '../../utils/logger.js';
 
 // ============================================================================
@@ -501,9 +502,18 @@ function extractDocstringBefore(
 ): string | undefined {
   // ── Python: scan forward past the colon into the function body ──────────
   if (language === 'Python') {
-    // Find the colon that ends the `def` line
+    // Find the colon that ends the `def` line. Track bracket depth so a colon
+    // inside a parameter annotation (`def f(x: int) -> T:`) doesn't end the scan
+    // prematurely — mirrors the depth handling in extractDeclaration below.
     let i = startIndex;
-    while (i < source.length && source[i] !== ':') i++;
+    let depth = 0;
+    while (i < source.length) {
+      const c = source[i];
+      if (c === '(' || c === '[' || c === '{') depth++;
+      else if (c === ')' || c === ']' || c === '}') depth--;
+      else if (c === ':' && depth === 0) break;
+      i++;
+    }
     // Skip past the colon
     i++;
     // Skip whitespace / newline
@@ -2416,15 +2426,11 @@ function buildClassNodes(
 // EXTERNAL NODE HELPER
 // ============================================================================
 
-const TEST_FILE_PATTERNS = [
-  /\.test\.[tj]sx?$/, /\.spec\.[tj]sx?$/,
-  /_test\.py$/, /test_[^/]+\.py$/,
-  /_spec\.rb$/, /_test\.go$/, /[A-Z][^/]*Test\.java$/,
-];
-
-function isTestFile(filePath: string): boolean {
-  return TEST_FILE_PATTERNS.some(p => p.test(filePath));
-}
+// isTestFile is imported at the top of the file from ./test-file.js — the shared
+// cross-language predicate, so call-graph classification can't drift from the
+// artifact generator's. (A narrower local copy previously let test code in
+// tests/, __tests__/, *Spec.kt, etc. leak into the production graph and dropped
+// `tested_by` edges for those layouts.)
 
 const EXTERNAL_HTTP_RE = /^(fetch|axios|got|superagent|node-fetch|ky|request|https?|xmlhttprequest|grpc|undici|requests|aiohttp|httpx|urllib|urllib2|urllib3|curl|curleasy|pycurl|http|httpclient|httpurlconnection|reqwest|hyper|ureq|isahc|surf|net|faraday|httparty|rest|typhoeus|excon|okhttp|retrofit|feign|resttemplate|webclient|urlsession|alamofire|moya)$/;
 const EXTERNAL_DB_RE = /^(pg|mysql|mysql2|sqlite|sqlite3|redis|ioredis|mongoose|mongo|mongodb|prisma|knex|sequelize|typeorm|drizzle|cassandra|dynamodb|firestore|supabase|neo4j|influxdb|clickhouse|kysely|psycopg2|psycopg|sqlalchemy|pymysql|asyncpg|motor|aiomysql|tortoise|sql|gorm|sqlx|pgx|bun|diesel|seaorm|rusqlite|activerecord|sequel|jdbc|hibernate|jpa|entitymanager|datasource|jdbctemplate|r2dbc|coredata|grdb|realm)$/;

--- a/src/core/analyzer/file-walker.ts
+++ b/src/core/analyzer/file-walker.ts
@@ -184,7 +184,15 @@ const CONFIG_PATTERNS = [
 ];
 
 /**
- * Test file/directory patterns
+ * Test file/directory patterns.
+ *
+ * NOTE: deliberately distinct from the shared call-graph predicate in
+ * ../analyzer/test-file.ts. This classifier sets FileMetadata.isTest, which feeds
+ * the repository map / significance scorer (a different view), and is intentionally
+ * broader — it excludes whole test/spec DIRECTORIES and any extension. The shared
+ * predicate is per-language and precise for graph-node classification. Do not merge
+ * them: narrowing this one would let directory-convention test code back into the
+ * repo map, and broadening the shared one would over-classify graph nodes.
  */
 const TEST_DIR_PATTERNS = [
   /\/test\//,

--- a/src/core/analyzer/test-file.test.ts
+++ b/src/core/analyzer/test-file.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for the canonical cross-language test-file predicate. These lock in the
+ * coverage that the call-graph builder previously LACKED (its narrower local copy
+ * let directory-convention tests leak into the production graph and dropped
+ * `tested_by` edges) — call-graph and artifact-generator now share this predicate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isTestFile } from './test-file.js';
+
+describe('isTestFile', () => {
+  it('detects directory-convention and framework test layouts', () => {
+    const tests = [
+      'src/foo.test.ts',
+      'src/foo.spec.tsx',
+      'src/__tests__/foo.ts',          // ← missed by the old call-graph copy
+      'tests/foo.ts',                  // ← missed
+      'tests/foo.rb',                  // ← missed
+      'tests/foo.php',                 // ← missed
+      'test/foo.py',                   // ← missed
+      'pkg/foo_test.go',
+      'app/test_foo.py',
+      'src/FooTest.java',
+      'src/FooSpec.kt',                // ← missed
+      'src/FooTest.scala',             // ← missed
+    ];
+    for (const f of tests) expect(isTestFile(f), f).toBe(true);
+  });
+
+  it('does not flag ordinary source files', () => {
+    const nonTests = [
+      'src/foo.ts',
+      'src/app-config.ts',
+      'src/contest.ts',                // contains "test" but not a test file
+      'src/latest.ts',
+      'lib/protest.py',
+      'src/Foo.java',
+    ];
+    for (const f of nonTests) expect(isTestFile(f), f).toBe(false);
+  });
+
+  it('normalizes Windows path separators', () => {
+    expect(isTestFile('src\\__tests__\\foo.ts')).toBe(true);
+    expect(isTestFile('src\\foo.test.ts')).toBe(true);
+  });
+});

--- a/src/core/analyzer/test-file.ts
+++ b/src/core/analyzer/test-file.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical test-file predicate shared by the call-graph builder and the
+ * artifact generator. These two must agree: the artifact generator excludes
+ * test files from signature extraction and the production edge store, while the
+ * call-graph builder marks their nodes `isTest` and derives `tested_by` edges.
+ * When the two definitions diverged, test code using directory conventions
+ * (tests/, __tests__/) or *Spec.kt/*Test.scala leaked into the production graph
+ * (polluting hubs/entry-points/stats) and `tested_by` edges were silently lost.
+ *
+ * Covers, by language:
+ *   JS/TS:        foo.test.ts, foo.spec.tsx, __tests__/foo.ts
+ *   Python:       test_foo.py, foo_test.py
+ *   Go:           foo_test.go
+ *   Ruby/PHP:     tests/foo.rb, tests/foo.php (directory convention)
+ *   Java/Kotlin:  FooTest.java, FooSpec.kt
+ *   Scala:        FooTest.scala, FooSpec.scala
+ */
+export function isTestFile(filePath: string): boolean {
+  const name = filePath.replace(/\\/g, '/');
+  return (
+    /\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/.test(name) ||   // JS/TS: foo.test.ts
+    /(^|\/)__tests__\//.test(name) ||                          // JS/TS: __tests__/
+    /(^|\/)test_[^/]+\.(ts|js|py)$/.test(name) ||             // Python/TS: test_foo.py
+    /[^/]+_test\.(py|go)$/.test(name) ||                      // Python/Go: foo_test.py, foo_test.go
+    /(^|\/)tests?\/[^/]+\.(py|ts|js|rb|php)$/.test(name) ||  // tests/ directory
+    /[A-Z][a-zA-Z0-9]*Test\.(java|kt|scala)$/.test(name) ||  // Java: FooTest.java
+    /[A-Z][a-zA-Z0-9]*Spec\.(kt|scala|rb)$/.test(name)       // Kotlin/Ruby: FooSpec.kt
+  );
+}

--- a/src/core/decisions/consolidator.test.ts
+++ b/src/core/decisions/consolidator.test.ts
@@ -88,6 +88,28 @@ describe('consolidateDrafts — empty store', () => {
   });
 });
 
+describe('consolidateDrafts — id anchoring', () => {
+  it('reuses a draft id when the LLM echoes it back, instead of re-minting from the title', async () => {
+    // The LLM keeps the source draft's id but rewords the title. Without anchoring,
+    // the consolidated decision would mint a fresh id from the reworded title, so the
+    // gate would advertise an id that no longer maps to the recorded draft.
+    const response = JSON.stringify([{
+      id: 'draft0000',
+      title: 'A reworded title that would otherwise produce a different id',
+      rationale: 'r',
+      consequences: 'c',
+      affectedDomains: ['api'],
+      affectedFiles: [],
+      proposedRequirement: 'The system SHALL do x',
+    }]);
+    const llm = makeLLM(response);
+    const store = makeStore([{ title: 'Original draft title' }]); // → draft0000
+    const result = await consolidateDrafts(store, llm);
+    expect(result.decisions).toHaveLength(1);
+    expect(result.decisions[0].id).toBe('draft0000');
+  });
+});
+
 // ============================================================================
 // Happy path
 // ============================================================================

--- a/src/core/decisions/consolidator.ts
+++ b/src/core/decisions/consolidator.ts
@@ -111,6 +111,12 @@ export async function consolidateDrafts(
   // are purged from the store after sync, so this set is empty in the common case.
   const existing = store.decisions.filter((d) => d.status !== 'draft' && d.status !== 'rejected' && d.status !== 'phantom');
   const existingIds = new Set(existing.map((d) => d.id));
+  // A consolidated decision that echoes back its source DRAFT's id should keep that
+  // id — replaceDecisions() assumes consolidated decisions share ids with their
+  // drafts. Without this, a single-draft consolidation re-mints a fresh id from the
+  // (LLM-reworded) title, so the gate advertises an id that no longer maps to the
+  // recorded draft, and approve/sync operate on a different logical record.
+  const reusableIds = new Set([...existingIds, ...drafts.map((d) => d.id)]);
 
   const userContent = JSON.stringify(
     {
@@ -160,7 +166,7 @@ export async function consolidateDrafts(
     // Prefer LLM-supplied ID when it matches a known existing decision — this is the
     // traceability anchor that prevents duplicate IDs across consolidation runs.
     const id =
-      c.id && existingIds.has(c.id)
+      c.id && reusableIds.has(c.id)
         ? c.id
         : makeDecisionId(store.sessionId, domain, c.title);
     return {

--- a/src/core/decisions/syncer.test.ts
+++ b/src/core/decisions/syncer.test.ts
@@ -161,6 +161,28 @@ describe('syncApprovedDecisions — filesystem writes', () => {
     expect(occurrences).toBe(1);
   });
 
+  it('is idempotent — re-syncing the same decision does not duplicate blocks', async () => {
+    const specDir = join(tmpDir, 'openspec', 'specs', 'services');
+    await mkdir(specDir, { recursive: true });
+    const specPath = join(specDir, 'spec.md');
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(specPath, MINIMAL_SPEC, 'utf-8');
+
+    const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
+    const opts = { rootPath: tmpDir, openspecPath: join(tmpDir, 'openspec'), specMap };
+
+    // Sync the same decision (same id) twice. A re-sync — or consolidation re-minting
+    // an id — would otherwise append a SECOND requirement + decision block, the exact
+    // spec corruption observed in the field.
+    await syncApprovedDecisions(makeStore([makeDecision()]), opts);
+    await syncApprovedDecisions(makeStore([makeDecision()]), opts);
+
+    const content = await readFile(specPath, 'utf-8');
+    expect((content.match(/### Requirement: UseRedisForCaching/g) ?? []).length).toBe(1);
+    expect((content.match(/\*\*ID:\*\* aaaabbbb/g) ?? []).length).toBe(1);
+    expect((content.match(/### Use Redis for caching/g) ?? []).length).toBe(1);
+  });
+
   it('adds new source files to > Source files: header', async () => {
     const specDir = join(tmpDir, 'openspec', 'specs', 'services');
     await mkdir(specDir, { recursive: true });

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -149,6 +149,10 @@ function addSourceFiles(content: string, newFiles: string[]): string {
 }
 
 function appendRequirement(content: string, decision: PendingDecision): string {
+  // Idempotent: if this decision's requirement was already synced (by id), don't
+  // append a second copy. Re-syncs and consolidation ID churn would otherwise
+  // duplicate the block. The id marker is the stable dedupe key.
+  if (content.includes(`> Decision recorded: ${decision.id}`)) return content;
   const slug = toPascalCase(decision.title);
   const req = decision.proposedRequirement ?? '';
   const reqText = /^the system shall\b/i.test(req.trim()) ? req.trim() : `The system SHALL ${req}`;
@@ -177,6 +181,8 @@ ${reqText}
 }
 
 function appendDecisionSection(content: string, decision: PendingDecision): string {
+  // Idempotent: skip if this decision's entry (by id) is already present.
+  if (content.includes(`**ID:** ${decision.id}`)) return content;
   const entry = buildDecisionEntry(decision);
 
   if (content.includes('## Decisions')) {

--- a/src/core/services/edge-store.ts
+++ b/src/core/services/edge-store.ts
@@ -39,7 +39,10 @@ function runTransaction(db: DatabaseSync, fn: () => void): void {
     if (depth === 0) {
       db.exec('ROLLBACK');
     } else {
+      // ROLLBACK TO reverts the savepoint's work but leaves it on the stack;
+      // RELEASE pops it so a caught nested-tx error doesn't orphan a savepoint.
       db.exec(`ROLLBACK TO ${sp}`);
+      db.exec(`RELEASE ${sp}`);
     }
     throw err;
   } finally {

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -919,7 +919,8 @@ export async function handleGetMinimalContext(
   const candidates = cg.nodes.filter(n =>
     n.name === functionName &&
     !n.isExternal && !n.isTest &&
-    (!filePath || n.filePath.endsWith(filePath)),
+    // Anchor on a path separator so "config.ts" doesn't also match "app-config.ts".
+    (!filePath || n.filePath === filePath || n.filePath.endsWith('/' + filePath.replace(/^\//, ''))),
   );
   if (candidates.length === 0) return { error: `Function "${functionName}" not found. Run analyze_codebase first.` };
   const target = candidates[0];

--- a/src/core/services/mcp-handlers/semantic.ts
+++ b/src/core/services/mcp-handlers/semantic.ts
@@ -339,12 +339,16 @@ export async function handleSuggestInsertionPoints(
 
         const role = classifyRole(callerNode.fanIn, callerNode.fanOut, false, false);
         const strategy = deriveStrategy(role);
-        // Graph-expanded candidates score slightly lower than the semantic seed
-        const score = compositeScore(seedResult.score + 0.15, role) * 0.85;
+        // Graph-expanded candidates score slightly lower than the semantic seed.
+        // Use the NORMALISED seed score so this is on the same scale as the seed
+        // candidates above (raw RRF scores top out ~0.03, which would otherwise
+        // rank every expanded node below — and report a misleading semanticScore).
+        const expandedSemantic = normalise(seedResult.score) + 0.15;
+        const score = compositeScore(expandedSemantic, role) * 0.85;
         candidates.push({
           rank: 0,
           score,
-          semanticScore: seedResult.score + 0.15,
+          semanticScore: expandedSemantic,
           name: callerNode.name,
           filePath: callerNode.filePath,
           className: callerNode.className,

--- a/src/core/services/mcp-handlers/utils.ts
+++ b/src/core/services/mcp-handlers/utils.ts
@@ -115,6 +115,10 @@ interface ContextCacheEntry {
 /** One entry per project directory. Invalidated by llm-context.json mtime change. */
 const _contextCache = new Map<string, ContextCacheEntry>();
 
+/** Grace period before closing an evicted EdgeStore so concurrent in-flight
+ * requests holding the old handle across an await can drain first. */
+const STALE_STORE_CLOSE_DELAY_MS = 30_000;
+
 /** Test-only: clear in-memory context cache to force cold path. */
 export function _resetContextCacheForTesting(): void {
   for (const entry of _contextCache.values()) entry.ctx.edgeStore?.close();
@@ -184,7 +188,20 @@ export async function readCachedContext(directory: string, timeout?: number): Pr
           ctx.edgeStore = es;
         }
       }
+      // Evict + close the previous entry's EdgeStore — otherwise each cache miss
+      // (every `analyze` rewrites llm-context.json's mtime) leaks an open SQLite
+      // connection + its WAL fd for the life of a long-lived daemon. The close is
+      // DEFERRED: serve dispatches requests concurrently, and a handler may hold
+      // the old handle across an await (e.g. get_subgraph awaits a vector search
+      // between edgeStore reads). A grace delay lets in-flight requests drain
+      // before release, bounding live handles to ~grace/reanalyze-interval.
+      const prev = _contextCache.get(directory);
       _contextCache.set(directory, { ctx, mtime });
+      if (prev?.ctx.edgeStore && prev.ctx.edgeStore !== ctx.edgeStore) {
+        const stale = prev.ctx.edgeStore;
+        const t = setTimeout(() => { try { stale.close(); } catch { /* already closed */ } }, STALE_STORE_CLOSE_DELAY_MS);
+        t.unref?.();
+      }
       emit(directory, 'cache', { event: 'cache_read', hit: true });
       return ctx;
     } catch {

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -31,6 +31,7 @@ import { spawn } from 'node:child_process';
 import chokidar, { type FSWatcher } from 'chokidar';
 import { extractSignatures, detectLanguage } from '../analyzer/signature-extractor.js';
 import type { FunctionNode } from '../analyzer/call-graph.js';
+import { isTestFile } from '../analyzer/test-file.js';
 import { EdgeStore } from './edge-store.js';
 import { primeContextCache, type CachedContext } from './mcp-handlers/utils.js';
 import {
@@ -669,14 +670,10 @@ export class McpWatcher {
 }
 
 // ── Module helpers ──────────────────────────────────────────────────────────────
-
-function isTestFile(relPath: string): boolean {
-  return (
-    relPath.includes('.test.') ||
-    relPath.includes('.spec.') ||
-    relPath.includes('__tests__')
-  );
-}
+// isTestFile is the shared cross-language predicate (../analyzer/test-file.js).
+// Incremental graph updates MUST classify tests identically to a full `analyze`,
+// or the watcher would add test files (e.g. foo_test.go, tests/foo.py) that a
+// full rebuild drops — leaving the incremental graph divergent from the rebuilt one.
 
 /**
  * Re-parse changedFile + up to CALLER_REPARSE_LIMIT callerFiles.


### PR DESCRIPTION
## Summary

Follow-up to #131. Started as a verification pass on the merged `pi`/`serve` work, then expanded into a deeper repo-wide review (daemon/watcher/graph-storage, MCP handlers, core analyzer, CLI + decisions). Every fix is verified against the code; the user-facing/decisions and concurrency ones ship with regression tests that fail without the fix.

## Fixes

### serve schema-reset auto-heal stalled indefinitely (the headline #131 bug)
`EdgeStore.open()` reports `wasReset` exactly once — `initSchema()` rewrites the on-disk schema version on that first open ([edge-store.ts:88](src/core/services/edge-store.ts#L88)), so later opens report `false`. #131's startup/first-request open in `serve` consumed that one-shot flag but never started a rebuild — it relied on `McpWatcher`'s self-heal, which is *also* keyed off `wasReset` ([mcp-watcher.ts:383](src/core/services/mcp-watcher.ts#L383)). So after any schema bump the "rebuilding in the background" log was false and **every graph request stalled the full 60s `waitForGraphRebuild` timeout, indefinitely**. Fix: `serve` now drives the rebuild itself.

### serve concurrent `analyze --force` race
The schema-reset healer and the watcher's debounced re-analyze each had an independent single-flight guard, so both could run `analyze --force` on the same directory at once — clearing and repopulating the same `EdgeStore` non-atomically (torn graph). Both now funnel through one per-directory `triggerRebuild` coordinator (running/pending sets): at most one forced analyze per directory, mid-flight triggers coalesced into a single follow-up (root re-runs via the debounce; other dirs immediately).

### Decisions workflow (a snag hit while building this PR)
- **Non-idempotent syncer** ([syncer.ts](src/core/decisions/syncer.ts)): `appendRequirement`/`appendDecisionSection` had no presence check, so a re-sync or consolidation id-churn appended **duplicate Requirement/Decision blocks** into `spec.md`. Now guarded on the decision id.
- **Consolidator id re-minting** ([consolidator.ts](src/core/decisions/consolidator.ts)): a draft's own id was excluded from the reuse set, so a single-draft consolidation minted a fresh id from the (LLM-reworded) title — the gate then advertised an id that no longer mapped to the recorded draft. Now a draft id is reused when the LLM echoes it back.

### Static analysis — test-file classification
- **Divergent `isTestFile`** ([test-file.ts](src/core/analyzer/test-file.ts), new): call-graph's detector was strictly narrower than the artifact generator's, so test code in `tests/`, `__tests__/`, `*Spec.kt`, `*Test.scala` leaked into the **production graph** and `tested_by` edges were dropped. call-graph + artifact-generator + **mcp-watcher** now share one predicate (the watcher's incremental updates previously classified tests differently from a full rebuild). `file-walker` keeps its own deliberately-broader directory-based classifier — it feeds the repo map / significance scorer (a different view), and merging it would regress that view; documented inline.
- **Python docstring extraction** ([call-graph.ts](src/core/analyzer/call-graph.ts)): the scan for a `def`'s terminating colon didn't track bracket depth, so `def f(x: int) -> T:` aborted on the annotation's colon. Now depth-aware.

### MCP handlers
- **`suggest_insertion_points`** ([semantic.ts](src/core/services/mcp-handlers/semantic.ts)): graph-expanded candidates used a raw RRF score (~0.03 max) while seeds were normalized, breaking ranking and the reported `semanticScore`. Now normalized consistently.
- **`get_minimal_context`** ([analysis.ts](src/core/services/mcp-handlers/analysis.ts)): the `filePath` disambiguator used an unanchored `endsWith`, so `"config.ts"` also matched `"app-config.ts"`. Now anchored on a path separator.

### Resource / correctness
- **EdgeStore handle leak** ([utils.ts](src/core/services/mcp-handlers/utils.ts)): `readCachedContext` overwrote the cached entry on every miss (each `analyze` bumps `llm-context.json`'s mtime) without closing the previous `EdgeStore` — an unbounded SQLite-handle + WAL-fd leak in long-lived daemons. Now closed, **deferred with a grace window** because `serve` dispatches requests concurrently and a handler can hold the old handle across an await (would otherwise be a use-after-close).
- **Savepoint leak** ([edge-store.ts](src/core/services/edge-store.ts)): nested `runTransaction` did `ROLLBACK TO` without the required `RELEASE`.
- **`generate --no-overwrite`** ([generate.ts](src/cli/commands/generate.ts)): a silent no-op — commander stores the negated flag under the `overwrite` key, so "skip existing specs" was unreachable.

## Testing
- Regression tests for: serve schema-reset rebuild, syncer idempotency, consolidator id anchoring, and the unified test-file predicate — each verified to fail against the pre-fix code.
- Full suite green: **3188 unit + 111 integration**, build, lint, typecheck.
- Manual end-to-end: `init` → `analyze` → `serve` daemon (`/health`, `/tool/orient`, `/tool/search_code`, with a Go test file correctly excluded from the production graph) and `pi` setup install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)