### PR TITLE
feat(health-map): structural health dashboard + bridge nodes + untested hotspots + get_surprising_connections

### DIFF
--- a/src/cli/commands/mcp-presets.test.ts
+++ b/src/cli/commands/mcp-presets.test.ts
@@ -154,8 +154,9 @@ describe('tools/list payload budget (spec-28)', () => {
   // preset — each a conscious budget decision, not silent drift.
   // Full ceiling bumped 48_000 → 50_000 when the navigation primitives get_landmarks,
   // get_map, and find_path were added to the surface — a conscious budget decision.
+  // Bumped 50_000 → 51_500 when get_surprising_connections was added — conscious budget decision.
   it('full surface stays within its prefix budget', () => {
-    expect(payloadBytes({})).toBeLessThan(50_000);
+    expect(payloadBytes({})).toBeLessThan(51_500);
   });
 
   it('navigation preset stays lean (the low-overhead surface that wins the benchmark)', () => {

--- a/src/cli/commands/mcp-presets.test.ts
+++ b/src/cli/commands/mcp-presets.test.ts
@@ -157,8 +157,10 @@ describe('tools/list payload budget (spec-28)', () => {
   // Bumped 50_000 → 52_000 when the opt-in `memory` preset's remember/recall were added
   // (code-anchored persistent memory) — again a conscious decision, not silent drift. The
   // two tools stay out of the default/minimal surface; only the full surface widens.
+  // Bumped 52_000 → 53_000 when get_surprising_connections and get_health_map were added
+  // to the full surface — conscious budget decision.
   it('full surface stays within its prefix budget', () => {
-    expect(payloadBytes({})).toBeLessThan(52_000);
+    expect(payloadBytes({})).toBeLessThan(53_000);
   });
 
   it('navigation preset stays lean (the low-overhead surface that wins the benchmark)', () => {

--- a/src/cli/commands/mcp-presets.test.ts
+++ b/src/cli/commands/mcp-presets.test.ts
@@ -33,9 +33,9 @@ describe('MCP tool presets', () => {
     }
   });
 
-  it('minimal preset keeps its 5-tool contract', () => {
+  it('minimal preset keeps its 6-tool contract', () => {
     const tools = selectActiveTools(TOOL_DEFINITIONS, { minimal: true }).map(t => t.name);
-    expect(new Set(tools)).toEqual(new Set(['orient', 'search_code', 'record_decision', 'detect_changes', 'check_spec_drift']));
+    expect(new Set(tools)).toEqual(new Set(['orient', 'search_code', 'record_decision', 'detect_changes', 'check_spec_drift', 'get_health_map']));
   });
 
   it('no selector exposes the full tool set', () => {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1341,6 +1341,25 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'get_surprising_connections',
+    description:
+      'Find unexpected structural coupling via composite scoring: cross-community edges, ' +
+      'peripheral-to-hub calls, and cross-test-boundary dependencies. ' +
+      'Use before a refactor or code review to spot accidental dependencies. ' +
+      'Run analyze_codebase first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directory: { type: 'string', description: DIR_DESC },
+        limit: {
+          type: 'number',
+          description: 'Max results to return (default: 15, max: 50)',
+        },
+      },
+      required: ['directory'],
+    },
+  },
+  {
     name: 'record_decision',
     description:
       'Record an architectural decision made during the current development session. ' +
@@ -1469,7 +1488,7 @@ const TOOL_ANNOTATIONS: Record<string, typeof _RO | typeof _RWI | typeof _RW> = 
   get_schema_inventory: _RO, get_ui_components: _RO, get_env_vars: _RO,
   get_external_packages: _RO, audit_spec_coverage: _RO, generate_tests: _RW,
   get_test_coverage: _RO, get_minimal_context: _RO, get_cluster: _RO,
-  detect_changes: _RO, get_health_map: _RO, record_decision: _RW, list_decisions: _RO,
+  detect_changes: _RO, get_health_map: _RO, get_surprising_connections: _RO, record_decision: _RW, list_decisions: _RO,
   approve_decision: _RWI, reject_decision: _RWI, sync_decisions: _RWI,
 };
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1321,6 +1321,26 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'get_health_map',
+    description:
+      'Return a structural health dashboard: hubs (high fan-in), god functions (high fan-out), ' +
+      'layer violations, and volatile files — aggregated in one call and ranked by severity. ' +
+      'Use this as a starting point before a refactor or code review to identify the riskiest areas. ' +
+      'Drill in with get_critical_hubs, get_god_functions, get_change_coupling, or find_dead_code. ' +
+      'Run analyze_codebase first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directory: { type: 'string', description: DIR_DESC },
+        limit: {
+          type: 'number',
+          description: 'Max items per hotspot list and max topRisks (default: 10, max: 50)',
+        },
+      },
+      required: ['directory'],
+    },
+  },
+  {
     name: 'record_decision',
     description:
       'Record an architectural decision made during the current development session. ' +
@@ -1449,7 +1469,7 @@ const TOOL_ANNOTATIONS: Record<string, typeof _RO | typeof _RWI | typeof _RW> = 
   get_schema_inventory: _RO, get_ui_components: _RO, get_env_vars: _RO,
   get_external_packages: _RO, audit_spec_coverage: _RO, generate_tests: _RW,
   get_test_coverage: _RO, get_minimal_context: _RO, get_cluster: _RO,
-  detect_changes: _RO, record_decision: _RW, list_decisions: _RO,
+  detect_changes: _RO, get_health_map: _RO, record_decision: _RW, list_decisions: _RO,
   approve_decision: _RWI, reject_decision: _RWI, sync_decisions: _RWI,
 };
 

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -1492,7 +1492,7 @@ export function toolAnnotations(name: string): Record<string, unknown> {
 }
 
 const MINIMAL_TOOLS = new Set([
-  'orient', 'search_code', 'record_decision', 'detect_changes', 'check_spec_drift',
+  'orient', 'search_code', 'record_decision', 'detect_changes', 'check_spec_drift', 'get_health_map',
 ]);
 
 // Named tool presets (Spec 14). A small, navigation-focused surface keeps the

--- a/src/core/services/mcp-handlers/analysis.test.ts
+++ b/src/core/services/mcp-handlers/analysis.test.ts
@@ -1121,6 +1121,125 @@ describe('handleDetectChanges', () => {
     expect(result.changedFunctions[0].name).toBe('doWork');
     expect(result.changedFunctions[0].file).toBe('src/a.ts');
   });
+
+  it('sets testCoverage=none and includes entry in testGaps when function has no test edges', async () => {
+    const git = (...args: string[]) =>
+      spawnSync('git', args, { cwd: tmpDir, encoding: 'utf-8' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@test.dev');
+    git('config', 'user.name', 'Test');
+    const srcDir = join(tmpDir, 'src');
+    await mkdir(srcDir, { recursive: true });
+    const file = join(srcDir, 'b.ts');
+    await writeFile(file, 'export function noTests(): void {\n  console.log(1);\n}\n', 'utf-8');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'init');
+    await writeFile(file, 'export function noTests(): void {\n  console.log(2);\n}\n', 'utf-8');
+
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [{
+          id: 'src/b.ts::noTests', name: 'noTests', filePath: 'src/b.ts',
+          language: 'typescript', fanIn: 2, fanOut: 0, startLine: 1, endLine: 3,
+          isExternal: false, isTest: false,
+        }],
+      }),
+    });
+
+    const { handleDetectChanges } = await import('./analysis.js');
+    const result = await handleDetectChanges(tmpDir) as {
+      changedFunctions: Array<{ name: string; testCoverage: string }>;
+      testGaps: Array<{ name: string; file: string; riskScore: number; changeType: string }>;
+    };
+
+    expect(result.changedFunctions[0].testCoverage).toBe('none');
+    expect(result.testGaps).toHaveLength(1);
+    expect(result.testGaps[0].name).toBe('noTests');
+    expect(result.testGaps[0].file).toBe('src/b.ts');
+    expect(typeof result.testGaps[0].riskScore).toBe('number');
+  });
+
+  it('sets testCoverage=import-only when only import test edges exist and excludes from testGaps', async () => {
+    const git = (...args: string[]) =>
+      spawnSync('git', args, { cwd: tmpDir, encoding: 'utf-8' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@test.dev');
+    git('config', 'user.name', 'Test');
+    const srcDir = join(tmpDir, 'src');
+    await mkdir(srcDir, { recursive: true });
+    const file = join(srcDir, 'c.ts');
+    await writeFile(file, 'export function wellTested(): void {\n  console.log(1);\n}\n', 'utf-8');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'init');
+    await writeFile(file, 'export function wellTested(): void {\n  console.log(2);\n}\n', 'utf-8');
+
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [{
+          id: 'src/c.ts::wellTested', name: 'wellTested', filePath: 'src/c.ts',
+          language: 'typescript', fanIn: 1, fanOut: 0, startLine: 1, endLine: 3,
+          isExternal: false, isTest: false,
+        }],
+        edges: [{
+          callerId: 'src/c.ts::wellTested',
+          calleeId: 'src/c.test.ts::wellTested.test',
+          calleeName: 'wellTested.test',
+          confidence: 'import',
+          kind: 'tested_by',
+        }],
+      }),
+    });
+
+    const { handleDetectChanges } = await import('./analysis.js');
+    const result = await handleDetectChanges(tmpDir) as {
+      changedFunctions: Array<{ name: string; testCoverage: string }>;
+      testGaps: Array<unknown>;
+    };
+
+    expect(result.changedFunctions[0].testCoverage).toBe('import-only');
+    expect(result.testGaps).toHaveLength(0);
+  });
+
+  it('sets testCoverage=direct when a called (non-import) test edge exists', async () => {
+    const git = (...args: string[]) =>
+      spawnSync('git', args, { cwd: tmpDir, encoding: 'utf-8' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@test.dev');
+    git('config', 'user.name', 'Test');
+    const srcDir = join(tmpDir, 'src');
+    await mkdir(srcDir, { recursive: true });
+    const file = join(srcDir, 'd.ts');
+    await writeFile(file, 'export function directlyCovered(): void {\n  return;\n}\n', 'utf-8');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'init');
+    await writeFile(file, 'export function directlyCovered(): void {\n  return undefined;\n}\n', 'utf-8');
+
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [{
+          id: 'src/d.ts::directlyCovered', name: 'directlyCovered', filePath: 'src/d.ts',
+          language: 'typescript', fanIn: 1, fanOut: 0, startLine: 1, endLine: 3,
+          isExternal: false, isTest: false,
+        }],
+        edges: [{
+          callerId: 'src/d.ts::directlyCovered',
+          calleeId: 'src/d.test.ts::it',
+          calleeName: 'it',
+          confidence: 'same_file', // non-'import' → maps to 'called' → testCoverage='direct'
+          kind: 'tested_by',
+        }],
+      }),
+    });
+
+    const { handleDetectChanges } = await import('./analysis.js');
+    const result = await handleDetectChanges(tmpDir) as {
+      changedFunctions: Array<{ name: string; testCoverage: string }>;
+      testGaps: Array<unknown>;
+    };
+
+    expect(result.changedFunctions[0].testCoverage).toBe('direct');
+    expect(result.testGaps).toHaveLength(0);
+  });
 });
 
 // ============================================================================

--- a/src/core/services/mcp-handlers/analysis.test.ts
+++ b/src/core/services/mcp-handlers/analysis.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 import {
   OPENLORE_DIR,
   OPENLORE_ANALYSIS_SUBDIR,
@@ -1075,6 +1076,50 @@ describe('handleDetectChanges', () => {
     // tmpDir is not a git repo — git diff will fail
     const result = await handleDetectChanges(tmpDir) as { error: string };
     expect(result.error).toMatch(/git diff failed/);
+  });
+
+  // Regression: call-graph nodes store repo-root-RELATIVE filePaths. The diff
+  // parser must key changed files by the same relative form, or no changed
+  // function ever matches a node (handler returns "no matching function nodes").
+  it('maps a real git diff to a node whose filePath is repo-relative', async () => {
+    const git = (...args: string[]) =>
+      spawnSync('git', args, { cwd: tmpDir, encoding: 'utf-8' });
+    git('init', '-q');
+    git('config', 'user.email', 'test@test.dev');
+    git('config', 'user.name', 'Test');
+
+    const srcDir = join(tmpDir, 'src');
+    await mkdir(srcDir, { recursive: true });
+    const file = join(srcDir, 'a.ts');
+    await writeFile(file, 'export function doWork(x: number): number {\n  const y = x + 1;\n  return y;\n}\n', 'utf-8');
+    git('add', '-A');
+    git('commit', '-q', '-m', 'init');
+
+    // Modify a line inside the function body in the working tree.
+    await writeFile(file, 'export function doWork(x: number): number {\n  const y = x + 2;\n  return y;\n}\n', 'utf-8');
+
+    // Node uses a RELATIVE filePath — the production convention.
+    readCachedContext.mockResolvedValue({
+      callGraph: makeCallGraph({
+        nodes: [{
+          id: 'src/a.ts::doWork', name: 'doWork', filePath: 'src/a.ts',
+          signature: 'doWork(x: number): number', language: 'typescript',
+          fanIn: 3, fanOut: 0, startLine: 1, endLine: 4,
+          isExternal: false, isTest: false,
+        }],
+      }),
+    });
+
+    const { handleDetectChanges } = await import('./analysis.js');
+    const result = await handleDetectChanges(tmpDir) as {
+      changedFunctions: Array<{ name: string; file: string }>;
+      message?: string;
+    };
+
+    expect(result.message).toBeUndefined();
+    expect(result.changedFunctions).toHaveLength(1);
+    expect(result.changedFunctions[0].name).toBe('doWork');
+    expect(result.changedFunctions[0].file).toBe('src/a.ts');
   });
 });
 

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -1391,6 +1391,9 @@ export async function handleDetectChanges(
     const changeType = classifyChangeType(n, changedFileData.get(relPath(n.filePath))?.addedLines ?? new Map());
     const changeScore = Math.min(rawChangeScore * CHANGE_TYPE_MULTIPLIER[changeType], 1);
     const tests = testedByMap.get(id) ?? [];
+    const testCoverage: 'none' | 'import-only' | 'direct' =
+      tests.length === 0 ? 'none' :
+      tests.some(t => t.confidence === 'called') ? 'direct' : 'import-only';
     // called-edges are direct proof; imported-only is weaker (survives vi.mock)
     const effectiveTests = tests.reduce((s, t) => s + (t.confidence === 'called' ? 1.0 : 0.3), 0);
     const coveragePenalty = 1 / (1 + Math.log(1 + effectiveTests));
@@ -1414,13 +1417,19 @@ export async function handleDetectChanges(
       changeType,
       riskScore,
       reason,
+      testCoverage,
       testedBy: testedByMap.get(id) ?? [],
     };
   }).sort((a, b) => b.riskScore - a.riskScore);
+
+  const testGaps = scored
+    .filter(f => f.testCoverage === 'none')
+    .map(f => ({ name: f.name, file: f.file, riskScore: f.riskScore, changeType: f.changeType }));
 
   return {
     base: ref,
     totalChanged: scored.length,
     changedFunctions: scored,
+    testGaps,
   };
 }

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -8,7 +8,6 @@
 
 import { readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
-import { volatilityLevel } from '../../provenance/change-coupling.js';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/src/core/services/mcp-handlers/analysis.ts
+++ b/src/core/services/mcp-handlers/analysis.ts
@@ -8,6 +8,7 @@
 
 import { readFile, stat } from 'node:fs/promises';
 import { join, relative } from 'node:path';
+import { volatilityLevel } from '../../provenance/change-coupling.js';
 import { spawnSync } from 'node:child_process';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -1262,7 +1263,10 @@ export async function handleDetectChanges(
   let newLineNum = 0;
   for (const line of diffOutput.split('\n')) {
     const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
-    if (fileMatch) { curFile = join(absDir, fileMatch[1]); newLineNum = 0; continue; }
+    // git diff paths are repo-root-relative, matching the call-graph node
+    // convention (nodes store relative filePaths). Keep them relative so the
+    // node-overlap match below — and the classifyChangeType lookup — line up.
+    if (fileMatch) { curFile = fileMatch[1]; newLineNum = 0; continue; }
     const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
     if (hunkMatch && curFile) {
       newLineNum = parseInt(hunkMatch[1], 10);
@@ -1284,11 +1288,15 @@ export async function handleDetectChanges(
   const cg = ctx.callGraph as SerializedCallGraph;
   const nodeMap = new Map(cg.nodes.map(n => [n.id, n]));
 
+  // Node filePaths are repo-root-relative, but tolerate an absolute path defensively
+  // (older analyses, or a future builder change) by normalising to the diff's relative form.
+  const relPath = (p: string) => (p.startsWith(absDir) ? relative(absDir, p) : p);
+
   // Map changed line ranges to function nodes; track overlapping line count per function
   const changedFnIds = new Set<string>();
   const fnChangedLineCount = new Map<string, number>(); // nodeId → #lines overlapping with diff
   for (const [filePath, ranges] of changedLines) {
-    const fileNodes = cg.nodes.filter(n => n.filePath === filePath && !n.isExternal && !n.isTest && n.startLine);
+    const fileNodes = cg.nodes.filter(n => relPath(n.filePath) === filePath && !n.isExternal && !n.isTest && n.startLine);
     for (const node of fileNodes) {
       const fnEnd = node.endLine ?? node.startLine!;
       let overlap = 0;
@@ -1380,7 +1388,7 @@ export async function handleDetectChanges(
     const absScore = Math.log(1 + changed) / Math.log(201);
     const rawChangeScore = Math.min(0.6 * relScore + 0.4 * absScore, 1);
     // Semantic modifier: signature changes are higher risk than config/literal tweaks
-    const changeType = classifyChangeType(n, changedFileData.get(n.filePath)?.addedLines ?? new Map());
+    const changeType = classifyChangeType(n, changedFileData.get(relPath(n.filePath))?.addedLines ?? new Map());
     const changeScore = Math.min(rawChangeScore * CHANGE_TYPE_MULTIPLIER[changeType], 1);
     const tests = testedByMap.get(id) ?? [];
     // called-edges are direct proof; imported-only is weaker (survives vi.mock)
@@ -1398,7 +1406,7 @@ export async function handleDetectChanges(
     const reason = buildReason({ changeType, directCallers, tests, bScore, fanIn: n.fanIn });
     return {
       name: n.name,
-      file: relative(absDir, n.filePath),
+      file: relPath(n.filePath),
       startLine: n.startLine ?? null,
       endLine: n.endLine ?? null,
       fanIn: n.fanIn,

--- a/src/core/services/mcp-handlers/health-map.test.ts
+++ b/src/core/services/mcp-handlers/health-map.test.ts
@@ -105,7 +105,7 @@ describe('handleGetHealthMap — empty graph', () => {
   it('returns zero-counts on an empty graph', async () => {
     mockCtx.mockResolvedValue({ callGraph: graph([], []) } as never);
     const r = await handleGetHealthMap({ directory: '/p' }) as {
-      summary: { totalFunctions: number; hubCount: number; godFunctionCount: number; layerViolationCount: number; volatileFileCount: number };
+      summary: { totalFunctions: number; hubCount: number; godFunctionCount: number; layerViolationCount: number; volatileFileCount: number; bridgeCount: number; untestedHotspotCount: number };
       topRisks: unknown[];
     };
     expect(r.summary).toEqual({
@@ -114,6 +114,8 @@ describe('handleGetHealthMap — empty graph', () => {
       godFunctionCount: 0,
       layerViolationCount: 0,
       volatileFileCount: 0,
+      bridgeCount: 0,
+      untestedHotspotCount: 0,
     });
     expect(r.topRisks).toEqual([]);
   });

--- a/src/core/services/mcp-handlers/health-map.test.ts
+++ b/src/core/services/mcp-handlers/health-map.test.ts
@@ -38,10 +38,6 @@ function node(over: Partial<FunctionNode> & { id: string }): FunctionNode {
   };
 }
 
-function edge(callerId: string, calleeId: string): CallEdge {
-  return { callerId, calleeId, calleeName: calleeId.split('::')[1] ?? calleeId, confidence: 'import', kind: 'calls' };
-}
-
 function violation(callerId: string, calleeId: string): LayerViolation {
   return { callerId, calleeId, callerLayer: 'cli', calleeLayer: 'core', reason: 'layer-skip' };
 }

--- a/src/core/services/mcp-handlers/health-map.test.ts
+++ b/src/core/services/mcp-handlers/health-map.test.ts
@@ -105,7 +105,7 @@ describe('handleGetHealthMap — empty graph', () => {
   it('returns zero-counts on an empty graph', async () => {
     mockCtx.mockResolvedValue({ callGraph: graph([], []) } as never);
     const r = await handleGetHealthMap({ directory: '/p' }) as {
-      summary: { totalFunctions: number; hubCount: number; godFunctionCount: number; layerViolationCount: number; volatileFileCount: number; bridgeCount: number; untestedHotspotCount: number };
+      summary: { totalFunctions: number; hubCount: number; godFunctionCount: number; layerViolationCount: number; volatileFileCount: number; bridgeCount: number; untestedHotspotCount: number; betweennessApprox: boolean; betweennessSourceCount: number };
       topRisks: unknown[];
     };
     expect(r.summary).toEqual({
@@ -116,6 +116,8 @@ describe('handleGetHealthMap — empty graph', () => {
       volatileFileCount: 0,
       bridgeCount: 0,
       untestedHotspotCount: 0,
+      betweennessApprox: false,
+      betweennessSourceCount: 0,
     });
     expect(r.topRisks).toEqual([]);
   });

--- a/src/core/services/mcp-handlers/health-map.test.ts
+++ b/src/core/services/mcp-handlers/health-map.test.ts
@@ -1,0 +1,440 @@
+/**
+ * Tests for handleGetHealthMap — structural health dashboard.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./utils.js', () => ({
+  validateDirectory: vi.fn(async (dir: string) => dir),
+  readCachedContext: vi.fn(async () => null),
+}));
+
+vi.mock('../../provenance/change-coupling.js', () => ({
+  volatilityLevel: vi.fn((churn: number) => (churn >= 12 ? 'high' : churn >= 5 ? 'medium' : 'low')),
+}));
+
+import { handleGetHealthMap } from './health-map.js';
+import { readCachedContext } from './utils.js';
+import { TOOL_OUTPUT_CLASS } from './tool-contract.js';
+import type { FunctionNode, CallEdge, SerializedCallGraph, LayerViolation } from '../../analyzer/call-graph.js';
+
+const mockCtx = vi.mocked(readCachedContext);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function node(over: Partial<FunctionNode> & { id: string }): FunctionNode {
+  return {
+    name: over.id.split('::')[1] ?? over.id,
+    filePath: over.id.split('::')[0] ?? 'x.ts',
+    isAsync: false,
+    language: 'typescript',
+    startIndex: 0,
+    endIndex: 1,
+    fanIn: 0,
+    fanOut: 0,
+    ...over,
+  };
+}
+
+function edge(callerId: string, calleeId: string): CallEdge {
+  return { callerId, calleeId, calleeName: calleeId.split('::')[1] ?? calleeId, confidence: 'import', kind: 'calls' };
+}
+
+function violation(callerId: string, calleeId: string): LayerViolation {
+  return { callerId, calleeId, callerLayer: 'cli', calleeLayer: 'core', reason: 'layer-skip' };
+}
+
+function graph(
+  nodes: FunctionNode[],
+  edges: CallEdge[] = [],
+  layerViolations: LayerViolation[] = [],
+): SerializedCallGraph {
+  return {
+    nodes,
+    edges,
+    classes: [],
+    inheritanceEdges: [],
+    hubFunctions: [],
+    entryPoints: [],
+    layerViolations,
+    stats: { totalNodes: nodes.length, totalEdges: edges.length, avgFanIn: 0, avgFanOut: 0 },
+  };
+}
+
+function noEdgeStore() {
+  return undefined;
+}
+
+function edgeStore(records: Array<{ filePath: string; churn: number }>) {
+  return {
+    countChangeCoupling: () => records.length,
+    getTopVolatile: (n: number) =>
+      [...records].sort((a, b) => b.churn - a.churn).slice(0, n),
+  };
+}
+
+// ============================================================================
+// Error paths
+// ============================================================================
+
+describe('handleGetHealthMap — error paths', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('errors when no analysis cached', async () => {
+    mockCtx.mockResolvedValue(null as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as { error: string };
+    expect(r.error).toMatch(/No analysis found/);
+  });
+
+  it('errors when call graph absent from cache', async () => {
+    mockCtx.mockResolvedValue({ callGraph: undefined } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as { error: string };
+    expect(r.error).toMatch(/Call graph not available/);
+  });
+});
+
+// ============================================================================
+// Empty graph
+// ============================================================================
+
+describe('handleGetHealthMap — empty graph', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns zero-counts on an empty graph', async () => {
+    mockCtx.mockResolvedValue({ callGraph: graph([], []) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      summary: { totalFunctions: number; hubCount: number; godFunctionCount: number; layerViolationCount: number; volatileFileCount: number };
+      topRisks: unknown[];
+    };
+    expect(r.summary).toEqual({
+      totalFunctions: 0,
+      hubCount: 0,
+      godFunctionCount: 0,
+      layerViolationCount: 0,
+      volatileFileCount: 0,
+    });
+    expect(r.topRisks).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Hub detection (fanIn >= 5)
+// ============================================================================
+
+describe('handleGetHealthMap — hubs', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('identifies hub nodes and excludes sub-threshold nodes', async () => {
+    const hub = node({ id: 'src/a.ts::hub', fanIn: 10 });
+    const notHub = node({ id: 'src/b.ts::small', fanIn: 4 });
+    mockCtx.mockResolvedValue({ callGraph: graph([hub, notHub]) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      summary: { hubCount: number };
+      hotspots: { hubs: Array<{ name: string; fanIn: number }> };
+    };
+    expect(r.summary.hubCount).toBe(1);
+    expect(r.hotspots.hubs).toHaveLength(1);
+    expect(r.hotspots.hubs[0].name).toBe('hub');
+    expect(r.hotspots.hubs[0].fanIn).toBe(10);
+  });
+
+  it('sorts hubs descending by fanIn', async () => {
+    const nodes = [
+      node({ id: 'src/a.ts::low', fanIn: 5 }),
+      node({ id: 'src/b.ts::high', fanIn: 20 }),
+      node({ id: 'src/c.ts::mid', fanIn: 12 }),
+    ];
+    mockCtx.mockResolvedValue({ callGraph: graph(nodes) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      hotspots: { hubs: Array<{ name: string }> };
+    };
+    expect(r.hotspots.hubs.map(h => h.name)).toEqual(['high', 'mid', 'low']);
+  });
+
+  it('excludes external and test nodes', async () => {
+    const ext = node({ id: 'src/a.ts::ext', fanIn: 20, isExternal: true });
+    const tst = node({ id: 'src/a.test.ts::testHelper', fanIn: 20, isTest: true });
+    const internal = node({ id: 'src/b.ts::real', fanIn: 8 });
+    mockCtx.mockResolvedValue({ callGraph: graph([ext, tst, internal]) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      summary: { totalFunctions: number; hubCount: number };
+    };
+    expect(r.summary.totalFunctions).toBe(1);
+    expect(r.summary.hubCount).toBe(1);
+  });
+});
+
+// ============================================================================
+// God function detection (fanOut >= 8)
+// ============================================================================
+
+describe('handleGetHealthMap — god functions', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('identifies god functions and excludes sub-threshold', async () => {
+    const god = node({ id: 'src/a.ts::dispatch', fanOut: 12 });
+    const normal = node({ id: 'src/b.ts::simple', fanOut: 3 });
+    mockCtx.mockResolvedValue({ callGraph: graph([god, normal]) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      summary: { godFunctionCount: number };
+      hotspots: { godFunctions: Array<{ name: string; fanOut: number }> };
+    };
+    expect(r.summary.godFunctionCount).toBe(1);
+    expect(r.hotspots.godFunctions[0].name).toBe('dispatch');
+    expect(r.hotspots.godFunctions[0].fanOut).toBe(12);
+  });
+
+  it('sorts god functions descending by fanOut', async () => {
+    const nodes = [
+      node({ id: 'src/a.ts::a', fanOut: 8 }),
+      node({ id: 'src/b.ts::b', fanOut: 30 }),
+    ];
+    mockCtx.mockResolvedValue({ callGraph: graph(nodes) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      hotspots: { godFunctions: Array<{ name: string }> };
+    };
+    expect(r.hotspots.godFunctions[0].name).toBe('b');
+  });
+});
+
+// ============================================================================
+// Layer violations
+// ============================================================================
+
+describe('handleGetHealthMap — layer violations', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('counts layer violations and surfaces them in topRisks', async () => {
+    const caller = node({ id: 'src/a.ts::caller', fanIn: 6 });
+    const callee = node({ id: 'src/b.ts::callee', fanIn: 1 });
+    const violations: LayerViolation[] = [violation(caller.id, callee.id)];
+    mockCtx.mockResolvedValue({ callGraph: graph([caller, callee], [], violations) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      summary: { layerViolationCount: number };
+      topRisks: Array<{ name: string; reasons: string[] }>;
+    };
+    expect(r.summary.layerViolationCount).toBe(1);
+    const risk = r.topRisks.find(x => x.name === 'caller');
+    expect(risk).toBeDefined();
+    expect(risk!.reasons).toContain('layer violation');
+  });
+
+  it('enriches callee-side file with violation signal too', async () => {
+    const caller = node({ id: 'src/a.ts::caller', fanIn: 1 });
+    const callee = node({ id: 'src/b.ts::calleeHub', fanIn: 7 });
+    const violations: LayerViolation[] = [violation(caller.id, callee.id)];
+    mockCtx.mockResolvedValue({ callGraph: graph([caller, callee], [], violations) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      topRisks: Array<{ name: string; reasons: string[] }>;
+    };
+    const risk = r.topRisks.find(x => x.name === 'calleeHub');
+    expect(risk).toBeDefined();
+    expect(risk!.reasons).toContain('layer violation');
+  });
+});
+
+// ============================================================================
+// Volatile files (edgeStore)
+// ============================================================================
+
+describe('handleGetHealthMap — volatile files', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists volatile files when edgeStore has data', async () => {
+    const store = edgeStore([
+      { filePath: 'src/hot.ts', churn: 20 },
+      { filePath: 'src/cold.ts', churn: 1 },
+    ]);
+    mockCtx.mockResolvedValue({ callGraph: graph([]), edgeStore: store } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      summary: { volatileFileCount: number };
+      hotspots: { volatile: Array<{ file: string; level: string; changes: number }> };
+    };
+    expect(r.summary.volatileFileCount).toBe(2);
+    expect(r.hotspots.volatile[0]).toMatchObject({ file: 'src/hot.ts', level: 'high', changes: 20 });
+  });
+
+  it('reports zero volatile files when edgeStore is absent', async () => {
+    mockCtx.mockResolvedValue({ callGraph: graph([]), edgeStore: noEdgeStore() } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      summary: { volatileFileCount: number };
+      hotspots: { volatile: unknown[] };
+    };
+    expect(r.summary.volatileFileCount).toBe(0);
+    expect(r.hotspots.volatile).toEqual([]);
+  });
+
+  it('reports zero volatile files when countChangeCoupling is zero', async () => {
+    const store = { countChangeCoupling: () => 0, getTopVolatile: () => [] };
+    mockCtx.mockResolvedValue({ callGraph: graph([]), edgeStore: store } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      summary: { volatileFileCount: number };
+    };
+    expect(r.summary.volatileFileCount).toBe(0);
+  });
+
+  it('hotspots.volatile is capped at min(limit, 5) while summary.volatileFileCount reflects full count', async () => {
+    const records = Array.from({ length: 20 }, (_, i) => ({ filePath: `src/f${i}.ts`, churn: 20 - i }));
+    const store = edgeStore(records);
+    mockCtx.mockResolvedValue({ callGraph: graph([]), edgeStore: store } as never);
+    const r = await handleGetHealthMap({ directory: '/p', limit: 10 }) as {
+      summary: { volatileFileCount: number };
+      hotspots: { volatile: unknown[] };
+    };
+    expect(r.summary.volatileFileCount).toBe(20);
+    expect(r.hotspots.volatile.length).toBeLessThanOrEqual(5);
+  });
+
+  it('marks topRisk as volatile when its file appears in volatile list', async () => {
+    const hub = node({ id: 'src/hot.ts::bigHub', fanIn: 8 });
+    const store = edgeStore([{ filePath: 'src/hot.ts', churn: 15 }]);
+    mockCtx.mockResolvedValue({ callGraph: graph([hub]), edgeStore: store } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      topRisks: Array<{ name: string; reasons: string[] }>;
+    };
+    const risk = r.topRisks.find(x => x.name === 'bigHub');
+    expect(risk!.reasons).toContain('volatile file');
+  });
+});
+
+// ============================================================================
+// Severity ranking
+// ============================================================================
+
+describe('handleGetHealthMap — severity', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rates medium for single signal', async () => {
+    const hub = node({ id: 'src/a.ts::singleHub', fanIn: 6 });
+    mockCtx.mockResolvedValue({ callGraph: graph([hub]) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      topRisks: Array<{ severity: string }>;
+    };
+    expect(r.topRisks[0].severity).toBe('medium');
+  });
+
+  it('rates high for two signals (hub + volatile)', async () => {
+    const hub = node({ id: 'src/a.ts::dualRisk', fanIn: 7 });
+    const store = edgeStore([{ filePath: 'src/a.ts', churn: 20 }]);
+    mockCtx.mockResolvedValue({ callGraph: graph([hub]), edgeStore: store } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      topRisks: Array<{ severity: string }>;
+    };
+    expect(r.topRisks[0].severity).toBe('high');
+  });
+
+  it('rates critical for three or more signals', async () => {
+    const hubGod = node({ id: 'src/a.ts::tripleRisk', fanIn: 9, fanOut: 10 });
+    const plain = node({ id: 'src/b.ts::callee', fanIn: 0 });
+    const violations: LayerViolation[] = [violation(hubGod.id, plain.id)];
+    const store = edgeStore([{ filePath: 'src/a.ts', churn: 30 }]);
+    mockCtx.mockResolvedValue({ callGraph: graph([hubGod, plain], [], violations), edgeStore: store } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      topRisks: Array<{ name: string; severity: string; reasons: string[] }>;
+    };
+    const risk = r.topRisks.find(x => x.name === 'tripleRisk');
+    expect(risk!.severity).toBe('critical');
+    expect(risk!.reasons.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('sorts topRisks critical → high → medium', async () => {
+    const hubGod = node({ id: 'src/a.ts::big', fanIn: 10, fanOut: 15 });
+    const violations: LayerViolation[] = [violation(hubGod.id, 'src/x.ts::x')];
+    const store = edgeStore([{ filePath: 'src/a.ts', churn: 20 }]);
+    const hubOnly = node({ id: 'src/b.ts::hubOnly', fanIn: 6 });
+    mockCtx.mockResolvedValue({
+      callGraph: graph([hubGod, hubOnly], [], violations),
+      edgeStore: store,
+    } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      topRisks: Array<{ severity: string }>;
+    };
+    const severities = r.topRisks.map(x => x.severity);
+    const order = { critical: 0, high: 1, medium: 2 } as Record<string, number>;
+    for (let i = 1; i < severities.length; i++) {
+      expect(order[severities[i]]).toBeGreaterThanOrEqual(order[severities[i - 1]]);
+    }
+  });
+});
+
+// ============================================================================
+// topRisks deduplication (hub + god function same node)
+// ============================================================================
+
+describe('handleGetHealthMap — deduplication', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('merges hub+god same node into one topRisk entry with both reasons', async () => {
+    const both = node({ id: 'src/a.ts::megaFn', fanIn: 10, fanOut: 12 });
+    mockCtx.mockResolvedValue({ callGraph: graph([both]) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      topRisks: Array<{ name: string; reasons: string[] }>;
+    };
+    const entries = r.topRisks.filter(x => x.name === 'megaFn');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].reasons).toContain('hub (10 callers)');
+    expect(entries[0].reasons).toContain('god function (12 callees)');
+  });
+});
+
+// ============================================================================
+// limit clamping
+// ============================================================================
+
+describe('handleGetHealthMap — limit', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function manyHubs(n: number) {
+    return Array.from({ length: n }, (_, i) =>
+      node({ id: `src/f${i}.ts::f${i}`, fanIn: 5 + i }),
+    );
+  }
+
+  it('defaults to limit=10', async () => {
+    const nodes = manyHubs(20);
+    mockCtx.mockResolvedValue({ callGraph: graph(nodes) } as never);
+    const r = await handleGetHealthMap({ directory: '/p' }) as {
+      topRisks: unknown[];
+    };
+    expect(r.topRisks.length).toBeLessThanOrEqual(10);
+  });
+
+  it('respects explicit limit', async () => {
+    const nodes = manyHubs(20);
+    mockCtx.mockResolvedValue({ callGraph: graph(nodes) } as never);
+    const r = await handleGetHealthMap({ directory: '/p', limit: 5 }) as {
+      topRisks: unknown[];
+    };
+    expect(r.topRisks.length).toBeLessThanOrEqual(5);
+  });
+
+  it('clamps limit to minimum 1', async () => {
+    const nodes = manyHubs(5);
+    mockCtx.mockResolvedValue({ callGraph: graph(nodes) } as never);
+    const r = await handleGetHealthMap({ directory: '/p', limit: 0 }) as {
+      topRisks: unknown[];
+    };
+    expect(r.topRisks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('clamps limit to maximum 50', async () => {
+    const nodes = manyHubs(60);
+    mockCtx.mockResolvedValue({ callGraph: graph(nodes) } as never);
+    const r = await handleGetHealthMap({ directory: '/p', limit: 100 }) as {
+      topRisks: unknown[];
+    };
+    expect(r.topRisks.length).toBeLessThanOrEqual(50);
+  });
+});
+
+// ============================================================================
+// Tool surface contract
+// ============================================================================
+
+describe('get_health_map tool surface', () => {
+  it('is classified conclusion under the contract', () => {
+    expect(TOOL_OUTPUT_CLASS.get_health_map).toBe('conclusion');
+  });
+});

--- a/src/core/services/mcp-handlers/health-map.ts
+++ b/src/core/services/mcp-handlers/health-map.ts
@@ -1,5 +1,5 @@
 import { validateDirectory, readCachedContext } from './utils.js';
-import type { SerializedCallGraph, FunctionNode, CallEdge, LayerViolation } from '../../analyzer/call-graph.js';
+import type { SerializedCallGraph, FunctionNode, CallEdge } from '../../analyzer/call-graph.js';
 import { volatilityLevel } from '../../provenance/change-coupling.js';
 
 const HUB_MIN_FAN_IN = 5;

--- a/src/core/services/mcp-handlers/health-map.ts
+++ b/src/core/services/mcp-handlers/health-map.ts
@@ -1,15 +1,87 @@
 import { validateDirectory, readCachedContext } from './utils.js';
-import type { SerializedCallGraph, FunctionNode, LayerViolation } from '../../analyzer/call-graph.js';
+import type { SerializedCallGraph, FunctionNode, CallEdge, LayerViolation } from '../../analyzer/call-graph.js';
 import { volatilityLevel } from '../../provenance/change-coupling.js';
 
 const HUB_MIN_FAN_IN = 5;
 const GOD_MIN_FAN_OUT = 8;
 const DEFAULT_LIMIT = 10;
+const MAX_BETWEENNESS_SOURCES = 300;
+const BRIDGE_MIN_BETWEENNESS = 0.005;
+const UNTESTED_MIN_DEGREE = 10;
 
 export interface GetHealthMapInput {
   directory: string;
   /** Max items per hotspot list and max topRisks (default 10, max 50). */
   limit?: number;
+}
+
+type BridgeEntry = { id: string; name: string; file: string; fanIn: number; fanOut: number; betweenness: number };
+type UntestedEntry = { id: string; name: string; file: string; degree: number };
+
+function computeBridgeNodes(nodes: FunctionNode[], edges: CallEdge[], topN: number): BridgeEntry[] {
+  if (nodes.length === 0) return [];
+  const nodeIds = nodes.map(n => n.id);
+  const idxMap = new Map<string, number>(nodeIds.map((id, i) => [id, i]));
+  const adj: number[][] = nodeIds.map(() => []);
+  for (const e of edges) {
+    const si = idxMap.get(e.callerId);
+    const ti = idxMap.get(e.calleeId);
+    if (si !== undefined && ti !== undefined) adj[si].push(ti);
+  }
+  const n = nodeIds.length;
+  const betweenness = new Float64Array(n);
+  const step = Math.max(1, Math.floor(n / MAX_BETWEENNESS_SOURCES));
+  for (let srcIdx = 0; srcIdx < n; srcIdx += step) {
+    const stack: number[] = [];
+    const pred: number[][] = Array.from({ length: n }, () => []);
+    const sigma = new Float64Array(n);
+    const dist = new Int32Array(n).fill(-1);
+    const delta = new Float64Array(n);
+    sigma[srcIdx] = 1;
+    dist[srcIdx] = 0;
+    const queue: number[] = [srcIdx];
+    let qi = 0;
+    while (qi < queue.length) {
+      const v = queue[qi++];
+      stack.push(v);
+      for (const w of adj[v]) {
+        if (dist[w] < 0) { queue.push(w); dist[w] = dist[v] + 1; }
+        if (dist[w] === dist[v] + 1) { sigma[w] += sigma[v]; pred[w].push(v); }
+      }
+    }
+    while (stack.length > 0) {
+      const w = stack.pop()!;
+      for (const v of pred[w]) delta[v] += (sigma[v] / sigma[w]) * (1 + delta[w]);
+      if (w !== srcIdx) betweenness[w] += delta[w];
+    }
+  }
+  let maxB = 1;
+  for (let i = 0; i < n; i++) if (betweenness[i] > maxB) maxB = betweenness[i];
+  return nodes
+    .map((node, i) => ({ node, b: betweenness[i] / maxB }))
+    .filter(x => x.b > 0)
+    .sort((a, b) => b.b - a.b)
+    .slice(0, topN)
+    .map(({ node, b }) => ({
+      id: node.id,
+      name: node.name,
+      file: node.filePath,
+      fanIn: node.fanIn ?? 0,
+      fanOut: node.fanOut ?? 0,
+      betweenness: Math.round(b * 1000) / 1000,
+    }));
+}
+
+function computeUntestedHotspots(nodes: FunctionNode[], edges: CallEdge[], topN: number): UntestedEntry[] {
+  const testNodeIds = new Set(nodes.filter(n => n.isTest).map(n => n.id));
+  const testedIds = new Set<string>();
+  for (const e of edges) { if (testNodeIds.has(e.callerId)) testedIds.add(e.calleeId); }
+  return nodes
+    .filter(n => !n.isTest && !n.isExternal && !testedIds.has(n.id))
+    .map(n => ({ id: n.id, name: n.name, file: n.filePath, degree: (n.fanIn ?? 0) + (n.fanOut ?? 0) }))
+    .filter(e => e.degree >= UNTESTED_MIN_DEGREE)
+    .sort((a, b) => b.degree - a.degree)
+    .slice(0, topN);
 }
 
 export async function handleGetHealthMap(input: GetHealthMapInput): Promise<unknown> {
@@ -54,9 +126,23 @@ export async function handleGetHealthMap(input: GetHealthMapInput): Promise<unkn
   const volatileFileList = allVolatileFiles.slice(0, limit);
   const volatileFileSet = new Set(allVolatileFiles.map(v => v.file));
 
-  // --- Top risks: deduplicated union of hubs + god functions, ranked by severity ---
+  // --- Bridge nodes (sampled betweenness centrality on the call graph) ---
+  const bridgeNodes = computeBridgeNodes(codeNodes, cg.edges, limit);
+  const bridgeNodeIds = new Set(bridgeNodes.map(b => b.id));
+  const bridgeCount = bridgeNodes.filter(b => b.betweenness >= BRIDGE_MIN_BETWEENNESS).length;
+  const bridgeMap = new Map(bridgeNodes.map(b => [b.id, b]));
+
+  // --- Untested hotspots (high-degree nodes not directly called by any test) ---
+  const untestedHotspots = computeUntestedHotspots(cg.nodes, cg.edges, limit);
+  const untestedHotspotIds = new Set(untestedHotspots.map(u => u.id));
+  const untestedMap = new Map(untestedHotspots.map(u => [u.id, u]));
+
+  // --- Top risks: union of all hotspot signal sources ---
+  const bridgeCandidates = codeNodes.filter(n => bridgeNodeIds.has(n.id));
+  const untestedCandidates = codeNodes.filter(n => untestedHotspotIds.has(n.id));
   const candidateMap = new Map(
-    [...hubNodes.slice(0, limit), ...godNodes.slice(0, limit)].map(n => [n.id, n])
+    [...hubNodes.slice(0, limit), ...godNodes.slice(0, limit), ...bridgeCandidates, ...untestedCandidates]
+      .map(n => [n.id, n])
   );
   const topRisks = [...candidateMap.values()]
     .map(n => {
@@ -64,11 +150,15 @@ export async function handleGetHealthMap(input: GetHealthMapInput): Promise<unkn
       const isGod = (n.fanOut ?? 0) >= GOD_MIN_FAN_OUT;
       const isVolatile = volatileFileSet.has(n.filePath);
       const hasViolation = violationFiles.has(n.filePath);
+      const isBridge = bridgeNodeIds.has(n.id);
+      const isUntested = untestedHotspotIds.has(n.id);
       const reasons: string[] = [];
       if (isHub) reasons.push(`hub (${n.fanIn} callers)`);
       if (isGod) reasons.push(`god function (${n.fanOut} callees)`);
       if (isVolatile) reasons.push('volatile file');
       if (hasViolation) reasons.push('layer violation');
+      if (isBridge) reasons.push(`bridge (betweenness ${bridgeMap.get(n.id)?.betweenness ?? 0})`);
+      if (isUntested) reasons.push(`untested hotspot (degree ${untestedMap.get(n.id)?.degree ?? 0})`);
       const severity: 'critical' | 'high' | 'medium' =
         reasons.length >= 3 ? 'critical' : reasons.length >= 2 ? 'high' : 'medium';
       return {
@@ -93,6 +183,8 @@ export async function handleGetHealthMap(input: GetHealthMapInput): Promise<unkn
       godFunctionCount: godNodes.length,
       layerViolationCount: violations.length,
       volatileFileCount: allVolatileFiles.length,
+      bridgeCount,
+      untestedHotspotCount: untestedHotspots.length,
     },
     topRisks,
     hotspots: {
@@ -108,11 +200,13 @@ export async function handleGetHealthMap(input: GetHealthMapInput): Promise<unkn
         fanOut: n.fanOut ?? 0,
       })),
       volatile: volatileFileList.slice(0, Math.min(limit, 5)),
+      bridges: bridgeNodes.slice(0, Math.min(limit, 5)).map(({ id: _id, ...rest }) => rest),
+      untestedHotspots: untestedHotspots.slice(0, Math.min(limit, 5)).map(({ id: _id, ...rest }) => rest),
     },
     guidance:
-      'topRisks covers structural hotspots (hubs + god functions) enriched with volatility and layer-violation signals. ' +
+      'topRisks covers structural hotspots ranked by signal count: hub, god function, volatile file, ' +
+      'layer violation, bridge (betweenness chokepoint), untested hotspot. ' +
       'critical = ≥3 signals, high = 2, medium = 1. ' +
-      'Volatile-only or violation-only files appear in hotspots.volatile but not in topRisks. ' +
-      'Drill in with get_critical_hubs, get_god_functions, get_change_coupling, or find_dead_code.',
+      'Drill in with get_critical_hubs, get_god_functions, get_change_coupling, find_dead_code, or get_surprising_connections.',
   };
 }

--- a/src/core/services/mcp-handlers/health-map.ts
+++ b/src/core/services/mcp-handlers/health-map.ts
@@ -1,0 +1,118 @@
+import { validateDirectory, readCachedContext } from './utils.js';
+import type { SerializedCallGraph, FunctionNode, LayerViolation } from '../../analyzer/call-graph.js';
+import { volatilityLevel } from '../../provenance/change-coupling.js';
+
+const HUB_MIN_FAN_IN = 5;
+const GOD_MIN_FAN_OUT = 8;
+const DEFAULT_LIMIT = 10;
+
+export interface GetHealthMapInput {
+  directory: string;
+  /** Max items per hotspot list and max topRisks (default 10, max 50). */
+  limit?: number;
+}
+
+export async function handleGetHealthMap(input: GetHealthMapInput): Promise<unknown> {
+  const absDir = await validateDirectory(input.directory);
+  const ctx = await readCachedContext(absDir);
+  if (!ctx) return { error: 'No analysis found. Run analyze_codebase first.' };
+  if (!ctx.callGraph) return { error: 'Call graph not available. Re-run analyze_codebase.' };
+
+  const limit = Math.max(1, Math.min(input.limit ?? DEFAULT_LIMIT, 50));
+  const cg = ctx.callGraph as SerializedCallGraph;
+  const codeNodes = cg.nodes.filter(n => !n.isExternal && !n.isTest);
+
+  // --- Hubs (high fan-in) ---
+  const hubNodes = codeNodes
+    .filter(n => (n.fanIn ?? 0) >= HUB_MIN_FAN_IN)
+    .sort((a, b) => (b.fanIn ?? 0) - (a.fanIn ?? 0));
+
+  // --- God functions (high fan-out) ---
+  const godNodes = codeNodes
+    .filter(n => (n.fanOut ?? 0) >= GOD_MIN_FAN_OUT)
+    .sort((a, b) => (b.fanOut ?? 0) - (a.fanOut ?? 0));
+
+  // --- Layer violations ---
+  const nodeMap = new Map(cg.nodes.map(n => [n.id, n]));
+  const violations = cg.layerViolations ?? [];
+  const violationFiles = new Set<string>(
+    violations.flatMap(v =>
+      [nodeMap.get(v.callerId)?.filePath, nodeMap.get(v.calleeId)?.filePath].filter((p): p is string => p !== undefined)
+    )
+  );
+
+  // --- Volatility (from edgeStore if present) ---
+  // Fetch all volatile files to get the true total count; slice to limit for display.
+  let allVolatileFiles: Array<{ file: string; level: string; changes: number }> = [];
+  if (ctx.edgeStore && ctx.edgeStore.countChangeCoupling() > 0) {
+    allVolatileFiles = ctx.edgeStore.getTopVolatile(10_000).map(r => ({
+      file: r.filePath,
+      level: volatilityLevel(r.churn),
+      changes: r.churn,
+    }));
+  }
+  const volatileFileList = allVolatileFiles.slice(0, limit);
+  const volatileFileSet = new Set(allVolatileFiles.map(v => v.file));
+
+  // --- Top risks: deduplicated union of hubs + god functions, ranked by severity ---
+  const candidateMap = new Map(
+    [...hubNodes.slice(0, limit), ...godNodes.slice(0, limit)].map(n => [n.id, n])
+  );
+  const topRisks = [...candidateMap.values()]
+    .map(n => {
+      const isHub = (n.fanIn ?? 0) >= HUB_MIN_FAN_IN;
+      const isGod = (n.fanOut ?? 0) >= GOD_MIN_FAN_OUT;
+      const isVolatile = volatileFileSet.has(n.filePath);
+      const hasViolation = violationFiles.has(n.filePath);
+      const reasons: string[] = [];
+      if (isHub) reasons.push(`hub (${n.fanIn} callers)`);
+      if (isGod) reasons.push(`god function (${n.fanOut} callees)`);
+      if (isVolatile) reasons.push('volatile file');
+      if (hasViolation) reasons.push('layer violation');
+      const severity: 'critical' | 'high' | 'medium' =
+        reasons.length >= 3 ? 'critical' : reasons.length >= 2 ? 'high' : 'medium';
+      return {
+        name: n.name,
+        file: n.filePath,
+        fanIn: n.fanIn ?? 0,
+        fanOut: n.fanOut ?? 0,
+        reasons,
+        severity,
+      };
+    })
+    .sort((a, b) => {
+      const rank = { critical: 0, high: 1, medium: 2 } as const;
+      return rank[a.severity] - rank[b.severity] || (b.fanIn + b.fanOut) - (a.fanIn + a.fanOut);
+    })
+    .slice(0, limit);
+
+  return {
+    summary: {
+      totalFunctions: codeNodes.length,
+      hubCount: hubNodes.length,
+      godFunctionCount: godNodes.length,
+      layerViolationCount: violations.length,
+      volatileFileCount: allVolatileFiles.length,
+    },
+    topRisks,
+    hotspots: {
+      hubs: hubNodes.slice(0, Math.min(limit, 5)).map(n => ({
+        name: n.name,
+        file: n.filePath,
+        fanIn: n.fanIn ?? 0,
+        fanOut: n.fanOut ?? 0,
+      })),
+      godFunctions: godNodes.slice(0, Math.min(limit, 5)).map(n => ({
+        name: n.name,
+        file: n.filePath,
+        fanOut: n.fanOut ?? 0,
+      })),
+      volatile: volatileFileList.slice(0, Math.min(limit, 5)),
+    },
+    guidance:
+      'topRisks covers structural hotspots (hubs + god functions) enriched with volatility and layer-violation signals. ' +
+      'critical = ≥3 signals, high = 2, medium = 1. ' +
+      'Volatile-only or violation-only files appear in hotspots.volatile but not in topRisks. ' +
+      'Drill in with get_critical_hubs, get_god_functions, get_change_coupling, or find_dead_code.',
+  };
+}

--- a/src/core/services/mcp-handlers/health-map.ts
+++ b/src/core/services/mcp-handlers/health-map.ts
@@ -18,8 +18,8 @@ export interface GetHealthMapInput {
 type BridgeEntry = { id: string; name: string; file: string; fanIn: number; fanOut: number; betweenness: number };
 type UntestedEntry = { id: string; name: string; file: string; degree: number };
 
-function computeBridgeNodes(nodes: FunctionNode[], edges: CallEdge[], topN: number): BridgeEntry[] {
-  if (nodes.length === 0) return [];
+function computeBridgeNodes(nodes: FunctionNode[], edges: CallEdge[], topN: number): { entries: BridgeEntry[]; sourcesUsed: number } {
+  if (nodes.length === 0) return { entries: [], sourcesUsed: 0 };
   const nodeIds = nodes.map(n => n.id);
   const idxMap = new Map<string, number>(nodeIds.map((id, i) => [id, i]));
   const adj: number[][] = nodeIds.map(() => []);
@@ -57,7 +57,8 @@ function computeBridgeNodes(nodes: FunctionNode[], edges: CallEdge[], topN: numb
   }
   let maxB = 1;
   for (let i = 0; i < n; i++) if (betweenness[i] > maxB) maxB = betweenness[i];
-  return nodes
+  const sourcesUsed = Math.ceil(n / step);
+  const entries = nodes
     .map((node, i) => ({ node, b: betweenness[i] / maxB }))
     .filter(x => x.b > 0)
     .sort((a, b) => b.b - a.b)
@@ -70,12 +71,16 @@ function computeBridgeNodes(nodes: FunctionNode[], edges: CallEdge[], topN: numb
       fanOut: node.fanOut ?? 0,
       betweenness: Math.round(b * 1000) / 1000,
     }));
+  return { entries, sourcesUsed };
 }
 
 function computeUntestedHotspots(nodes: FunctionNode[], edges: CallEdge[], topN: number): UntestedEntry[] {
   const testNodeIds = new Set(nodes.filter(n => n.isTest).map(n => n.id));
   const testedIds = new Set<string>();
+  // Direct: testNode → X
   for (const e of edges) { if (testNodeIds.has(e.callerId)) testedIds.add(e.calleeId); }
+  // 1-hop transitive: testNode → Y → X
+  for (const e of edges) { if (testedIds.has(e.callerId)) testedIds.add(e.calleeId); }
   return nodes
     .filter(n => !n.isTest && !n.isExternal && !testedIds.has(n.id))
     .map(n => ({ id: n.id, name: n.name, file: n.filePath, degree: (n.fanIn ?? 0) + (n.fanOut ?? 0) }))
@@ -127,7 +132,7 @@ export async function handleGetHealthMap(input: GetHealthMapInput): Promise<unkn
   const volatileFileSet = new Set(allVolatileFiles.map(v => v.file));
 
   // --- Bridge nodes (sampled betweenness centrality on the call graph) ---
-  const bridgeNodes = computeBridgeNodes(codeNodes, cg.edges, limit);
+  const { entries: bridgeNodes, sourcesUsed: betweennessSourceCount } = computeBridgeNodes(codeNodes, cg.edges, limit);
   const bridgeNodeIds = new Set(bridgeNodes.map(b => b.id));
   const bridgeCount = bridgeNodes.filter(b => b.betweenness >= BRIDGE_MIN_BETWEENNESS).length;
   const bridgeMap = new Map(bridgeNodes.map(b => [b.id, b]));
@@ -185,6 +190,8 @@ export async function handleGetHealthMap(input: GetHealthMapInput): Promise<unkn
       volatileFileCount: allVolatileFiles.length,
       bridgeCount,
       untestedHotspotCount: untestedHotspots.length,
+      betweennessApprox: codeNodes.length > MAX_BETWEENNESS_SOURCES,
+      betweennessSourceCount,
     },
     topRisks,
     hotspots: {

--- a/src/core/services/mcp-handlers/live-data/tool-driver.ts
+++ b/src/core/services/mcp-handlers/live-data/tool-driver.ts
@@ -85,6 +85,8 @@ export const TOOL_REGISTRY: Record<string, ToolPlan> = {
   list_decisions: { kind: 'read', buildArgs: dirOnly },
   get_landmarks: { kind: 'read', buildArgs: dirOnly },
   get_map: { kind: 'read', buildArgs: dirOnly },
+  get_health_map: { kind: 'read', buildArgs: dirOnly },
+  get_surprising_connections: { kind: 'read', buildArgs: dirOnly },
   detect_changes: { kind: 'read', buildArgs: dirOnly },
   get_critical_hubs: { kind: 'read', buildArgs: dirOnly },
   get_leaf_functions: { kind: 'read', buildArgs: dirOnly },

--- a/src/core/services/mcp-handlers/surprising-connections.ts
+++ b/src/core/services/mcp-handlers/surprising-connections.ts
@@ -1,0 +1,85 @@
+import { validateDirectory, readCachedContext } from './utils.js';
+import type { SerializedCallGraph, FunctionNode } from '../../analyzer/call-graph.js';
+
+const DEFAULT_LIMIT = 15;
+const HUB_MIN_FAN_IN = 5;
+const PERIPHERAL_MAX_DEGREE = 4;
+
+export interface GetSurprisingConnectionsInput {
+  directory: string;
+  /** Max results to return (default: 15, max: 50). */
+  limit?: number;
+}
+
+export async function handleGetSurprisingConnections(input: GetSurprisingConnectionsInput): Promise<unknown> {
+  const absDir = await validateDirectory(input.directory);
+  const ctx = await readCachedContext(absDir);
+  if (!ctx) return { error: 'No analysis found. Run analyze_codebase first.' };
+  if (!ctx.callGraph) return { error: 'Call graph not available. Re-run analyze_codebase.' };
+
+  const limit = Math.max(1, Math.min(input.limit ?? DEFAULT_LIMIT, 50));
+  const cg = ctx.callGraph as SerializedCallGraph;
+  const nodeById = new Map<string, FunctionNode>(cg.nodes.map(n => [n.id, n]));
+
+  // Deduplicate: one entry per (callerId, calleeId) pair.
+  const seen = new Set<string>();
+  const results: Array<{
+    from: string; fromFile: string;
+    to: string; toFile: string;
+    score: number; reasons: string[];
+  }> = [];
+
+  for (const e of cg.edges) {
+    const key = `${e.callerId}→${e.calleeId}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const src = nodeById.get(e.callerId);
+    const tgt = nodeById.get(e.calleeId);
+    if (!src || !tgt || src.isExternal || tgt.isExternal) continue;
+
+    const reasons: string[] = [];
+    let score = 0;
+
+    // Cross-community: different non-null community IDs
+    if (src.communityId && tgt.communityId && src.communityId !== tgt.communityId) {
+      score += 0.3;
+      reasons.push('cross-community');
+    }
+
+    // Peripheral-to-hub: low-degree source calling a high-fanIn target
+    const srcDegree = (src.fanIn ?? 0) + (src.fanOut ?? 0);
+    if (srcDegree <= PERIPHERAL_MAX_DEGREE && (tgt.fanIn ?? 0) >= HUB_MIN_FAN_IN * 3) {
+      score += 0.2;
+      reasons.push('peripheral-to-hub');
+    }
+
+    // Cross-test-boundary: one side is test, the other is not
+    if (!!src.isTest !== !!tgt.isTest) {
+      score += 0.15;
+      reasons.push('cross-test-boundary');
+    }
+
+    if (score === 0) continue;
+
+    results.push({
+      from: src.name,
+      fromFile: src.filePath,
+      to: tgt.name,
+      toFile: tgt.filePath,
+      score: Math.round(score * 100) / 100,
+      reasons,
+    });
+  }
+
+  const top = results.sort((a, b) => b.score - a.score).slice(0, limit);
+
+  return {
+    count: top.length,
+    connections: top,
+    guidance:
+      'Each connection is scored by: cross-community (+0.3), peripheral-to-hub (+0.2), ' +
+      'cross-test-boundary (+0.15). High scores flag accidental coupling. ' +
+      'Verify with get_subgraph or trace_execution_path before acting.',
+  };
+}

--- a/src/core/services/mcp-handlers/surprising-connections.ts
+++ b/src/core/services/mcp-handlers/surprising-connections.ts
@@ -4,6 +4,8 @@ import type { SerializedCallGraph, FunctionNode } from '../../analyzer/call-grap
 const DEFAULT_LIMIT = 15;
 const HUB_MIN_FAN_IN = 5;
 const PERIPHERAL_MAX_DEGREE = 4;
+// Global utilities (very high fanIn, low fanOut) are designed to be called cross-community — not surprising.
+const GLOBAL_UTILITY_FAN_IN = 20;
 
 export interface GetSurprisingConnectionsInput {
   directory: string;
@@ -21,13 +23,10 @@ export async function handleGetSurprisingConnections(input: GetSurprisingConnect
   const cg = ctx.callGraph as SerializedCallGraph;
   const nodeById = new Map<string, FunctionNode>(cg.nodes.map(n => [n.id, n]));
 
-  // Deduplicate: one entry per (callerId, calleeId) pair.
+  // Score each unique (caller, callee) edge.
+  type EdgeResult = { from: string; fromFile: string; to: string; toFile: string; score: number; reasons: string[] };
   const seen = new Set<string>();
-  const results: Array<{
-    from: string; fromFile: string;
-    to: string; toFile: string;
-    score: number; reasons: string[];
-  }> = [];
+  const edgeResults: EdgeResult[] = [];
 
   for (const e of cg.edges) {
     const key = `${e.callerId}→${e.calleeId}`;
@@ -47,9 +46,11 @@ export async function handleGetSurprisingConnections(input: GetSurprisingConnect
       reasons.push('cross-community');
     }
 
-    // Peripheral-to-hub: low-degree source calling a high-fanIn target
+    // Peripheral-to-hub: low-degree source calling a domain hub.
+    // Skip if target is a global utility (very high fanIn) — those are designed to be called cross-community.
     const srcDegree = (src.fanIn ?? 0) + (src.fanOut ?? 0);
-    if (srcDegree <= PERIPHERAL_MAX_DEGREE && (tgt.fanIn ?? 0) >= HUB_MIN_FAN_IN * 3) {
+    const tgtFanIn = tgt.fanIn ?? 0;
+    if (srcDegree <= PERIPHERAL_MAX_DEGREE && tgtFanIn >= HUB_MIN_FAN_IN * 3 && tgtFanIn < GLOBAL_UTILITY_FAN_IN) {
       score += 0.2;
       reasons.push('peripheral-to-hub');
     }
@@ -61,25 +62,41 @@ export async function handleGetSurprisingConnections(input: GetSurprisingConnect
     }
 
     if (score === 0) continue;
-
-    results.push({
-      from: src.name,
-      fromFile: src.filePath,
-      to: tgt.name,
-      toFile: tgt.filePath,
-      score: Math.round(score * 100) / 100,
-      reasons,
-    });
+    edgeResults.push({ from: src.name, fromFile: src.filePath, to: tgt.name, toFile: tgt.filePath, score: Math.round(score * 100) / 100, reasons });
   }
 
-  const top = results.sort((a, b) => b.score - a.score).slice(0, limit);
+  // Group by target: multiple callers reaching the same surprising target is one finding.
+  type Group = { to: string; toFile: string; score: number; reasons: string[]; callers: Array<{ from: string; fromFile: string }> };
+  const grouped = new Map<string, Group>();
+  for (const r of edgeResults) {
+    const key = `${r.toFile}::${r.to}`;
+    const g = grouped.get(key);
+    if (!g) {
+      grouped.set(key, { to: r.to, toFile: r.toFile, score: r.score, reasons: r.reasons, callers: [{ from: r.from, fromFile: r.fromFile }] });
+    } else {
+      if (r.score > g.score) { g.score = r.score; g.reasons = r.reasons; }
+      if (!g.callers.some(c => c.from === r.from && c.fromFile === r.fromFile)) g.callers.push({ from: r.from, fromFile: r.fromFile });
+    }
+  }
+
+  const top = [...grouped.values()]
+    .sort((a, b) => b.score - a.score || b.callers.length - a.callers.length)
+    .slice(0, limit)
+    .map(g => ({
+      to: g.to,
+      toFile: g.toFile,
+      callerCount: g.callers.length,
+      callers: g.callers.slice(0, 3),
+      score: g.score,
+      reasons: g.reasons,
+    }));
 
   return {
     count: top.length,
     connections: top,
     guidance:
-      'Each connection is scored by: cross-community (+0.3), peripheral-to-hub (+0.2), ' +
-      'cross-test-boundary (+0.15). High scores flag accidental coupling. ' +
+      'Grouped by target: callerCount shows how many distinct modules reach this surprising dependency. ' +
+      'Scored by: cross-community (+0.3), peripheral-to-hub (+0.2), cross-test-boundary (+0.15). ' +
       'Verify with get_subgraph or trace_execution_path before acting.',
   };
 }

--- a/src/core/services/mcp-handlers/tool-contract.ts
+++ b/src/core/services/mcp-handlers/tool-contract.ts
@@ -92,6 +92,7 @@ export const TOOL_OUTPUT_CLASS: Record<string, ToolOutputClass> = {
   find_path: 'conclusion',
   detect_changes: 'conclusion',
   get_health_map: 'conclusion',
+  get_surprising_connections: 'conclusion',
   record_decision: 'conclusion',
   list_decisions: 'conclusion',
   approve_decision: 'conclusion',

--- a/src/core/services/mcp-handlers/tool-contract.ts
+++ b/src/core/services/mcp-handlers/tool-contract.ts
@@ -91,6 +91,7 @@ export const TOOL_OUTPUT_CLASS: Record<string, ToolOutputClass> = {
   get_map: 'conclusion',
   find_path: 'conclusion',
   detect_changes: 'conclusion',
+  get_health_map: 'conclusion',
   record_decision: 'conclusion',
   list_decisions: 'conclusion',
   approve_decision: 'conclusion',

--- a/src/core/services/tool-dispatch.ts
+++ b/src/core/services/tool-dispatch.ts
@@ -23,6 +23,7 @@ import { handleSelectTests } from './mcp-handlers/test-impact.js';
 import { handleFindDeadCode } from './mcp-handlers/reachability.js';
 import { handleStructuralDiff } from './mcp-handlers/structural-diff.js';
 import { handleGetChangeCoupling } from './mcp-handlers/change-coupling.js';
+import { handleGetHealthMap } from './mcp-handlers/health-map.js';
 import { handleGetLandmarks } from './mcp-handlers/landmarks.js';
 import { handleGetMap } from './mcp-handlers/map.js';
 import { handleFindPath } from './mcp-handlers/pathfind.js';
@@ -277,6 +278,9 @@ export async function dispatchTool(
   } else if (name === 'detect_changes') {
     const { directory, base } = args as { directory: string; base?: string };
     return handleDetectChanges(directory, base);
+  } else if (name === 'get_health_map') {
+    const { directory, limit } = args as { directory: string; limit?: number };
+    return handleGetHealthMap({ directory, limit });
   } else if (name === 'record_decision') {
     const { directory, title, rationale, consequences, affectedFiles, supersedes, scope } =
       args as { directory: string; title: string; rationale: string; consequences?: string; affectedFiles?: string[]; supersedes?: string; scope?: DecisionScope };

--- a/src/core/services/tool-dispatch.ts
+++ b/src/core/services/tool-dispatch.ts
@@ -24,6 +24,7 @@ import { handleFindDeadCode } from './mcp-handlers/reachability.js';
 import { handleStructuralDiff } from './mcp-handlers/structural-diff.js';
 import { handleGetChangeCoupling } from './mcp-handlers/change-coupling.js';
 import { handleGetHealthMap } from './mcp-handlers/health-map.js';
+import { handleGetSurprisingConnections } from './mcp-handlers/surprising-connections.js';
 import { handleGetLandmarks } from './mcp-handlers/landmarks.js';
 import { handleGetMap } from './mcp-handlers/map.js';
 import { handleFindPath } from './mcp-handlers/pathfind.js';
@@ -281,6 +282,9 @@ export async function dispatchTool(
   } else if (name === 'get_health_map') {
     const { directory, limit } = args as { directory: string; limit?: number };
     return handleGetHealthMap({ directory, limit });
+  } else if (name === 'get_surprising_connections') {
+    const { directory, limit } = args as { directory: string; limit?: number };
+    return handleGetSurprisingConnections({ directory, limit });
   } else if (name === 'record_decision') {
     const { directory, title, rationale, consequences, affectedFiles, supersedes, scope } =
       args as { directory: string; title: string; rationale: string; consequences?: string; affectedFiles?: string[]; supersedes?: string; scope?: DecisionScope };

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -464,6 +464,20 @@ const NAV_TOOLS: NavToolSpec[] = [
     guideline: 'Use openlore_get_function_skeleton to read a file cheaply before opening it.',
     parameters: Type.Object({ filePath: Type.String() }),
   },
+  {
+    name: 'get_health_map',
+    label: 'openlore get_health_map',
+    description: 'Structural health dashboard: hubs, god functions, bridge nodes, untested hotspots, layer violations — ranked by severity. Start here before a refactor.',
+    guideline: 'Use openlore_get_health_map before any refactor to identify riskiest areas.',
+    parameters: Type.Object({ limit: Type.Optional(Type.Number()) }),
+  },
+  {
+    name: 'get_surprising_connections',
+    label: 'openlore get_surprising_connections',
+    description: 'Find unexpected coupling: cross-community edges, peripheral-to-hub calls, cross-test-boundary dependencies — scored by surprise.',
+    guideline: 'Use openlore_get_surprising_connections to spot accidental dependencies before a PR.',
+    parameters: Type.Object({ limit: Type.Optional(Type.Number()) }),
+  },
 ];
 
 function toolResult(text: string, details: unknown = null): AgentToolResult<unknown> {


### PR DESCRIPTION
## Summary

- Fix `detect_changes` always returning zero `changedFunctions` — git diff paths were joined with `absDir` creating absolute paths that never matched call-graph nodes
- Add `get_health_map` tool: structural health dashboard (hubs, god functions, layer violations, volatile files, severity-ranked `topRisks`)
- Add `testCoverage` field and `testGaps` array to `detect_changes` output
- Extend `get_health_map` with bridge nodes (sampled betweenness centrality) and untested hotspots
- Add new `get_surprising_connections` tool: cross-community coupling scored by surprise, grouped by target
- Register both tools in Pi NAV_TOOLS

## Bug fix — `fix(detect-changes)`

`git diff` produces repo-root-relative paths (e.g. `src/foo.ts`) but the handler was joining them with `absDir`, producing absolute paths that never matched call-graph nodes. Fix: keep diff paths relative throughout; add `relPath()` normalizer for legacy absolute-path nodes.

## feat(detect-changes) — testCoverage + testGaps

**`testCoverage`** per changed function — filterable enum: `'none' | 'import-only' | 'direct'`

**`testGaps`** top-level array — changed functions with `testCoverage='none'`, sorted by `riskScore`.

## get_health_map — bridge nodes + untested hotspots

Two new signals in `summary`, `hotspots`, and `topRisks`:

**Bridge nodes** — sampled Brandes' BFS (max 300 sources) on the call graph. Finds chokepoints that fan-in/fan-out misses: a node with fanIn=2 can still be on 89% of shortest paths.

**Untested hotspots** — high-degree nodes (fanIn + fanOut ≥ 10) not reachable within 1 hop from any test. 1-hop transitive reduces false positives vs direct-call-only.

Summary now exposes `betweennessApprox` + `betweennessSourceCount` so agents know precision.

```json
{
  "summary": {
    "bridgeCount": 3,
    "untestedHotspotCount": 3,
    "betweennessApprox": true,
    "betweennessSourceCount": 353
  },
  "hotspots": {
    "bridges": [{ "name": "buildProjectedIac", "betweenness": 1.0, "fanIn": 1, "fanOut": 2 }],
    "untestedHotspots": [{ "name": "handleOrient", "degree": 76 }]
  }
}
```

## get_surprising_connections (new tool)

Scores edges by composite surprise: cross-community (+0.3), peripheral-to-hub (+0.2, skipped for global utilities with fanIn ≥ 20), cross-test-boundary (+0.15).

**Grouped by target** — `callerCount` shows how many distinct modules reach the same surprising dependency. One finding per hub, not one per caller.

```json
{
  "connections": [
    {
      "to": "estimateTokens", "toFile": "src/core/services/llm-service.ts",
      "callerCount": 3, "score": 0.5,
      "reasons": ["cross-community", "peripheral-to-hub"],
      "callers": [{ "from": "applyTokenBudget", "fromFile": "…/progressive.ts" }, …]
    }
  ]
}
```

## Test plan

- [x] `npx vitest run src/core/services/mcp-handlers/health-map.test.ts` → 25/25 pass
- [x] `npx vitest run src/pi/extension.test.ts` → 12/12 pass
- [x] `npx tsc --noEmit` → no errors
- [x] Both tools called live on openlore repo — bridge nodes, grouped surprising connections, betweennessApprox confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)