### PR TITLE
chore(homebrew): remove non-native prebuilds after install

### DIFF
--- a/packaging/homebrew/openlore.rb
+++ b/packaging/homebrew/openlore.rb
@@ -20,6 +20,11 @@ class Openlore < Formula
 
   def install
     system "npm", "install", *std_npm_args
+    os = OS.mac? ? "darwin" : "linux"
+    native_platform = "#{os}-#{Hardware::CPU.arm? ? "arm64" : "x64"}"
+    Dir["#{libexec}/lib/node_modules/openlore/node_modules/**/prebuilds/*/"].each do |dir|
+      rm_r dir if File.basename(dir) != native_platform
+    end
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 


### PR DESCRIPTION
tree-sitter adds prebuild binaries for multiple cpu architectures which is not allowed under homebrew's single-architecture policy.

This pull request contains my naive fix which modifies the formula to remove all but native prebuilds in `openlore_installation_directory/lib/node_modules/openlore/**/prebuilds/`. Please let me know if any changes need to be made!