### PR TITLE
hotfix(pi): use shell:true on Windows to avoid ENOENT on spawn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,8 @@
         "openlore": "dist/cli/index.js"
       },
       "devDependencies": {
-        "@earendil-works/pi-ai": "^0.78.1",
-        "@earendil-works/pi-coding-agent": "^0.78.1",
+        "@earendil-works/pi-ai": "^0.79.0",
+        "@earendil-works/pi-coding-agent": "^0.79.0",
         "@eslint/js": "^9.17.0",
         "@types/node": "^22.10.5",
         "@vitest/coverage-v8": "^4.0.18",
@@ -892,9 +892,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.78.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.78.1.tgz",
-      "integrity": "sha512-CM2pkTs1iupG/maw381lC9Q/Y/aQaMGK7GILc28ttImD0ci3LDwKroDsGkWbly5JIy3iqxdRxB9JlG7vvzCzTg==",
+      "version": "0.79.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.0.tgz",
+      "integrity": "sha512-D/2aDoe9vcCbqAztALQcKkdqXGuaQcqAzLm8LfUhNaorwoIHkwnaAuDVlo+OkF5clpEwS8Z1bk2o8NiSrwEdsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -917,16 +917,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.78.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.78.1.tgz",
-      "integrity": "sha512-Syjf6Ib8UoY5t9ZdKjp0BRrQZuFkFBc8j2KEU9zG/ZnmYPcAxYeioofdv2Q3MEXnHEX2U8sKQptkSnJIdMsd0g==",
+      "version": "0.79.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.0.tgz",
+      "integrity": "sha512-pZoXk65vFR3dAzzmPNWEX61aHnT6+BaVhTyFDQAs1DyumaMeWpvzRV9ZrGxqlbVLwhrq+0LnXbaqDAFkhe2+MQ==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.78.1",
-        "@earendil-works/pi-ai": "^0.78.1",
-        "@earendil-works/pi-tui": "^0.78.1",
+        "@earendil-works/pi-agent-core": "^0.79.0",
+        "@earendil-works/pi-ai": "^0.79.0",
+        "@earendil-works/pi-tui": "^0.79.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1415,12 +1415,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.78.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.78.1.tgz",
+      "version": "0.79.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.78.1",
+        "@earendil-works/pi-ai": "^0.79.0",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1430,8 +1430,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.78.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.78.1.tgz",
+      "version": "0.79.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1447,15 +1447,15 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "./dist/cli.js"
+        "pi-ai": "dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.78.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.78.1.tgz",
+      "version": "0.79.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -137,8 +137,8 @@
     "tree-sitter-cli": "file:stubs/tree-sitter-cli-stub"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.78.1",
-    "@earendil-works/pi-coding-agent": "^0.78.1",
+    "@earendil-works/pi-ai": "^0.79.0",
+    "@earendil-works/pi-coding-agent": "^0.79.0",
     "@eslint/js": "^9.17.0",
     "@types/node": "^22.10.5",
     "@vitest/coverage-v8": "^4.0.18",

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -302,9 +302,12 @@ async function runConfigWizard(ctx: ExtensionContext, existing?: OpenLoreConfig 
     ui.notify('Running openlore analyze…', 'info');
     const [exitCode, errText] = await new Promise<[number, string]>((resolve) => {
       // Try `openlore` in PATH; fall back to `npx openlore` if not found.
+      // On Windows, npm installs .cmd wrappers — shell: true is required for
+      // Node's spawn() to resolve them without an explicit .cmd suffix.
+      const isWin = process.platform === 'win32';
       const trySpawn = (cmd: string, args: string[]) => new Promise<[number, string] | null>((res) => {
         const chunks: Buffer[] = [];
-        const proc = spawn(cmd, args, { cwd: ctx.cwd, stdio: ['ignore', 'ignore', 'pipe'] });
+        const proc = spawn(cmd, args, { cwd: ctx.cwd, stdio: ['ignore', 'ignore', 'pipe'], shell: isWin });
         proc.stderr?.on('data', (d: Buffer) => chunks.push(d));
         proc.on('close', (code) => res([code ?? 1, Buffer.concat(chunks).toString().trim()]));
         proc.on('error', () => res(null));
@@ -350,7 +353,10 @@ async function ensureDaemon(cwd: string): Promise<Daemon | null> {
   const existing = await readDescriptor(cwd);
   if (existing && (await healthy(existing))) return { baseUrl: `http://${existing.host}:${existing.port}`, token: existing.token };
   try {
-    spawn('openlore', ['serve', '--directory', cwd], { detached: true, stdio: 'ignore' }).unref();
+    // On Windows, npm installs .cmd wrappers — spawn() can't resolve them
+    // without an explicit suffix. Use openlore.cmd on win32.
+    const cmd = process.platform === 'win32' ? 'openlore.cmd' : 'openlore';
+    spawn(cmd, ['serve', '--directory', cwd], { detached: true, stdio: 'ignore' }).unref();
   } catch { return null; }
   const deadline = Date.now() + HEALTH_TIMEOUT_MS;
   while (Date.now() < deadline) {

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -353,10 +353,9 @@ async function ensureDaemon(cwd: string): Promise<Daemon | null> {
   const existing = await readDescriptor(cwd);
   if (existing && (await healthy(existing))) return { baseUrl: `http://${existing.host}:${existing.port}`, token: existing.token };
   try {
-    // On Windows, npm installs .cmd wrappers — spawn() can't resolve them
-    // without an explicit suffix. Use openlore.cmd on win32.
-    const cmd = process.platform === 'win32' ? 'openlore.cmd' : 'openlore';
-    spawn(cmd, ['serve', '--directory', cwd], { detached: true, stdio: 'ignore' }).unref();
+    // On Windows, npm installs .cmd wrappers — shell: true lets spawn()
+    // resolve them without an explicit suffix.
+    spawn('openlore', ['serve', '--directory', cwd], { detached: true, stdio: 'ignore', shell: process.platform === 'win32' }).unref();
   } catch { return null; }
   const deadline = Date.now() + HEALTH_TIMEOUT_MS;
   while (Date.now() < deadline) {

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -28,12 +28,12 @@ import type {
   SessionStartEvent,
 } from '@earendil-works/pi-coding-agent';
 import { StringEnum } from '@earendil-works/pi-ai';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import { Type, type TObject, type TSchema } from 'typebox';
 
 import { spawn } from 'node:child_process';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 
 // ── Config types & helpers ────────────────────────────────────────────────────
 
@@ -579,5 +579,5 @@ export default function openlore(pi: ExtensionAPI): void {
 
 export const installPaths = {
   project: (cwd: string) => join(cwd, '.pi', 'extensions', 'openlore.js'),
-  global: () => join(homedir(), '.pi', 'agent', 'extensions', 'openlore.js'),
+  global: () => join(getAgentDir(), 'extensions', 'openlore.js'),
 };


### PR DESCRIPTION
## Summary

- `ensureDaemon`: add `shell: true` on `win32` — npm installs CLI wrappers as `.cmd` files on Windows, which `spawn()` can't resolve without shell delegation
- `trySpawn` / `runConfigWizard`: same `shell: true` on `win32` so both `openlore analyze` and `npx openlore analyze` resolve correctly
- Bump `@earendil-works/pi-coding-agent` + `@earendil-works/pi-ai` to `0.79.0`
- Use `getAgentDir()` from the new 0.79 SDK exports for the global install path — respects env var overrides instead of hardcoding `~/.pi/agent`

## Context

Without this fix, launching Pi on Windows throws ENOENT on spawn — the extension fails to start the openlore daemon entirely.

**0.79 bonus**: the config wizard (`openlore_configure`) uses `ui.select` / `ui.input` / `ui.confirm` throughout. In 0.78.x those dialog calls silently no-oped in RPC mode. With 0.79's extension UI protocol they emit `extension_ui_request` on stdout and block for a response — the wizard now works interactively in IDE / headless contexts, not just TUI. No code change needed; the bump enables it automatically.

## Test plan

- [ ] On Windows: `pi install npm:openlore` → daemon starts without ENOENT
- [ ] On Windows: config wizard runs `openlore analyze` successfully
- [ ] On macOS/Linux: no regression — platform checks are `win32`-gated
- [ ] In RPC mode (IDE): `openlore_configure` tool shows interactive dialogs

🤖 Generated with [Claude Code](https://claude.com/claude-code)