### PR TITLE
feat(memory): harden the memory-integrity invariant under concurrency + adversarial edits

### DIFF
--- a/openspec/specs/api/spec.md
+++ b/openspec/specs/api/spec.md
@@ -2977,3 +2977,17 @@ The API SHALL support `CLI Command openlore drift` to [partial spec — file too
 - **GIVEN** A git repository with a pre-commit hook installed
 - **WHEN** openlore drift --uninstall-hook is executed
 - **THEN** The pre-commit hook is removed
+
+### Requirement: DecisionApiWritesUseAtomicCompareAndSwap
+
+The decision-writing API functions (`openloreRecordDecision`, `openloreConsolidateDecisions`,
+`openloreSyncDecisions`) SHALL persist through the shared atomic compare-and-swap store path
+(`updateDecisionStore`), so a write committed concurrently by another path (e.g. the MCP
+`record_decision` handler or a background consolidation) is never silently clobbered.
+`openloreRecordDecision` SHALL derive the decision id from the committed store's `sessionId`
+so repeated records within a session deduplicate correctly.
+
+#### Scenario: Concurrent API record and MCP record lose no decision
+- **GIVEN** an `openloreRecordDecision` call and a concurrent `record_decision` against the same store
+- **WHEN** both complete
+- **THEN** the persisted store contains both decisions — neither write is lost

--- a/openspec/specs/architecture/spec.md
+++ b/openspec/specs/architecture/spec.md
@@ -38,6 +38,44 @@ The system SHALL implement security via: API key-based authentication for LLM pr
 - **WHEN** accessing protected resources
 - **THEN** access is denied
 
+### Requirement: DurableAtomicStorePersistence
+
+The persisted memory and decision stores (`.openlore/memory/notes.json`,
+`.openlore/decisions/pending.json`) SHALL be written atomically: a write goes to a temporary
+file and is moved into place with an atomic rename (after `fsync`), so a crash or
+interruption mid-write leaves the previously committed store intact and never a partially
+written (torn) file. Each store SHALL carry a monotonic `sequence` field used to order writes
+and detect conflicts; the field defaults to `0` for legacy stores. Saves use compare-and-swap
+on `sequence`: on a conflict the save re-reads the current store and re-applies the pending
+append/upsert rather than overwriting a competing write. Implemented in
+`src/core/decisions/atomic-store.ts`; guarded by `atomic-store.test.ts`.
+
+#### Scenario: A crash mid-write preserves the prior store
+- **GIVEN** a store write interrupted between writing the temporary file and the rename
+- **WHEN** the store is next loaded
+- **THEN** the previously committed store is returned intact, with no torn or partial content
+
+#### Scenario: Save uses compare-and-swap on sequence
+- **GIVEN** a store loaded at sequence S
+- **WHEN** a save is attempted but the on-disk sequence is no longer S
+- **THEN** the save re-reads the current store, re-applies the pending change, and writes at
+  the new sequence instead of overwriting
+
+### Requirement: CorruptStoreQuarantineNotSilentEmpty
+
+When a persisted store fails validation on load, the system SHALL move the unreadable file
+aside to a quarantine path (`*.corrupt-<n>`) and emit a recoverable signal. The system SHALL
+NOT silently substitute an empty store for a corrupt one, because silently losing persisted
+memory presents absence as current fact and violates the authoritative-recall invariant. The
+quarantine suffix SHALL be derived from on-disk state (the next free index), not wall-clock
+time, to keep recovery reproducible.
+
+#### Scenario: A malformed store is quarantined, not silently emptied
+- **GIVEN** a store file that fails schema or JSON validation
+- **WHEN** the store is loaded
+- **THEN** the file is moved to `*.corrupt-<n>` and a recoverable signal is emitted, rather
+  than an empty store being returned silently
+
 ## System Diagram
 
 ```mermaid

--- a/openspec/specs/architecture/spec.md
+++ b/openspec/specs/architecture/spec.md
@@ -41,14 +41,21 @@ The system SHALL implement security via: API key-based authentication for LLM pr
 ### Requirement: DurableAtomicStorePersistence
 
 The persisted memory and decision stores (`.openlore/memory/notes.json`,
-`.openlore/decisions/pending.json`) SHALL be written atomically: a write goes to a temporary
-file and is moved into place with an atomic rename (after `fsync`), so a crash or
-interruption mid-write leaves the previously committed store intact and never a partially
-written (torn) file. Each store SHALL carry a monotonic `sequence` field used to order writes
-and detect conflicts; the field defaults to `0` for legacy stores. Saves use compare-and-swap
-on `sequence`: on a conflict the save re-reads the current store and re-applies the pending
-append/upsert rather than overwriting a competing write. Implemented in
-`src/core/decisions/atomic-store.ts`; guarded by `atomic-store.test.ts`.
+`.openlore/decisions/pending.json`) SHALL be written atomically: a write goes to a
+uniquely-named temporary file, is `fsync`'d, and is moved into place with an atomic rename,
+after which the containing directory is `fsync`'d (best-effort) so the rename itself is
+durable. A crash or interruption mid-write leaves the previously committed store intact and
+never a partially written (torn) file. Each store SHALL carry a monotonic `sequence` field
+(defaults to `0` for legacy stores) that orders writes and lets external readers detect
+change. The read-modify-write SHALL be performed entirely inside a single per-store advisory
+lock so that the lock — not an optimistic sequence guard — is the serialization point:
+`mutate` always runs against the freshest on-disk store and a competing write cannot
+interleave. The advisory lock SHALL be released only by the writer that acquired it, and a
+crashed holder's lock SHALL become stealable well before a waiter gives up. ALL writers of a
+given store (record, approve/reject, consolidation, sync, and HTTP-API equivalents) SHALL go
+through this single compare-and-swap path; a raw lock-free overwrite is prohibited because it
+would defeat the serialization. Implemented in `src/core/decisions/atomic-store.ts`; guarded
+by `atomic-store.test.ts`.
 
 #### Scenario: A crash mid-write preserves the prior store
 - **GIVEN** a store write interrupted between writing the temporary file and the rename

--- a/openspec/specs/architecture/spec.md
+++ b/openspec/specs/architecture/spec.md
@@ -50,12 +50,14 @@ never a partially written (torn) file. Each store SHALL carry a monotonic `seque
 change. The read-modify-write SHALL be performed entirely inside a single per-store advisory
 lock so that the lock — not an optimistic sequence guard — is the serialization point:
 `mutate` always runs against the freshest on-disk store and a competing write cannot
-interleave. The advisory lock SHALL be released only by the writer that acquired it, and a
-crashed holder's lock SHALL become stealable well before a waiter gives up. ALL writers of a
-given store (record, approve/reject, consolidation, sync, and HTTP-API equivalents) SHALL go
-through this single compare-and-swap path; a raw lock-free overwrite is prohibited because it
-would defeat the serialization. Implemented in `src/core/decisions/atomic-store.ts`; guarded
-by `atomic-store.test.ts`.
+interleave. The advisory lock SHALL carry an ownership token and be released only by the
+writer that still owns it (so a hold stolen as stale is never freed out from under its new
+owner); a crashed holder's lock SHALL become stealable well before a waiter gives up, and a
+wait that times out SHALL fail loud rather than write unlocked. ALL writers of a given store
+(record, approve/reject, consolidation, sync, and HTTP-API equivalents) SHALL go through this
+single compare-and-swap path; a raw lock-free overwrite is prohibited because it would defeat
+the serialization. Implemented in `src/core/decisions/atomic-store.ts`; guarded by
+`atomic-store.test.ts`.
 
 #### Scenario: A crash mid-write preserves the prior store
 - **GIVEN** a store write interrupted between writing the temporary file and the rename
@@ -75,7 +77,9 @@ aside to a quarantine path (`*.corrupt-<n>`) and emit a recoverable signal. The 
 NOT silently substitute an empty store for a corrupt one, because silently losing persisted
 memory presents absence as current fact and violates the authoritative-recall invariant. The
 quarantine suffix SHALL be derived from on-disk state (the next free index), not wall-clock
-time, to keep recovery reproducible.
+time, to keep recovery reproducible. The claim on a quarantine path SHALL be atomic (it fails
+if the path already exists), so two concurrent loaders can never overwrite each other's
+quarantine file and lose preserved bytes.
 
 #### Scenario: A malformed store is quarantined, not silently emptied
 - **GIVEN** a store file that fails schema or JSON validation

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -286,6 +286,49 @@ The system SHALL serialize concurrent decision consolidation processes using a c
 
 > Decision recorded: 412817d2
 > Date: 2026-06-01
+
+### Requirement: GateReasonMachineIsAPureTotalClassifier
+
+The pre-commit gate's block-reason decision SHALL be computed by a pure, total
+classifier (`classifyGateState`, `src/core/decisions/gate-state.ts`) that maps the
+decision-store state (approved / verified / draft counts, consolidation recency,
+active count, git-repo + staged-source flags) to exactly one outcome: pass, or
+block with one of the canonical reasons (`verified`, `approved_not_synced`,
+`drafts_pending_consolidation`, `no_decisions_recorded`). The CLI gate command
+SHALL delegate the reason decision to this classifier and only build the
+user-facing payload around it. The classifier SHALL be **total** (every state maps
+to exactly one outcome), **deterministic / idempotent** (same state ⇒ same
+outcome), and **deadlock-free** (a blocking outcome always carries an actionable
+reason; a passing outcome never carries one), enforced by property tests
+(`gate-state.test.ts`).
+
+#### Scenario: Every gate state yields exactly one outcome
+
+- **GIVEN** any combination of decision-store counts, consolidation recency, and
+  git staged-source state
+- **WHEN** the gate reason is classified
+- **THEN** the result is either a clean pass or a block with exactly one canonical
+  reason — never blocked-without-reason and never passing-with-reason
+
+### Requirement: AllDecisionStoreWritersUseAtomicCompareAndSwap
+
+Every writer of the decision store (`pending.json`) — `record_decision`,
+`approve`/`reject`, consolidation, sync, and the HTTP API equivalents — SHALL
+persist through the single atomic compare-and-swap path
+(`updateDecisionStore` / `casUpdate`), so a write committed by one path is never
+silently clobbered by a stale snapshot from another. A raw, lock-free overwrite of
+the store by any production writer is prohibited.
+
+#### Scenario: Rapid record_decision under background consolidation loses no draft
+
+- **GIVEN** several `record_decision` calls in quick succession, each spawning a
+  background consolidation that also writes the store
+- **WHEN** all writes complete
+- **THEN** the persisted store contains every recorded decision — no write is lost
+  to a competing path on a different lock
+
+> Decision recorded: 412817d2
+> Date: 2026-06-01
 ### Requirement: AddSelecttestsMcpToolForCallgraphbasedTestImpactSelection
 
 The system SHALL expose a select_tests MCP tool that walks the call graph backward from changed symbols or a git diff ref to identify transitively reachable test files, returning reaching paths and confidence metadata.

--- a/openspec/specs/mcp-handlers/spec.md
+++ b/openspec/specs/mcp-handlers/spec.md
@@ -116,6 +116,72 @@ The system SHALL The recall tool SHALL partition returned memories into authorit
 
 > Decision recorded: dbe6a95e
 > Date: 2026-06-16
+
+### Requirement: AuthoritativeRecallInvariant
+
+The system SHALL guarantee, as a single named and test-enforced invariant, that **no
+memory whose freshness verdict is `drifted` or `orphaned` ever appears in an authoritative
+recall path unlabeled**. The authoritative recall paths are the `recall` tool and the
+memory (decision) section of `orient`. An `orphaned` memory SHALL be fully withheld from
+the authoritative set (surfaced only under `needsReanchoring` / `staleDecisions`); a
+`drifted` memory MAY remain in the authoritative set only when it carries an explicit
+`verify` label. This invariant is the operational definition of the project promise:
+*OpenLore never serves an unverified or stale fact as authoritative.* It SHALL be enforced
+by a property-based test (`memory-invariant.test.ts`) that generates arbitrary memories and
+arbitrary code mutations and asserts the property holds for every generated case.
+
+#### Scenario: A drifted memory is excluded from the authoritative set unlabeled
+
+- **GIVEN** a memory whose anchor verdict is `drifted`
+- **WHEN** `recall` or `orient` produces its response
+- **THEN** the memory does not appear in the authoritative set unlabeled; it is withheld or
+  carries an explicit verify/non-authoritative label
+
+#### Scenario: The invariant holds under generated mutation
+
+- **GIVEN** an arbitrary memory and an arbitrary mutation to the code it anchors
+- **WHEN** the authoritative recall path is computed
+- **THEN** the authoritative set contains only `fresh` memories and explicitly-labeled
+  `drifted` ones, never an `orphaned` memory
+
+### Requirement: FreshnessFailsSafeTowardDistrust
+
+The freshness computation (`anchorFreshness`, `hashSpan`) SHALL fail safe toward distrust:
+any ambiguity, hash collision, or boundary error SHALL bias the verdict toward `drifted` or
+`orphaned`, never toward a false `fresh`. A renamed, moved, or deleted symbol SHALL yield
+`orphaned` (or `drifted` only when a confident relocation is established). `hashSpan` SHALL
+slice spans by byte offset so multibyte UTF-8 boundaries hash correctly. A test that
+produces a false `fresh` SHALL be treated as a correctness failure; a false `orphaned` is
+acceptable. This is guarded by the adversarial suite (`anchor-adversarial.test.ts`).
+
+#### Scenario: A forced collision does not produce false fresh
+
+- **GIVEN** two distinct source spans
+- **WHEN** freshness is computed for a memory anchored to one after the other replaces it
+- **THEN** the verdict is `drifted` or `orphaned`, never `fresh` (distinct spans do not
+  collide on the truncated content hash; a collision would fail the suite loudly)
+
+#### Scenario: A multibyte span boundary hashes correctly
+
+- **GIVEN** an anchored span whose start or end falls on a multibyte UTF-8 boundary
+- **WHEN** `hashSpan` computes the content hash before and after an unrelated edit elsewhere
+- **THEN** the hash is byte-correct and stable, producing `fresh` only when the span bytes
+  are unchanged
+
+### Requirement: ConcurrentMemoryWriteSafety
+
+The `remember` and `record_decision` tools SHALL be safe under concurrent invocation: two
+concurrent writes to the same store SHALL NOT cause either write to be lost. On a write
+conflict the system SHALL re-read the current store and re-apply the pending
+append/upsert (compare-and-swap on a monotonic `sequence`), rather than overwrite the
+competing write.
+
+#### Scenario: Concurrent remember calls lose no write
+
+- **GIVEN** N concurrent `remember` calls against the same memory store
+- **WHEN** all calls complete
+- **THEN** the persisted store contains all N memories
+
 ### Requirement: DecisionsCarryStructuralAnchorsForSelfinvalidation
 
 The system SHALL resolve structural anchors against the call graph when recording a decision, falling back to file-level anchors when no analysis is available.

--- a/src/api/decisions.ts
+++ b/src/api/decisions.ts
@@ -20,7 +20,7 @@ import { createLLMService } from '../core/services/llm-service.js';
 import { isGitRepository, getChangedFiles, getFileDiff, getCommitMessages, resolveBaseRef, buildSpecMap } from '../core/drift/index.js';
 import {
   loadDecisionStore,
-  saveDecisionStore,
+  updateDecisionStore,
   upsertDecisions,
   patchDecision,
   makeDecisionId,
@@ -102,10 +102,15 @@ export async function openloreRecordDecision(options: RecordDecisionOptions): Pr
     syncedToSpecs: [],
   };
 
-  const updated = upsertDecisions(store, [decision]);
-  await saveDecisionStore(rootPath, updated);
+  // CAS upsert so concurrent writers never lose a draft; derive the id from the
+  // committed store's sessionId so repeated records in a session dedupe correctly.
+  let recordedId = id;
+  await updateDecisionStore(rootPath, (s) => {
+    recordedId = makeDecisionId(s.sessionId, domain, options.title);
+    return upsertDecisions(s, [{ ...decision, id: recordedId, sessionId: s.sessionId }]);
+  });
 
-  return { id };
+  return { id: recordedId };
 }
 
 // ============================================================================
@@ -182,12 +187,12 @@ export async function openloreConsolidateDecisions(
     : { verified: consolidated.map((d) => ({ ...d, status: 'verified' as const, confidence: 'medium' as const })), phantom: [], missing: [] };
   progress(onProgress, 'Verifying decisions', 'complete', `${verified.length} verified`);
 
-  let updatedStore = { ...store };
-  for (const id of supersededIds) {
-    updatedStore = patchDecision(updatedStore, id, { status: 'rejected' });
-  }
-  updatedStore = upsertDecisions(updatedStore, [...verified, ...phantom]);
-  await saveDecisionStore(rootPath, updatedStore);
+  // CAS persist onto the freshest store so a concurrently-recorded draft is kept.
+  const updatedStore = await updateDecisionStore(rootPath, (s) => {
+    let next = s;
+    for (const id of supersededIds) next = patchDecision(next, id, { status: 'rejected' });
+    return upsertDecisions(next, [...verified, ...phantom]);
+  });
 
   return { verified, phantom, missing, store: updatedStore };
 }

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -29,6 +29,7 @@ import {
   INACTIVE_STATUSES,
 } from '../../core/decisions/store.js';
 import { consolidateDrafts } from '../../core/decisions/consolidator.js';
+import { classifyGateState } from '../../core/decisions/gate-state.js';
 import { acquireDecisionsLock } from '../../core/decisions/lock.js';
 import { extractFromDiff } from '../../core/decisions/extractor.js';
 import { verifyDecisions } from '../../core/decisions/verifier.js';
@@ -769,9 +770,49 @@ Examples:
 
     // ── Gate only (no consolidation — consolidation happens on record_decision) ──
     if (options.gate && !options.consolidate) {
-      // Block if approved decisions haven't been synced to spec files yet.
       const approved = getDecisionsByStatus(store, 'approved');
-      if (approved.length > 0) {
+      const verified = getDecisionsByStatus(store, 'verified');
+      const drafts = getDecisionsByStatus(store, 'draft');
+      const missing: Array<{ file: string; description: string }> = [];
+
+      // Phantom decisions ("recorded but no code evidence") are excluded — stale
+      // phantoms from previous sessions would otherwise silently bypass the gate.
+      const activeCount = store.decisions.filter((d) => !INACTIVE_STATUSES.has(d.status)).length;
+      const consolidatedRecently = !!store.lastConsolidatedAt
+        && (Date.now() - new Date(store.lastConsolidatedAt).getTime()) < CONSOLIDATION_GRACE_PERIOD_MS;
+
+      // The staged-source check is the only input requiring git; resolve it lazily,
+      // only in the state where it can change the outcome (nothing else gates).
+      let isGitRepo = false;
+      let hasStagedSourceChanges = false;
+      if (approved.length === 0 && verified.length === 0 && drafts.length === 0
+          && !consolidatedRecently && activeCount === 0) {
+        isGitRepo = await isGitRepository(rootPath);
+        if (isGitRepo) {
+          try {
+            const { stdout } = await execFileAsync(
+              'git', ['diff', '--cached', '--name-only', '--diff-filter=ACDMR'],
+              { cwd: rootPath },
+            );
+            const stagedFiles = stdout.trim().split('\n').filter(Boolean);
+            const SOURCE_EXTS = /\.(ts|js|tsx|jsx|py|go|rs|rb|java|cpp|cc|swift)$/;
+            hasStagedSourceChanges = stagedFiles.some((f) => SOURCE_EXTS.test(f));
+          } catch { /* git unavailable — skip */ }
+        }
+      }
+
+      // The pure reason machine is the single arbiter of which reason applies.
+      const outcome = classifyGateState({
+        approvedCount: approved.length,
+        verifiedCount: verified.length,
+        draftCount: drafts.length,
+        consolidatedRecently,
+        activeCount,
+        isGitRepo,
+        hasStagedSourceChanges,
+      });
+
+      if (outcome.reason === GATE_REASONS.APPROVED_NOT_SYNCED) {
         const payload = {
           gated: true,
           reason: GATE_REASONS.APPROVED_NOT_SYNCED,
@@ -784,74 +825,48 @@ Examples:
         return;
       }
 
-      const verified = getDecisionsByStatus(store, 'verified');
-      const missing: Array<{ file: string; description: string }> = [];
+      if (outcome.reason === GATE_REASONS.DRAFTS_PENDING_CONSOLIDATION) {
+        // Drafts recorded but consolidation never completed.
+        // Output structured JSON so the agent can relay to the user and act on the answer.
+        const payload = {
+          gated: true,
+          reason: GATE_REASONS.DRAFTS_PENDING_CONSOLIDATION,
+          message: `${drafts.length} draft decision(s) were recorded but never consolidated.`,
+          drafts: drafts.map((d) => ({ id: d.id, title: d.title, recordedAt: d.recordedAt })),
+          actions: {
+            consolidate: 'openlore decisions --consolidate',
+            consolidateAndGate: 'openlore decisions --consolidate --gate',
+            skip: 'git commit --no-verify',
+          },
+        };
+        process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+        process.exitCode = 1;
+        return;
+      }
 
-      if (verified.length === 0) {
-        const drafts = getDecisionsByStatus(store, 'draft');
-        if (drafts.length > 0) {
-          // Drafts recorded but consolidation never completed.
-          // Output structured JSON so the agent can relay to the user and act on the answer.
-          const payload = {
-            gated: true,
-            reason: GATE_REASONS.DRAFTS_PENDING_CONSOLIDATION,
-            message: `${drafts.length} draft decision(s) were recorded but never consolidated.`,
-            drafts: drafts.map((d) => ({ id: d.id, title: d.title, recordedAt: d.recordedAt })),
-            actions: {
-              consolidate: 'openlore decisions --consolidate',
-              consolidateAndGate: 'openlore decisions --consolidate --gate',
-              skip: 'git commit --no-verify',
-            },
-          };
-          process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
-          process.exitCode = 1;
-          return;
-        }
+      if (outcome.reason === GATE_REASONS.NO_DECISIONS_RECORDED) {
+        // Source files staged but nothing recorded — output JSON for agent to relay.
+        const payload = {
+          gated: true,
+          reason: GATE_REASONS.NO_DECISIONS_RECORDED,
+          message: 'Source files are staged but no architectural decisions were recorded.',
+          actions: {
+            consolidateAndGate: 'openlore decisions --consolidate --gate',
+            skip: 'git commit --no-verify',
+          },
+        };
+        process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+        process.exitCode = 1;
+        return;
+      }
 
-        // If consolidation already ran recently, trust it found nothing — skip the warning.
-        const consolidatedRecently = store.lastConsolidatedAt
-          && (Date.now() - new Date(store.lastConsolidatedAt).getTime()) < CONSOLIDATION_GRACE_PERIOD_MS;
-        if (consolidatedRecently) {
-          process.exitCode = 0;
-          return;
-        }
-
-        // If source files are staged but nothing was recorded, offer to run the fallback extractor.
-        // Phantom decisions ("recorded but no code evidence") are excluded — stale phantoms from
-        // previous sessions would otherwise silently bypass the gate for all future commits.
-        const activeDecisions = store.decisions.filter(
-          (d) => !INACTIVE_STATUSES.has(d.status),
-        );
-        if (activeDecisions.length === 0 && await isGitRepository(rootPath)) {
-          try {
-            const { stdout } = await execFileAsync(
-              'git', ['diff', '--cached', '--name-only', '--diff-filter=ACDMR'],
-              { cwd: rootPath },
-            );
-            const stagedFiles = stdout.trim().split('\n').filter(Boolean);
-            const SOURCE_EXTS = /\.(ts|js|tsx|jsx|py|go|rs|rb|java|cpp|cc|swift)$/;
-            const hasSourceChanges = stagedFiles.some((f) => SOURCE_EXTS.test(f));
-            if (hasSourceChanges) {
-              // Source files staged but nothing recorded — output JSON for agent to relay.
-              const payload = {
-                gated: true,
-                reason: GATE_REASONS.NO_DECISIONS_RECORDED,
-                message: 'Source files are staged but no architectural decisions were recorded.',
-                actions: {
-                  consolidateAndGate: 'openlore decisions --consolidate --gate',
-                  skip: 'git commit --no-verify',
-                },
-              };
-              process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
-              process.exitCode = 1;
-              return;
-            }
-          } catch { /* git unavailable — skip */ }
-        }
+      if (!outcome.gated) {
+        // Clean commit — nothing to review.
         process.exitCode = 0;
         return;
       }
 
+      // outcome.reason === GATE_REASONS.VERIFIED — verified decisions await review.
       // TTY: interactive TUI
       if (process.stdin.isTTY && process.stdout.isTTY && verified.length > 0) {
         const results = await runTuiApproval(verified);

--- a/src/cli/commands/decisions.ts
+++ b/src/cli/commands/decisions.ts
@@ -22,7 +22,7 @@ import { createLLMService } from '../../core/services/llm-service.js';
 import { isGitRepository, getChangedFiles, getFileDiff, getCommitMessages, resolveBaseRef, buildSpecMap } from '../../core/drift/index.js';
 import {
   loadDecisionStore,
-  saveDecisionStore,
+  updateDecisionStore,
   replaceDecisions,
   patchDecision,
   getDecisionsByStatus,
@@ -488,12 +488,13 @@ Examples:
         process.exitCode = 1;
         return;
       }
-      const updated = patchDecision(store, id, {
-        status: 'approved',
+      const approvePatch = {
+        status: 'approved' as const,
         reviewedAt: new Date().toISOString(),
         reviewNote: options.note ?? options.reason,
-      });
-      await saveDecisionStore(rootPath, updated);
+      };
+      // CAS so the write can't clobber a concurrent record/consolidate write.
+      const updated = await updateDecisionStore(rootPath, (s) => patchDecision(s, id, approvePatch));
       emit(rootPath, 'decisions', { event: 'decision_approved', id, title: decision.title, transport: 'cli' });
       logger.success(`Decision ${id} approved.`);
       if (!options.json) displayDecision({ ...decision, status: 'approved' }, true);
@@ -530,12 +531,11 @@ Examples:
         process.exitCode = 1;
         return;
       }
-      const updated = patchDecision(store, id, {
+      await updateDecisionStore(rootPath, (s) => patchDecision(s, id, {
         status: 'rejected',
         reviewedAt: new Date().toISOString(),
         reviewNote: options.note ?? options.reason,
-      });
-      await saveDecisionStore(rootPath, updated);
+      }));
       emit(rootPath, 'decisions', { event: 'decision_rejected', id, title: decision.title, transport: 'cli' });
       logger.success(`Decision ${id} rejected.`);
 
@@ -635,14 +635,10 @@ Examples:
         : { verified: consolidated.map((d) => ({ ...d, status: 'verified' as const, confidence: 'medium' as const })), phantom: [], missing: [] };
 
       // Step 4 — Persist
-      let updatedStore = { ...store };
       // Reject all original drafts — they've been replaced by consolidated decisions.
       // Also reject any explicitly superseded IDs from prior sessions.
       const originalDraftIds = new Set(drafts.map((d) => d.id));
       const originalById = new Map(store.decisions.map((d) => [d.id, d]));
-      for (const id of [...originalDraftIds, ...supersededIds]) {
-        updatedStore = patchDecision(updatedStore, id, { status: 'rejected' });
-      }
       // Preserve recordedAt provenance:
       // - Direct match: consolidated decision ID matches original draft → use its recordedAt.
       // - Merged decision (new ID, no match): use earliest recordedAt across all superseded
@@ -658,11 +654,18 @@ Examples:
         if (earliestSupersededAt) return { ...d, recordedAt: earliestSupersededAt };
         return d;
       });
-      // replaceDecisions (not upsertDecisions) — consolidated decisions share IDs
-      // with their original drafts; upsert would silently no-op after the reject above.
-      updatedStore = replaceDecisions(updatedStore, withProvenance);
-      updatedStore = { ...updatedStore, lastConsolidatedAt: new Date().toISOString() };
-      await saveDecisionStore(rootPath, updatedStore);
+      // CAS persist: apply the consolidation result to the FRESHEST store, so a
+      // record_decision/approve committed concurrently (different lock) is preserved
+      // rather than clobbered by this stale snapshot. replaceDecisions (not upsert)
+      // because consolidated decisions share IDs with their original drafts.
+      const updatedStore = await updateDecisionStore(rootPath, (s) => {
+        let next = s;
+        for (const id of [...originalDraftIds, ...supersededIds]) {
+          next = patchDecision(next, id, { status: 'rejected' });
+        }
+        next = replaceDecisions(next, withProvenance);
+        return { ...next, lastConsolidatedAt: new Date().toISOString() };
+      });
 
       if (options.json) {
         process.stdout.write(JSON.stringify({ verified, phantom, missing }, null, 2) + '\n');
@@ -674,18 +677,17 @@ Examples:
       if (options.gate && process.stdin.isTTY && process.stdout.isTTY && verified.length > 0) {
         const results = await runTuiApproval(verified);
 
-        let gateStore = updatedStore;
+        const reviewedAt = new Date().toISOString();
+        const tuiPatches: Array<{ id: string; status: 'approved' | 'rejected' }> = [];
         for (const [id, decision] of results) {
           if (decision === 'approved' || decision === 'rejected') {
-            gateStore = patchDecision(gateStore, id, {
-              status: decision,
-              reviewedAt: new Date().toISOString(),
-            });
+            tuiPatches.push({ id, status: decision });
             const d = updatedStore.decisions.find((x) => x.id === id);
             emit(rootPath, 'decisions', { event: `decision_${decision}`, id, title: d?.title, transport: 'cli-tui' });
           }
         }
-        await saveDecisionStore(rootPath, gateStore);
+        await updateDecisionStore(rootPath, (s) =>
+          tuiPatches.reduce((acc, p) => patchDecision(acc, p.id, { status: p.status, reviewedAt }), s));
 
         const stillPending = verified.filter(
           (d) => !results.has(d.id) || results.get(d.id) === 'skipped',
@@ -870,16 +872,15 @@ Examples:
       // TTY: interactive TUI
       if (process.stdin.isTTY && process.stdout.isTTY && verified.length > 0) {
         const results = await runTuiApproval(verified);
-        let gateStore = store;
+        const reviewedAt = new Date().toISOString();
+        const tuiPatches: Array<{ id: string; status: 'approved' | 'rejected' }> = [];
         for (const [id, decision] of results) {
           if (decision === 'approved' || decision === 'rejected') {
-            gateStore = patchDecision(gateStore, id, {
-              status: decision,
-              reviewedAt: new Date().toISOString(),
-            });
+            tuiPatches.push({ id, status: decision });
           }
         }
-        await saveDecisionStore(rootPath, gateStore);
+        await updateDecisionStore(rootPath, (s) =>
+          tuiPatches.reduce((acc, p) => patchDecision(acc, p.id, { status: p.status, reviewedAt }), s));
         const stillPending = verified.filter(
           (d) => !results.has(d.id) || results.get(d.id) === 'skipped',
         );

--- a/src/core/decisions/anchor-adversarial.test.ts
+++ b/src/core/decisions/anchor-adversarial.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Adversarial freshness suite (change: harden-memory-integrity-invariant).
+ *
+ * Guards the mcp-handlers-spec requirement FreshnessFailsSafeTowardDistrust. The
+ * danger of a content-addressed memory system is the *false-fresh*: a memory
+ * served as grounded after the code beneath it changed. This suite fuzzes the
+ * address derivation (`hashSpan`) and the verdict engine (`anchorFreshness`) with
+ * the edits that actually break anchoring in the field — rename / move / delete,
+ * whitespace- and comment-only edits, multibyte UTF-8 span boundaries, and a
+ * truncated-hash collision attempt.
+ *
+ * Governing assertion across the whole file: **a false-`fresh` is a correctness
+ * failure; a false-`orphaned`/`drifted` is acceptable.** Fail safe toward distrust.
+ *
+ * Plain .test.ts so CI runs it.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  hashSpan,
+  anchorFreshness,
+  type GraphFreshnessView,
+} from './anchor.js';
+import { makeFreshnessView } from './anchor-adapter.js';
+import { EdgeStore } from '../services/edge-store.js';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR } from '../../constants.js';
+import type { StructuralAnchor } from '../../types/index.js';
+import type { FunctionNode } from '../analyzer/call-graph.js';
+
+// ── deterministic PRNG (no new dependency; replayable across runs) ────────────
+// mulberry32: a tiny seeded generator so the property cases are reproducible.
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const CHARSET =
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 \t\n(){}[];=+-*/"\'.café日本語🚀—';
+const CHARS = [...CHARSET]; // code-point split so multibyte chars stay intact
+
+function randomSpan(rand: () => number, minLen = 1, maxLen = 80): string {
+  const len = minLen + Math.floor(rand() * (maxLen - minLen + 1));
+  let s = '';
+  for (let i = 0; i < len; i++) s += CHARS[Math.floor(rand() * CHARS.length)];
+  return s;
+}
+
+// ── pure-engine view helpers ──────────────────────────────────────────────────
+function viewFrom(opts: {
+  nodes?: Record<string, string>;
+  files?: Record<string, string | null>;
+  renames?: Record<string, string>;
+  stableIds?: Record<string, { nodeId: string; contentHash: string }>;
+}): GraphFreshnessView {
+  return {
+    nodeHash: (id) => opts.nodes?.[id],
+    fileExists: (f) => opts.files !== undefined && f in opts.files,
+    fileHash: (f) => opts.files?.[f] ?? undefined,
+    renameOf: (id) => opts.renames?.[id],
+    resolveStableId: (sid) => opts.stableIds?.[sid],
+  };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1. Rename vs. move-across-file vs. delete — each must yield `orphaned`
+// ════════════════════════════════════════════════════════════════════════════
+describe('FreshnessFailsSafeTowardDistrust — rename / move / delete', () => {
+  const anchor: StructuralAnchor = {
+    nodeId: 'a.ts::foo',
+    stableId: 'sid:foo()',
+    symbolName: 'foo',
+    filePath: 'a.ts',
+    contentHash: 'h1',
+  };
+
+  it('a deleted symbol (no relocation evidence) is orphaned, never fresh', () => {
+    // Symbol id gone, no stable-id survivor, no rename map.
+    const v = anchorFreshness(anchor, viewFrom({ nodes: {}, files: { 'a.ts': 'fh' } }));
+    expect(v.freshness).toBe('orphaned');
+  });
+
+  it('a renamed symbol (new name, no surviving stable id) is orphaned, never fresh', () => {
+    // The old id no longer resolves and the stable id (name+shape) no longer
+    // matches any node because the name changed — orphaned, not a false fresh.
+    const v = anchorFreshness(anchor, viewFrom({ nodes: {}, stableIds: {}, files: { 'a.ts': 'fh' } }));
+    expect(v.freshness).toBe('orphaned');
+  });
+
+  it('a symbol moved across files but changed is drifted, never fresh', () => {
+    // stable id resolves to the relocated node, but its span hash differs.
+    const v = anchorFreshness(
+      anchor,
+      viewFrom({ nodes: {}, stableIds: { 'sid:foo()': { nodeId: 'b.ts::foo', contentHash: 'DIFFERENT' } } }),
+    );
+    expect(v.freshness).toBe('drifted');
+    expect(v.freshness).not.toBe('fresh');
+  });
+
+  it('a symbol moved across files and unchanged is fresh (the only fresh path) — relocation is explicit', () => {
+    const v = anchorFreshness(
+      anchor,
+      viewFrom({ nodes: {}, stableIds: { 'sid:foo()': { nodeId: 'b.ts::foo', contentHash: 'h1' } } }),
+    );
+    expect(v.freshness).toBe('fresh');
+    expect(v.relocatedTo).toBe('b.ts::foo'); // never silently — the move is reported
+  });
+
+  it('an ambiguous stable id (homonym collision) resolves to nothing → orphaned, never a guessed fresh', () => {
+    // The adapter returns undefined when more than one node carries the stable id
+    // (unique-only resolution). Model that as a missing resolution → orphaned.
+    const v = anchorFreshness(anchor, viewFrom({ nodes: {}, stableIds: {} }));
+    expect(v.freshness).toBe('orphaned');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2. Whitespace-only and comment-only edits inside an anchored span
+//    Documented verdict: DRIFTED. hashSpan is over raw, unnormalized bytes, so
+//    any edit inside the span — even a reformat or a comment — is a real change.
+//    This is intentional: fail safe toward distrust rather than guess that a
+//    reformat "doesn't count."
+// ════════════════════════════════════════════════════════════════════════════
+describe('FreshnessFailsSafeTowardDistrust — whitespace / comment-only edits drift', () => {
+  it('whitespace-only reformat changes the span hash (→ drifted, not fresh)', () => {
+    const before = 'function f(){return 1}';
+    const after = 'function f() {\n  return 1;\n}';
+    expect(hashSpan(after)).not.toBe(hashSpan(before));
+  });
+
+  it('comment-only insertion changes the span hash (→ drifted, not fresh)', () => {
+    const before = 'function f() { return 1; }';
+    const after = 'function f() { /* note */ return 1; }';
+    expect(hashSpan(after)).not.toBe(hashSpan(before));
+  });
+
+  it('a span with a whitespace-only edit reads drifted through the engine, never fresh', () => {
+    const anchor: StructuralAnchor = { nodeId: 'a.ts::f', filePath: 'a.ts', contentHash: hashSpan('function f(){return 1}') };
+    const v = anchorFreshness(anchor, viewFrom({ nodes: { 'a.ts::f': hashSpan('function f() { return 1 }') } }));
+    expect(v.freshness).toBe('drifted');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3. Multibyte / UTF-8 span boundaries — byte-correct slicing end to end
+// ════════════════════════════════════════════════════════════════════════════
+describe('FreshnessFailsSafeTowardDistrust — multibyte span boundaries', () => {
+  let root: string;
+  const ANALYSIS = () => join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+
+  // Source whose function body contains multibyte chars so the span's end byte
+  // offset lands after a multibyte sequence, not inside an ASCII run.
+  const SRC = 'const banner = "préface 日本語 🚀";\nexport function foo() {\n  return "café";\n}\n';
+
+  function fooNode(): FunctionNode {
+    const start = Buffer.byteLength('const banner = "préface 日本語 🚀";\n', 'utf-8');
+    const end = Buffer.byteLength(SRC, 'utf-8') - 1; // through the function, drop trailing newline
+    return { id: 'src/foo.ts::foo', name: 'foo', filePath: 'src/foo.ts', isAsync: false, language: 'typescript', startIndex: start, endIndex: end, fanIn: 0, fanOut: 0 };
+  }
+
+  async function buildStore(): Promise<void> {
+    await mkdir(ANALYSIS(), { recursive: true });
+    const store = EdgeStore.open(EdgeStore.dbPath(ANALYSIS()));
+    store.clearAll();
+    store.insertNodes([fooNode()]);
+    store.close();
+  }
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'openlore-mb-'));
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src', 'foo.ts'), SRC, 'utf-8');
+    await buildStore();
+  });
+  afterEach(async () => { await rm(root, { recursive: true, force: true }); });
+
+  function spanHashOfCurrent(): string {
+    const buf = Buffer.from(SRC, 'utf-8');
+    const n = fooNode();
+    return hashSpan(buf.subarray(n.startIndex, n.endIndex).toString('utf-8'));
+  }
+
+  it('the freshness view hashes a multibyte-bounded span byte-correctly (fresh only when bytes unchanged)', () => {
+    const store = EdgeStore.open(EdgeStore.dbPath(ANALYSIS()));
+    try {
+      const view = makeFreshnessView(store, root);
+      const anchor: StructuralAnchor = { nodeId: 'src/foo.ts::foo', filePath: 'src/foo.ts', contentHash: spanHashOfCurrent() };
+      // Unchanged bytes → fresh, proving the byte-offset slice reconstructs the
+      // exact same span across a multibyte boundary (no off-by-one corruption).
+      expect(anchorFreshness(anchor, view).freshness).toBe('fresh');
+    } finally {
+      store.close();
+    }
+  });
+
+  it('changing a multibyte char inside the span drifts (never a false fresh)', async () => {
+    const recorded = spanHashOfCurrent();
+    // Swap the in-body multibyte string for a different one of a different byte length.
+    await writeFile(join(root, 'src', 'foo.ts'), SRC.replace('café', 'thé'), 'utf-8');
+    const store = EdgeStore.open(EdgeStore.dbPath(ANALYSIS()));
+    try {
+      const view = makeFreshnessView(store, root);
+      const anchor: StructuralAnchor = { nodeId: 'src/foo.ts::foo', filePath: 'src/foo.ts', contentHash: recorded };
+      expect(anchorFreshness(anchor, view).freshness).toBe('drifted');
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 4. Truncated 16-char hash — collision behavior must never produce false fresh
+// ════════════════════════════════════════════════════════════════════════════
+describe('FreshnessFailsSafeTowardDistrust — truncated hash & collision', () => {
+  it('hashSpan emits exactly 16 hex chars (the truncation the engine compares)', () => {
+    for (const s of ['', 'x', 'function f(){}', 'café 日本語 🚀']) {
+      expect(hashSpan(s)).toMatch(/^[0-9a-f]{16}$/);
+    }
+  });
+
+  it('a single-byte change flips the hash → drifted, never fresh (exact-equality only)', () => {
+    const rand = rng(0xC0FFEE);
+    for (let i = 0; i < 2000; i++) {
+      const span = randomSpan(rand, 4, 60);
+      const idx = Math.floor(rand() * span.length);
+      const mutated = span.slice(0, idx) + (span[idx] === 'z' ? 'y' : 'z') + span.slice(idx + 1);
+      if (mutated === span) continue;
+      // Anchor recorded against `span`; current code is `mutated`.
+      const anchor: StructuralAnchor = { nodeId: 'n', filePath: 'f', contentHash: hashSpan(span) };
+      const v = anchorFreshness(anchor, viewFrom({ nodes: { n: hashSpan(mutated) } }));
+      // The ONLY way this is `fresh` is a truncated-hash collision. Treated as a
+      // correctness failure if it ever happens.
+      expect(v.freshness, `false-fresh on mutation of ${JSON.stringify(span)}`).not.toBe('fresh');
+    }
+  });
+
+  it('PROPERTY: distinct generated spans never collide on the truncated 16-char hash', () => {
+    // This is the collision guard the verdict's trust rests on: the engine reads
+    // `fresh` iff the truncated hashes are equal, so if two distinct spans ever
+    // truncate-collide a false-fresh becomes reachable. Across a large corpus we
+    // assert that does not happen — and the suite fails loudly if it ever does.
+    const rand = rng(0x5EED);
+    const seen = new Map<string, string>();
+    for (let i = 0; i < 20000; i++) {
+      const span = randomSpan(rand, 1, 100);
+      const h = hashSpan(span);
+      const prior = seen.get(h);
+      if (prior !== undefined && prior !== span) {
+        throw new Error(`truncated-hash collision: ${JSON.stringify(prior)} vs ${JSON.stringify(span)} → ${h}`);
+      }
+      seen.set(h, span);
+    }
+    expect(seen.size).toBeGreaterThan(0);
+  });
+
+  it('a forced collision (current hash forced equal to a changed span) is the documented trust boundary', () => {
+    // anchorFreshness delegates trust entirely to hashSpan equality. If a view
+    // were to report the recorded hash for genuinely-different content, the engine
+    // would read it as fresh — this is the boundary the collision-freedom property
+    // above guards. We assert the delegation is exact (no fuzzy/prefix match): a
+    // hash that differs in even its last nibble is NOT fresh.
+    const recorded = hashSpan('the original span');
+    const offByOneNibble = recorded.slice(0, -1) + (recorded.endsWith('0') ? '1' : '0');
+    const anchor: StructuralAnchor = { nodeId: 'n', filePath: 'f', contentHash: recorded };
+    expect(anchorFreshness(anchor, viewFrom({ nodes: { n: offByOneNibble } })).freshness).toBe('drifted');
+  });
+});

--- a/src/core/decisions/atomic-store.test.ts
+++ b/src/core/decisions/atomic-store.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Durability + concurrency guarantees for the JSON stores.
+ * (change: harden-memory-integrity-invariant)
+ *
+ * Guards architecture-spec requirements DurableAtomicStorePersistence and
+ * CorruptStoreQuarantineNotSilentEmpty, and the mcp-handlers requirement
+ * ConcurrentMemoryWriteSafety. Plain .test.ts so CI runs it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, readFile, readdir, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  atomicWriteFile,
+  casUpdate,
+  quarantineCorrupt,
+  type SequencedStore,
+} from './atomic-store.js';
+import {
+  loadMemoryStore,
+  saveMemoryStore,
+  updateMemoryStore,
+  memoryDir,
+} from './memory-store.js';
+import { loadDecisionStore, saveDecisionStore, decisionsDir } from './store.js';
+import { MEMORY_NOTES_FILE, DECISIONS_PENDING_FILE } from '../../constants.js';
+import type { AnchoredMemory, MemoryStore } from '../../types/index.js';
+
+vi.mock('../../utils/logger.js', () => ({
+  logger: { warning: vi.fn(), info: vi.fn(), error: vi.fn(), success: vi.fn(), section: vi.fn(), discovery: vi.fn(), analysis: vi.fn(), blank: vi.fn() },
+}));
+
+let root: string;
+beforeEach(async () => { root = await mkdtemp(join(tmpdir(), 'openlore-atomic-')); });
+afterEach(async () => { await rm(root, { recursive: true, force: true }); });
+
+function note(id: string): AnchoredMemory {
+  return { id, kind: 'note', content: `note ${id}`, anchors: [], recordedAt: '2026-01-01T00:00:00Z' };
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// atomicWriteFile — temp + fsync + rename
+// ════════════════════════════════════════════════════════════════════════════
+describe('atomicWriteFile', () => {
+  it('writes content and leaves no temp file behind', async () => {
+    const path = join(root, 'sub', 'data.json');
+    await atomicWriteFile(path, '{"ok":true}');
+    expect(JSON.parse(await readFile(path, 'utf-8'))).toEqual({ ok: true });
+    const entries = await readdir(join(root, 'sub'));
+    expect(entries.filter((e) => e.includes('.tmp'))).toHaveLength(0);
+  });
+
+  it('replaces existing content atomically (prior content fully overwritten)', async () => {
+    const path = join(root, 'data.json');
+    await atomicWriteFile(path, 'first');
+    await atomicWriteFile(path, 'second');
+    expect(await readFile(path, 'utf-8')).toBe('second');
+  });
+
+  it('a crash BETWEEN temp-write and rename preserves the prior committed file', async () => {
+    // atomicWriteFile writes a sibling temp file, then renames it into place. A
+    // crash before the rename leaves the temp file orphaned and the committed
+    // file untouched — never a torn in-place write. Reproduce that state: commit
+    // v1, then leave a torn temp file exactly where a crashed writer would.
+    const path = join(root, 'store.json');
+    await atomicWriteFile(path, JSON.stringify({ committed: true }));
+    const tornTemp = join(root, `.store.json.tmp-${process.pid}`);
+    await writeFile(tornTemp, '{ partial torn write that never renamed', 'utf-8');
+
+    // The committed file is intact (the crash never touched it in place).
+    expect(JSON.parse(await readFile(path, 'utf-8'))).toEqual({ committed: true });
+
+    // A subsequent successful write still produces clean committed content and
+    // overwrites/ignores the orphaned temp.
+    await atomicWriteFile(path, JSON.stringify({ committed: false }));
+    expect(JSON.parse(await readFile(path, 'utf-8'))).toEqual({ committed: false });
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// casUpdate — compare-and-swap, re-apply on conflict
+// ════════════════════════════════════════════════════════════════════════════
+describe('casUpdate', () => {
+  interface Store extends SequencedStore { items: string[] }
+  const path = () => join(root, 'cas.json');
+  const load = async (): Promise<Store> => {
+    try { return JSON.parse(await readFile(path(), 'utf-8')) as Store; }
+    catch { return { items: [], sequence: 0 }; }
+  };
+  const serialize = (s: Store) => JSON.stringify(s);
+
+  it('bumps sequence by exactly one per committed write', async () => {
+    const a = await casUpdate<Store>({ storePath: path(), load, serialize, mutate: (s) => ({ ...s, items: [...s.items, 'a'] }) });
+    expect(a.sequence).toBe(1);
+    const b = await casUpdate<Store>({ storePath: path(), load, serialize, mutate: (s) => ({ ...s, items: [...s.items, 'b'] }) });
+    expect(b.sequence).toBe(2);
+    expect(b.items).toEqual(['a', 'b']);
+  });
+
+  it('re-applies the mutate when the on-disk sequence changed mid-update (no lost write)', async () => {
+    // A competing writer has already committed {items:['other'], sequence:1} to disk.
+    await writeFile(path(), serialize({ items: ['other'], sequence: 1 }));
+    // Make the FIRST outer load return a stale (sequence 0) view so the commit
+    // re-read detects the conflict and forces exactly one re-apply.
+    let calls = 0;
+    const staleThenFresh = async (): Promise<Store> => {
+      calls++;
+      return calls === 1 ? { items: [], sequence: 0 } : load();
+    };
+    const result = await casUpdate<Store>({
+      storePath: path(),
+      load: staleThenFresh,
+      serialize,
+      mutate: (s) => ({ ...s, items: [...s.items, 'mine'] }),
+    });
+    // The competing 'other' write is NOT clobbered; 'mine' is re-applied on top.
+    expect(result.items).toEqual(['other', 'mine']);
+    expect(result.sequence).toBe(2);
+  });
+
+  it('N concurrent casUpdate calls lose zero writes', async () => {
+    const N = 25;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        casUpdate<Store>({ storePath: path(), load, serialize, mutate: (s) => ({ ...s, items: [...s.items, `w${i}`] }) }),
+      ),
+    );
+    const final = await load();
+    expect(final.items.sort()).toEqual(Array.from({ length: N }, (_, i) => `w${i}`).sort());
+    expect(final.sequence).toBe(N);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// quarantineCorrupt
+// ════════════════════════════════════════════════════════════════════════════
+describe('quarantineCorrupt', () => {
+  it('moves the file aside to a deterministic .corrupt-<n> path (no timestamp)', async () => {
+    const path = join(root, 'notes.json');
+    await writeFile(path, 'garbage', 'utf-8');
+    const dest = await quarantineCorrupt(path, 'test');
+    expect(dest).toBe(`${path}.corrupt-0`);
+    expect(await readFile(dest!, 'utf-8')).toBe('garbage');
+  });
+
+  it('uses the next free index when a prior quarantine exists', async () => {
+    const path = join(root, 'notes.json');
+    await writeFile(`${path}.corrupt-0`, 'old', 'utf-8');
+    await writeFile(path, 'garbage', 'utf-8');
+    const dest = await quarantineCorrupt(path, 'test');
+    expect(dest).toBe(`${path}.corrupt-1`);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// memory store end-to-end durability
+// ════════════════════════════════════════════════════════════════════════════
+describe('memory store — durability + concurrency end-to-end', () => {
+  it('legacy store without a sequence field loads as sequence 0 and saves at 1', async () => {
+    const dir = memoryDir(root);
+    await mkdir(dir, { recursive: true });
+    // Legacy shape: no `sequence` field.
+    await writeFile(join(dir, MEMORY_NOTES_FILE), JSON.stringify({ version: '1', updatedAt: '', memories: [note('a')] }), 'utf-8');
+    const loaded = await loadMemoryStore(root);
+    expect(loaded.sequence).toBe(0);
+    expect(loaded.memories).toHaveLength(1);
+    await saveMemoryStore(root, loaded);
+    expect((await loadMemoryStore(root)).sequence).toBe(1);
+  });
+
+  it('N concurrent remember-style updates persist all N memories', async () => {
+    const N = 20;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        updateMemoryStore(root, (s: MemoryStore) => ({
+          ...s,
+          memories: [...s.memories.filter((m) => m.id !== `m${i}`), note(`m${i}`)],
+        })),
+      ),
+    );
+    const final = await loadMemoryStore(root);
+    expect(final.memories.map((m) => m.id).sort()).toEqual(Array.from({ length: N }, (_, i) => `m${i}`).sort());
+  });
+
+  it('a corrupted notes store is quarantined, not silently emptied', async () => {
+    const dir = memoryDir(root);
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, MEMORY_NOTES_FILE);
+    await writeFile(path, '{ this is : not valid json', 'utf-8');
+    const loaded = await loadMemoryStore(root);
+    expect(loaded.memories).toHaveLength(0); // degrades to empty (no crash)
+    // ...but the corrupt bytes are preserved on disk, not dropped.
+    const entries = await readdir(dir);
+    expect(entries.some((e) => e.startsWith(`${MEMORY_NOTES_FILE}.corrupt-`))).toBe(true);
+  });
+
+  it('writes notes.json atomically (no lingering temp files)', async () => {
+    await updateMemoryStore(root, (s) => ({ ...s, memories: [note('x')] }));
+    const entries = await readdir(memoryDir(root));
+    expect(entries.filter((e) => e.includes('.tmp'))).toHaveLength(0);
+    expect(entries).toContain(MEMORY_NOTES_FILE);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// decision store quarantine + sequence
+// ════════════════════════════════════════════════════════════════════════════
+describe('decision store — quarantine + sequence', () => {
+  it('a corrupted pending.json is quarantined, not silently emptied', async () => {
+    const dir = decisionsDir(root);
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, DECISIONS_PENDING_FILE);
+    await writeFile(path, 'totally not json', 'utf-8');
+    const loaded = await loadDecisionStore(root);
+    expect(loaded.decisions).toHaveLength(0);
+    const entries = await readdir(dir);
+    expect(entries.some((e) => e.startsWith(`${DECISIONS_PENDING_FILE}.corrupt-`))).toBe(true);
+  });
+
+  it('an invalid-shape store (object without decisions array) is quarantined', async () => {
+    const dir = decisionsDir(root);
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, DECISIONS_PENDING_FILE);
+    await writeFile(path, JSON.stringify({ version: '1', sessionId: 's', updatedAt: '' }), 'utf-8');
+    await loadDecisionStore(root);
+    const entries = await readdir(dir);
+    expect(entries.some((e) => e.startsWith(`${DECISIONS_PENDING_FILE}.corrupt-`))).toBe(true);
+  });
+
+  it('save bumps the monotonic sequence', async () => {
+    const s0 = await loadDecisionStore(root);
+    expect(s0.sequence).toBe(0);
+    await saveDecisionStore(root, s0);
+    const s1 = await loadDecisionStore(root);
+    expect(s1.sequence).toBe(1);
+    await saveDecisionStore(root, s1);
+    expect((await loadDecisionStore(root)).sequence).toBe(2);
+  });
+
+  it('quarantined file retains the original bytes (recoverable)', async () => {
+    const dir = decisionsDir(root);
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, DECISIONS_PENDING_FILE);
+    const original = '{ torn store ';
+    await writeFile(path, original, 'utf-8');
+    await loadDecisionStore(root);
+    const corrupt = (await readdir(dir)).find((e) => e.startsWith(`${DECISIONS_PENDING_FILE}.corrupt-`))!;
+    expect(await readFile(join(dir, corrupt), 'utf-8')).toBe(original);
+    await stat(join(dir, corrupt)); // exists
+  });
+});

--- a/src/core/decisions/atomic-store.test.ts
+++ b/src/core/decisions/atomic-store.test.ts
@@ -7,7 +7,7 @@
  * ConcurrentMemoryWriteSafety. Plain .test.ts so CI runs it.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile, readFile, readdir, stat } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, readFile, readdir, stat, utimes } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -130,6 +130,25 @@ describe('casUpdate', () => {
     expect(final.items.sort()).toEqual(Array.from({ length: N }, (_, i) => `w${i}`).sort());
     expect(final.sequence).toBe(N);
   });
+
+  it('steals a stale lock left by a crashed holder and still commits', async () => {
+    // Simulate a crashed writer: a lock file with an mtime well past the stale
+    // threshold (10s). casUpdate must steal it rather than block, and commit.
+    const lockPath = `${path()}.lock`;
+    await writeFile(lockPath, '99999-0', 'utf-8'); // some other process's token
+    const old = new Date(Date.now() - 60_000);
+    await utimes(lockPath, old, old);
+
+    const result = await casUpdate<Store>({
+      storePath: path(),
+      load,
+      serialize,
+      mutate: (s) => ({ ...s, items: [...s.items, 'after-steal'] }),
+    });
+    expect(result.items).toEqual(['after-steal']);
+    // The lock we acquired (and owned) is released on completion.
+    await expect(readFile(lockPath, 'utf-8')).rejects.toThrow();
+  });
 });
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -150,6 +169,32 @@ describe('quarantineCorrupt', () => {
     await writeFile(path, 'garbage', 'utf-8');
     const dest = await quarantineCorrupt(path, 'test');
     expect(dest).toBe(`${path}.corrupt-1`);
+  });
+
+  it('never overwrites an existing quarantine file (atomic claim preserves prior bytes)', async () => {
+    const path = join(root, 'notes.json');
+    await writeFile(`${path}.corrupt-0`, 'PRIOR', 'utf-8');
+    await writeFile(path, 'NEW garbage', 'utf-8');
+    const dest = await quarantineCorrupt(path, 'test');
+    expect(dest).toBe(`${path}.corrupt-1`);
+    // The earlier quarantine's bytes are intact — not clobbered.
+    expect(await readFile(`${path}.corrupt-0`, 'utf-8')).toBe('PRIOR');
+    expect(await readFile(`${path}.corrupt-1`, 'utf-8')).toBe('NEW garbage');
+  });
+
+  it('two concurrent quarantines of the same file preserve the bytes exactly once', async () => {
+    const path = join(root, 'notes.json');
+    await writeFile(path, 'ONLY COPY', 'utf-8');
+    const [a, b] = await Promise.all([
+      quarantineCorrupt(path, 'racer-a'),
+      quarantineCorrupt(path, 'racer-b'),
+    ]);
+    // Exactly one claim succeeds; the other sees the file already moved (null).
+    const winners = [a, b].filter((d): d is string => d !== null);
+    expect(winners).toHaveLength(1);
+    expect(await readFile(winners[0], 'utf-8')).toBe('ONLY COPY');
+    // Original path is gone (moved), not left as a duplicate.
+    await expect(readFile(path, 'utf-8')).rejects.toThrow();
   });
 });
 

--- a/src/core/decisions/atomic-store.test.ts
+++ b/src/core/decisions/atomic-store.test.ts
@@ -22,9 +22,16 @@ import {
   updateMemoryStore,
   memoryDir,
 } from './memory-store.js';
-import { loadDecisionStore, saveDecisionStore, decisionsDir } from './store.js';
+import {
+  loadDecisionStore,
+  saveDecisionStore,
+  updateDecisionStore,
+  upsertDecisions,
+  patchDecision,
+  decisionsDir,
+} from './store.js';
 import { MEMORY_NOTES_FILE, DECISIONS_PENDING_FILE } from '../../constants.js';
-import type { AnchoredMemory, MemoryStore } from '../../types/index.js';
+import type { AnchoredMemory, MemoryStore, PendingDecision } from '../../types/index.js';
 
 vi.mock('../../utils/logger.js', () => ({
   logger: { warning: vi.fn(), info: vi.fn(), error: vi.fn(), success: vi.fn(), section: vi.fn(), discovery: vi.fn(), analysis: vi.fn(), blank: vi.fn() },
@@ -97,23 +104,17 @@ describe('casUpdate', () => {
     expect(b.items).toEqual(['a', 'b']);
   });
 
-  it('re-applies the mutate when the on-disk sequence changed mid-update (no lost write)', async () => {
+  it('applies the mutate to the freshest on-disk store, never clobbering a prior write', async () => {
     // A competing writer has already committed {items:['other'], sequence:1} to disk.
     await writeFile(path(), serialize({ items: ['other'], sequence: 1 }));
-    // Make the FIRST outer load return a stale (sequence 0) view so the commit
-    // re-read detects the conflict and forces exactly one re-apply.
-    let calls = 0;
-    const staleThenFresh = async (): Promise<Store> => {
-      calls++;
-      return calls === 1 ? { items: [], sequence: 0 } : load();
-    };
     const result = await casUpdate<Store>({
       storePath: path(),
-      load: staleThenFresh,
+      load,
       serialize,
       mutate: (s) => ({ ...s, items: [...s.items, 'mine'] }),
     });
-    // The competing 'other' write is NOT clobbered; 'mine' is re-applied on top.
+    // The mutate runs against the latest store read inside the lock: 'other' is
+    // preserved and 'mine' is merged on top; the sequence advances from 1 to 2.
     expect(result.items).toEqual(['other', 'mine']);
     expect(result.sequence).toBe(2);
   });
@@ -247,5 +248,59 @@ describe('decision store — quarantine + sequence', () => {
     const corrupt = (await readdir(dir)).find((e) => e.startsWith(`${DECISIONS_PENDING_FILE}.corrupt-`))!;
     expect(await readFile(join(dir, corrupt), 'utf-8')).toBe(original);
     await stat(join(dir, corrupt)); // exists
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// decision store — concurrent mixed-mutation writers lose no write (C1 regression)
+// ════════════════════════════════════════════════════════════════════════════
+describe('decision store — concurrent CAS writers across mutation kinds', () => {
+  function decision(id: string, status: PendingDecision['status'] = 'draft'): PendingDecision {
+    return {
+      id, status, title: `decision ${id}`, rationale: '', consequences: '',
+      proposedRequirement: null, affectedDomains: [], affectedFiles: [],
+      sessionId: 's', recordedAt: '2026-01-01T00:00:00Z', confidence: 'medium', syncedToSpecs: [],
+    };
+  }
+
+  it('N concurrent upserts (record-style) persist every decision', async () => {
+    const N = 25;
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        updateDecisionStore(root, (s) => upsertDecisions(s, [decision(`d${i}`)])),
+      ),
+    );
+    const final = await loadDecisionStore(root);
+    expect(final.decisions.map((d) => d.id).sort()).toEqual(
+      Array.from({ length: N }, (_, i) => `d${i}`).sort(),
+    );
+  });
+
+  it('a consolidation-style replace racing concurrent record upserts loses neither', async () => {
+    // Seed two drafts the "consolidation" will reject+replace.
+    await updateDecisionStore(root, (s) => upsertDecisions(s, [decision('draftA'), decision('draftB')]));
+
+    // Race: a consolidation that rejects draftA/draftB and writes a consolidated
+    // decision, concurrently with two fresh record_decision-style upserts. With CAS
+    // on a single lock, the consolidation snapshot cannot clobber the new records.
+    await Promise.all([
+      updateDecisionStore(root, (s) => {
+        let next = patchDecision(s, 'draftA', { status: 'rejected' });
+        next = patchDecision(next, 'draftB', { status: 'rejected' });
+        return upsertDecisions(next, [decision('consolidated', 'verified')]);
+      }),
+      updateDecisionStore(root, (s) => upsertDecisions(s, [decision('lateX')])),
+      updateDecisionStore(root, (s) => upsertDecisions(s, [decision('lateY')])),
+    ]);
+
+    const final = await loadDecisionStore(root);
+    const byId = new Map(final.decisions.map((d) => [d.id, d]));
+    // Every write survived — no lost update across mutation kinds.
+    expect(byId.has('consolidated')).toBe(true);
+    expect(byId.has('lateX')).toBe(true);
+    expect(byId.has('lateY')).toBe(true);
+    // The consolidation's rejects also applied.
+    expect(byId.get('draftA')?.status).toBe('rejected');
+    expect(byId.get('draftB')?.status).toBe('rejected');
   });
 });

--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -1,0 +1,174 @@
+/**
+ * Durable, concurrency-safe persistence primitives for the JSON stores.
+ * (change: harden-memory-integrity-invariant)
+ *
+ * OpenLore's promise — *never serve an unverified or stale fact as
+ * authoritative* — is only as strong as the durability of the files behind it.
+ * Both stores (`.openlore/memory/notes.json`, `.openlore/decisions/pending.json`)
+ * are single JSON files rewritten in full. Without these primitives:
+ *
+ *   - a crash mid-write leaves a torn file that loads as a silent empty store
+ *     (memory vanishes, nothing says so), and
+ *   - two concurrent writers race: last-writer-wins silently drops the other.
+ *
+ * This module supplies three stdlib-only primitives (no new dependency, no LLM):
+ *
+ *   1. {@link atomicWriteFile} — write to a temp file, fsync, then POSIX-rename
+ *      into place. A crash before the rename leaves the prior store intact.
+ *   2. {@link casUpdate} — optimistic compare-and-swap on a monotonic `sequence`:
+ *      load → mutate → commit only if the on-disk sequence is unchanged; on a
+ *      conflict, re-read and re-apply the (append/supersede) merge rather than
+ *      clobber. No concurrent write is lost.
+ *   3. {@link quarantineCorrupt} — move a store that fails validation aside to
+ *      `*.corrupt-<n>` and signal it, instead of silently substituting empty.
+ */
+
+import { open, rename, stat, unlink, mkdir, access } from 'node:fs/promises';
+import { dirname, basename, join } from 'node:path';
+import { logger } from '../../utils/logger.js';
+
+/** Any persisted store that carries the monotonic CAS counter. */
+export interface SequencedStore {
+  sequence?: number;
+}
+
+/**
+ * Write `data` to `path` atomically. The data goes to a sibling temp file, is
+ * flushed to disk (`fsync`), and is moved into place with a single atomic
+ * `rename`. A crash or interruption before the rename leaves the previously
+ * committed file untouched — never a partially written (torn) file.
+ */
+export async function atomicWriteFile(path: string, data: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  // pid-scoped temp name: each writer holds the store lock during commit, but a
+  // distinct name per process keeps concurrent best-effort writers from sharing a
+  // temp file even outside the lock.
+  const tmp = join(dirname(path), `.${basename(path)}.tmp-${process.pid}`);
+  const fh = await open(tmp, 'w');
+  try {
+    await fh.writeFile(data, 'utf-8');
+    await fh.sync(); // durability barrier: bytes are on disk before the rename
+  } finally {
+    await fh.close();
+  }
+  await rename(tmp, path); // atomic replace
+}
+
+// ── advisory lock for the tiny compare-and-write commit section ───────────────
+
+const LOCK_STALE_MS = 30_000; // steal a lock older than this (crashed holder)
+const LOCK_POLL_MS = 25;
+const LOCK_MAX_WAIT_MS = 30_000;
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/**
+ * Run `fn` while holding a per-file advisory lock (exclusive-create lockfile,
+ * polled, with stale-steal for a crashed holder). The lock guards only the brief
+ * compare-and-write commit, so contention is minimal. Best-effort on timeout: it
+ * proceeds rather than block a writer forever (the CAS check still protects the
+ * write from clobbering a committed change).
+ */
+async function withCommitLock<T>(lockPath: string, fn: () => Promise<T>): Promise<T> {
+  await mkdir(dirname(lockPath), { recursive: true });
+  const start = Date.now();
+  for (;;) {
+    try {
+      const fh = await open(lockPath, 'wx'); // exclusive create — fails if held
+      await fh.writeFile(`${process.pid}`);
+      await fh.close();
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      try {
+        const s = await stat(lockPath);
+        if (Date.now() - s.mtimeMs > LOCK_STALE_MS) {
+          await unlink(lockPath).catch(() => {});
+          continue;
+        }
+      } catch {
+        continue; // lock vanished between open and stat — retry
+      }
+      if (Date.now() - start > LOCK_MAX_WAIT_MS) break; // best-effort
+      await sleep(LOCK_POLL_MS);
+    }
+  }
+  try {
+    return await fn();
+  } finally {
+    await unlink(lockPath).catch(() => {});
+  }
+}
+
+const MAX_CAS_ATTEMPTS = 50;
+
+/**
+ * Atomically read-modify-write a sequenced JSON store with optimistic
+ * compare-and-swap. Loads the current store, applies `mutate`, and commits at
+ * `sequence + 1` only if the on-disk sequence is still what was loaded; on a
+ * conflict it re-reads and re-applies `mutate` to the newer store rather than
+ * overwrite the competing write. Returns the committed store.
+ *
+ * `mutate` MUST be a pure merge over the loaded store (append / id-keyed
+ * upsert / supersede) so that re-applying it after a conflict is correct.
+ */
+export async function casUpdate<T extends SequencedStore>(opts: {
+  storePath: string;
+  load: () => Promise<T>;
+  mutate: (current: T) => T;
+  serialize: (next: T) => string;
+}): Promise<T> {
+  const lockPath = `${opts.storePath}.lock`;
+  for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
+    const current = await opts.load();
+    const baseSeq = current.sequence ?? 0;
+    const next = { ...opts.mutate(current), sequence: baseSeq + 1 } as T;
+
+    const committed = await withCommitLock(lockPath, async () => {
+      const onDisk = await opts.load(); // re-read under the lock
+      if ((onDisk.sequence ?? 0) !== baseSeq) return false; // conflict → re-apply
+      await atomicWriteFile(opts.storePath, opts.serialize(next));
+      return true;
+    });
+    if (committed) return next;
+    // else: a competing writer advanced the sequence — loop, re-read, re-apply.
+  }
+  throw new Error(
+    `casUpdate: exhausted ${MAX_CAS_ATTEMPTS} attempts on ${opts.storePath} (persistent write contention)`,
+  );
+}
+
+// ── corrupt-store quarantine ──────────────────────────────────────────────────
+
+async function exists(p: string): Promise<boolean> {
+  try { await access(p); return true; } catch { return false; }
+}
+
+/**
+ * Move a store that failed validation aside to a deterministic quarantine path
+ * `${path}.corrupt-<n>` and emit a recoverable signal, instead of silently
+ * substituting an empty store (which would present absence as current fact).
+ *
+ * The suffix is the first free non-negative integer — derived from what is
+ * already on disk, never wall-clock time — so recovery is reproducible. Returns
+ * the quarantine path, or `null` if the move could not be performed (in which
+ * case the caller still degrades to empty, but loudly).
+ */
+export async function quarantineCorrupt(path: string, reason: string): Promise<string | null> {
+  try {
+    let n = 0;
+    while (await exists(`${path}.corrupt-${n}`)) n++;
+    const dest = `${path}.corrupt-${n}`;
+    await rename(path, dest);
+    logger.warning(
+      `store quarantine: ${path} failed validation (${reason}) — moved to ${dest}. ` +
+        `Persisted data was NOT silently dropped; inspect or restore the quarantined file.`,
+    );
+    return dest;
+  } catch (err) {
+    logger.warning(
+      `store quarantine: ${path} failed validation (${reason}) and could not be moved aside ` +
+        `(${(err as Error).message}). Starting from an empty store.`,
+    );
+    return null;
+  }
+}

--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -23,7 +23,7 @@
  *      `*.corrupt-<n>` and signal it, instead of silently substituting empty.
  */
 
-import { open, rename, stat, unlink, mkdir, access } from 'node:fs/promises';
+import { open, rename, stat, unlink, mkdir, access, readFile, link } from 'node:fs/promises';
 import { dirname, basename, join } from 'node:path';
 import { logger } from '../../utils/logger.js';
 
@@ -78,31 +78,37 @@ export async function atomicWriteFile(path: string, data: string): Promise<void>
 // ── advisory lock for the tiny compare-and-write commit section ───────────────
 
 // STALE < MAX_WAIT by design: a crashed holder's lock always becomes stealable
-// (10s) well before a waiter gives up (30s), so the best-effort unlocked fallback
-// is only ever reached under genuine sustained contention — implausible for these
-// tiny critical sections — never because of a dead holder.
+// (10s) well before a waiter gives up (30s), so a wait timeout means genuine
+// sustained contention — implausible for these tiny critical sections — never a
+// dead holder. On timeout we fail loud rather than write unlocked: for a store
+// whose promise is "no write is lost," a rare surfaced error the caller can retry
+// beats a rare silent lost update.
 const LOCK_STALE_MS = 10_000; // steal a lock older than this (crashed holder)
 const LOCK_POLL_MS = 25;
 const LOCK_MAX_WAIT_MS = 30_000;
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
+// Globally-unique-among-live-holders lock token: pid is unique across concurrent
+// processes, the counter across concurrent in-process acquires.
+let lockSeq = 0;
+
 /**
  * Run `fn` while holding a per-file advisory lock (exclusive-create lockfile,
  * polled, with stale-steal for a crashed holder). The lock guards only the brief
- * compare-and-write commit, so contention is minimal. Best-effort on timeout: it
- * proceeds rather than block a writer forever (the CAS check still protects the
- * write from clobbering a committed change).
+ * compare-and-write commit, so contention is minimal. On a wait timeout it throws
+ * rather than proceed unlocked. The lock carries an ownership token and is released
+ * only if it is still ours — so if our hold was stolen as stale (e.g. a long GC
+ * pause) and recreated by another writer, we never delete a lock someone else holds.
  */
 async function withCommitLock<T>(lockPath: string, fn: () => Promise<T>): Promise<T> {
   await mkdir(dirname(lockPath), { recursive: true });
+  const token = `${process.pid}-${lockSeq++}`;
   const start = Date.now();
-  let acquired = false;
   for (;;) {
     try {
       const fh = await open(lockPath, 'wx'); // exclusive create — fails if held
-      await fh.writeFile(`${process.pid}`);
+      await fh.writeFile(token);
       await fh.close();
-      acquired = true;
       break;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
@@ -115,17 +121,23 @@ async function withCommitLock<T>(lockPath: string, fn: () => Promise<T>): Promis
       } catch {
         continue; // lock vanished between open and stat — retry
       }
-      if (Date.now() - start > LOCK_MAX_WAIT_MS) break; // best-effort: proceed unlocked
+      if (Date.now() - start > LOCK_MAX_WAIT_MS) {
+        throw new Error(
+          `store lock: timed out after ${LOCK_MAX_WAIT_MS}ms waiting for ${lockPath} ` +
+            `(sustained write contention) — retry the operation`,
+        );
+      }
       await sleep(LOCK_POLL_MS);
     }
   }
   try {
     return await fn();
   } finally {
-    // Only remove the lock if we actually created it. On a best-effort timeout we
-    // never acquired it, so unlinking here would delete the current holder's lock
-    // and break mutual exclusion exactly when contention is highest.
-    if (acquired) await unlink(lockPath).catch(() => {});
+    // Release only if the on-disk lock is still ours. A token mismatch means our
+    // hold was stolen as stale and another writer now owns it — leave theirs alone.
+    try {
+      if ((await readFile(lockPath, 'utf-8')) === token) await unlink(lockPath).catch(() => {});
+    } catch { /* lock already gone — nothing to release */ }
   }
 }
 
@@ -169,22 +181,55 @@ async function exists(p: string): Promise<boolean> {
  * `${path}.corrupt-<n>` and emit a recoverable signal, instead of silently
  * substituting an empty store (which would present absence as current fact).
  *
- * The suffix is the first free non-negative integer — derived from what is
- * already on disk, never wall-clock time — so recovery is reproducible. Returns
- * the quarantine path, or `null` if the move could not be performed (in which
- * case the caller still degrades to empty, but loudly).
+ * The suffix is the first free non-negative integer — derived from what is already
+ * on disk, never wall-clock time — so recovery is reproducible. The claim is atomic
+ * (a hard link that fails if the destination exists), so two concurrent loaders can
+ * never overwrite each other's quarantine file and lose preserved bytes. Returns the
+ * quarantine path, or `null` when the move was unnecessary or impossible (caller
+ * still degrades to empty, but loudly).
  */
 export async function quarantineCorrupt(path: string, reason: string): Promise<string | null> {
   try {
-    let n = 0;
-    while (await exists(`${path}.corrupt-${n}`)) n++;
-    const dest = `${path}.corrupt-${n}`;
-    await rename(path, dest);
-    logger.warning(
-      `store quarantine: ${path} failed validation (${reason}) — moved to ${dest}. ` +
-        `Persisted data was NOT silently dropped; inspect or restore the quarantined file.`,
-    );
-    return dest;
+    for (let n = 0; ; n++) {
+      const dest = `${path}.corrupt-${n}`;
+      try {
+        // Atomic claim: link succeeds only if `dest` does not yet exist, so a
+        // racing loader that took this `n` is never overwritten.
+        await link(path, dest);
+        await unlink(path); // link + unlink = move-without-clobber
+        logger.warning(
+          `store quarantine: ${path} failed validation (${reason}) — moved to ${dest}. ` +
+            `Persisted data was NOT silently dropped; inspect or restore the quarantined file.`,
+        );
+        return dest;
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'EEXIST') continue; // a prior quarantine took this n — try the next
+        if (code === 'ENOENT') {
+          // `path` is already gone — a concurrent loader quarantined it first, so the
+          // bytes are preserved under its own suffix. Not a loss.
+          logger.warning(
+            `store quarantine: ${path} was already moved aside by a concurrent loader (${reason}).`,
+          );
+          return null;
+        }
+        if (code === 'EPERM' || code === 'ENOSYS' || code === 'EXDEV' || code === 'EMLINK') {
+          // Hard links unsupported on this filesystem — fall back to a plain rename
+          // to the first free suffix (loses the atomic-claim guarantee, but such
+          // filesystems are rare and concurrent corrupt-loads rarer still).
+          let m = 0;
+          while (await exists(`${path}.corrupt-${m}`)) m++;
+          const dest2 = `${path}.corrupt-${m}`;
+          await rename(path, dest2);
+          logger.warning(
+            `store quarantine: ${path} failed validation (${reason}) — moved to ${dest2}. ` +
+              `Persisted data was NOT silently dropped; inspect or restore the quarantined file.`,
+          );
+          return dest2;
+        }
+        throw err;
+      }
+    }
   } catch (err) {
     logger.warning(
       `store quarantine: ${path} failed validation (${reason}) and could not be moved aside ` +

--- a/src/core/decisions/atomic-store.ts
+++ b/src/core/decisions/atomic-store.ts
@@ -32,6 +32,11 @@ export interface SequencedStore {
   sequence?: number;
 }
 
+// Monotonic per-process counter so two concurrent writers to the SAME path never
+// share a temp filename (which would let one truncate the other's temp before its
+// rename). Combined with the pid it is unique per in-flight write.
+let tmpCounter = 0;
+
 /**
  * Write `data` to `path` atomically. The data goes to a sibling temp file, is
  * flushed to disk (`fsync`), and is moved into place with a single atomic
@@ -39,24 +44,44 @@ export interface SequencedStore {
  * committed file untouched — never a partially written (torn) file.
  */
 export async function atomicWriteFile(path: string, data: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  // pid-scoped temp name: each writer holds the store lock during commit, but a
-  // distinct name per process keeps concurrent best-effort writers from sharing a
-  // temp file even outside the lock.
-  const tmp = join(dirname(path), `.${basename(path)}.tmp-${process.pid}`);
-  const fh = await open(tmp, 'w');
+  const dir = dirname(path);
+  await mkdir(dir, { recursive: true });
+  // Unique temp name per in-flight write (pid + monotonic counter): concurrent
+  // writers to the same path — even outside the commit lock — never collide on a
+  // shared temp file.
+  const tmp = join(dir, `.${basename(path)}.tmp-${process.pid}-${tmpCounter++}`);
+  let renamed = false;
   try {
-    await fh.writeFile(data, 'utf-8');
-    await fh.sync(); // durability barrier: bytes are on disk before the rename
+    const fh = await open(tmp, 'w');
+    try {
+      await fh.writeFile(data, 'utf-8');
+      await fh.sync(); // durability barrier: bytes are on disk before the rename
+    } finally {
+      await fh.close();
+    }
+    await rename(tmp, path); // atomic replace
+    renamed = true;
   } finally {
-    await fh.close();
+    // If we never renamed (write/sync threw), remove the orphaned temp so a failed
+    // write does not litter the store directory.
+    if (!renamed) await unlink(tmp).catch(() => {});
   }
-  await rename(tmp, path); // atomic replace
+  // Best-effort: fsync the directory so the rename (a metadata op) is durable
+  // across a crash. POSIX allows fsync on a directory fd; platforms that reject it
+  // (e.g. Windows) simply skip — the data fsync above already bounds the loss.
+  try {
+    const dh = await open(dir, 'r');
+    try { await dh.sync(); } finally { await dh.close(); }
+  } catch { /* directory fsync unsupported — skip */ }
 }
 
 // ── advisory lock for the tiny compare-and-write commit section ───────────────
 
-const LOCK_STALE_MS = 30_000; // steal a lock older than this (crashed holder)
+// STALE < MAX_WAIT by design: a crashed holder's lock always becomes stealable
+// (10s) well before a waiter gives up (30s), so the best-effort unlocked fallback
+// is only ever reached under genuine sustained contention — implausible for these
+// tiny critical sections — never because of a dead holder.
+const LOCK_STALE_MS = 10_000; // steal a lock older than this (crashed holder)
 const LOCK_POLL_MS = 25;
 const LOCK_MAX_WAIT_MS = 30_000;
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -71,11 +96,13 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 async function withCommitLock<T>(lockPath: string, fn: () => Promise<T>): Promise<T> {
   await mkdir(dirname(lockPath), { recursive: true });
   const start = Date.now();
+  let acquired = false;
   for (;;) {
     try {
       const fh = await open(lockPath, 'wx'); // exclusive create — fails if held
       await fh.writeFile(`${process.pid}`);
       await fh.close();
+      acquired = true;
       break;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
@@ -88,28 +115,33 @@ async function withCommitLock<T>(lockPath: string, fn: () => Promise<T>): Promis
       } catch {
         continue; // lock vanished between open and stat — retry
       }
-      if (Date.now() - start > LOCK_MAX_WAIT_MS) break; // best-effort
+      if (Date.now() - start > LOCK_MAX_WAIT_MS) break; // best-effort: proceed unlocked
       await sleep(LOCK_POLL_MS);
     }
   }
   try {
     return await fn();
   } finally {
-    await unlink(lockPath).catch(() => {});
+    // Only remove the lock if we actually created it. On a best-effort timeout we
+    // never acquired it, so unlinking here would delete the current holder's lock
+    // and break mutual exclusion exactly when contention is highest.
+    if (acquired) await unlink(lockPath).catch(() => {});
   }
 }
 
-const MAX_CAS_ATTEMPTS = 50;
-
 /**
- * Atomically read-modify-write a sequenced JSON store with optimistic
- * compare-and-swap. Loads the current store, applies `mutate`, and commits at
- * `sequence + 1` only if the on-disk sequence is still what was loaded; on a
- * conflict it re-reads and re-applies `mutate` to the newer store rather than
- * overwrite the competing write. Returns the committed store.
+ * Atomically read-modify-write a sequenced JSON store. The load → mutate →
+ * write happens entirely inside the per-store advisory lock, so the lock — not an
+ * optimistic sequence guard — is the real serialization point: `mutate` always
+ * runs against the freshest on-disk store, and a competing write cannot interleave
+ * between the read and the write. The monotonic `sequence` is still bumped (it
+ * orders writes, names quarantine files, and lets external readers detect change),
+ * but correctness no longer depends on every writer honoring it.
  *
  * `mutate` MUST be a pure merge over the loaded store (append / id-keyed
- * upsert / supersede) so that re-applying it after a conflict is correct.
+ * upsert / supersede) so that applying it to the latest store is always correct.
+ * ALL writers of a given store MUST go through this function (or a wrapper of it)
+ * — a raw, lock-free write to the same path defeats the serialization.
  */
 export async function casUpdate<T extends SequencedStore>(opts: {
   storePath: string;
@@ -118,23 +150,12 @@ export async function casUpdate<T extends SequencedStore>(opts: {
   serialize: (next: T) => string;
 }): Promise<T> {
   const lockPath = `${opts.storePath}.lock`;
-  for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt++) {
-    const current = await opts.load();
-    const baseSeq = current.sequence ?? 0;
-    const next = { ...opts.mutate(current), sequence: baseSeq + 1 } as T;
-
-    const committed = await withCommitLock(lockPath, async () => {
-      const onDisk = await opts.load(); // re-read under the lock
-      if ((onDisk.sequence ?? 0) !== baseSeq) return false; // conflict → re-apply
-      await atomicWriteFile(opts.storePath, opts.serialize(next));
-      return true;
-    });
-    if (committed) return next;
-    // else: a competing writer advanced the sequence — loop, re-read, re-apply.
-  }
-  throw new Error(
-    `casUpdate: exhausted ${MAX_CAS_ATTEMPTS} attempts on ${opts.storePath} (persistent write contention)`,
-  );
+  return withCommitLock(lockPath, async () => {
+    const current = await opts.load(); // fresh read inside the lock
+    const next = { ...opts.mutate(current), sequence: (current.sequence ?? 0) + 1 } as T;
+    await atomicWriteFile(opts.storePath, opts.serialize(next));
+    return next;
+  });
 }
 
 // ── corrupt-store quarantine ──────────────────────────────────────────────────

--- a/src/core/decisions/gate-state.test.ts
+++ b/src/core/decisions/gate-state.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Pre-commit gate reason machine — property tests.
+ * (change: harden-memory-integrity-invariant)
+ *
+ * Proves the machine is TOTAL (every state maps to exactly one outcome),
+ * DETERMINISTIC / IDEMPOTENT (same state ⇒ same outcome), and DEADLOCK-FREE (a
+ * blocked outcome always carries an actionable reason; a passing outcome never
+ * carries one). Exhaustive over a representative finite slice of the state space.
+ *
+ * Plain .test.ts so CI runs it.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyGateState, type GateState, type GateOutcome } from './gate-state.js';
+import { GATE_REASONS } from '../../constants.js';
+
+const ALL_REASONS = new Set<string>(Object.values(GATE_REASONS));
+
+/** Enumerate a representative finite slice: counts 0..2, both booleans. */
+function* enumerateStates(): Generator<GateState> {
+  for (const approvedCount of [0, 1, 2])
+    for (const verifiedCount of [0, 1, 2])
+      for (const draftCount of [0, 1, 2])
+        for (const activeCount of [0, 1, 2])
+          for (const consolidatedRecently of [false, true])
+            for (const isGitRepo of [false, true])
+              for (const hasStagedSourceChanges of [false, true])
+                yield { approvedCount, verifiedCount, draftCount, activeCount, consolidatedRecently, isGitRepo, hasStagedSourceChanges };
+}
+
+/** Independent re-derivation of the spec'd priority order — locks the machine. */
+function expectedOutcome(s: GateState): GateOutcome {
+  if (s.approvedCount > 0) return { gated: true, reason: GATE_REASONS.APPROVED_NOT_SYNCED };
+  if (s.verifiedCount > 0) return { gated: true, reason: GATE_REASONS.VERIFIED };
+  if (s.draftCount > 0) return { gated: true, reason: GATE_REASONS.DRAFTS_PENDING_CONSOLIDATION };
+  if (s.consolidatedRecently) return { gated: false, reason: null };
+  if (s.activeCount === 0 && s.isGitRepo && s.hasStagedSourceChanges) {
+    return { gated: true, reason: GATE_REASONS.NO_DECISIONS_RECORDED };
+  }
+  return { gated: false, reason: null };
+}
+
+describe('classifyGateState — totality', () => {
+  it('every state maps to exactly one well-formed outcome', () => {
+    for (const s of enumerateStates()) {
+      const o = classifyGateState(s);
+      expect(typeof o.gated).toBe('boolean');
+      if (o.gated) {
+        expect(ALL_REASONS.has(o.reason as string), `gated state ${JSON.stringify(s)} → unknown reason ${o.reason}`).toBe(true);
+      } else {
+        expect(o.reason, `passing state ${JSON.stringify(s)} carries a reason`).toBeNull();
+      }
+    }
+  });
+});
+
+describe('classifyGateState — deadlock-free', () => {
+  it('a blocked outcome always carries an actionable reason; a pass never does', () => {
+    for (const s of enumerateStates()) {
+      const o = classifyGateState(s);
+      // No "blocked with no reason" deadlock, and no "passing but flagged" contradiction.
+      expect(o.gated === (o.reason !== null), `contradictory outcome for ${JSON.stringify(s)}`).toBe(true);
+    }
+  });
+});
+
+describe('classifyGateState — deterministic / idempotent', () => {
+  it('produces an identical outcome on repeated evaluation', () => {
+    for (const s of enumerateStates()) {
+      expect(classifyGateState(s)).toEqual(classifyGateState(s));
+    }
+  });
+});
+
+describe('classifyGateState — matches the documented priority order', () => {
+  it('agrees with the independent re-derivation across the whole slice', () => {
+    for (const s of enumerateStates()) {
+      expect(classifyGateState(s), `mismatch at ${JSON.stringify(s)}`).toEqual(expectedOutcome(s));
+    }
+  });
+
+  it('approved-not-synced outranks every other reason', () => {
+    const o = classifyGateState({
+      approvedCount: 1, verifiedCount: 1, draftCount: 1, activeCount: 2,
+      consolidatedRecently: false, isGitRepo: true, hasStagedSourceChanges: true,
+    });
+    expect(o).toEqual({ gated: true, reason: GATE_REASONS.APPROVED_NOT_SYNCED });
+  });
+
+  it('verified outranks drafts and no-decisions', () => {
+    const o = classifyGateState({
+      approvedCount: 0, verifiedCount: 1, draftCount: 1, activeCount: 1,
+      consolidatedRecently: false, isGitRepo: true, hasStagedSourceChanges: true,
+    });
+    expect(o).toEqual({ gated: true, reason: GATE_REASONS.VERIFIED });
+  });
+
+  it('recent consolidation passes even when source is staged', () => {
+    const o = classifyGateState({
+      approvedCount: 0, verifiedCount: 0, draftCount: 0, activeCount: 0,
+      consolidatedRecently: true, isGitRepo: true, hasStagedSourceChanges: true,
+    });
+    expect(o).toEqual({ gated: false, reason: null });
+  });
+
+  it('no-decisions-recorded requires git repo AND staged source AND no active decisions', () => {
+    const base = { approvedCount: 0, verifiedCount: 0, draftCount: 0, consolidatedRecently: false } as const;
+    expect(classifyGateState({ ...base, activeCount: 0, isGitRepo: true, hasStagedSourceChanges: true }))
+      .toEqual({ gated: true, reason: GATE_REASONS.NO_DECISIONS_RECORDED });
+    // Missing any one condition → passes.
+    expect(classifyGateState({ ...base, activeCount: 1, isGitRepo: true, hasStagedSourceChanges: true }).gated).toBe(false);
+    expect(classifyGateState({ ...base, activeCount: 0, isGitRepo: false, hasStagedSourceChanges: true }).gated).toBe(false);
+    expect(classifyGateState({ ...base, activeCount: 0, isGitRepo: true, hasStagedSourceChanges: false }).gated).toBe(false);
+  });
+});

--- a/src/core/decisions/gate-state.ts
+++ b/src/core/decisions/gate-state.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure pre-commit gate reason machine.
+ * (change: harden-memory-integrity-invariant)
+ *
+ * The commit gate maps the current decision-store state to exactly one outcome:
+ * either it passes, or it blocks with one of the canonical {@link GATE_REASONS}.
+ * That mapping used to live inline in the CLI command, tangled with stdout, git,
+ * and TTY I/O — impossible to prove total or deterministic. Extracting it as this
+ * pure function makes the machine a tested contract:
+ *
+ *   - **total**     — every reachable state yields exactly one outcome;
+ *   - **deterministic / idempotent** — same state ⇒ same outcome, every time;
+ *   - **deadlock-free** — no state maps to "blocked with no actionable reason."
+ *
+ * The CLI gathers the booleans (store counts, consolidation recency, staged git
+ * changes) and builds the user-facing payload; this function is the single
+ * arbiter of *which* reason applies.
+ */
+
+import { GATE_REASONS, type GateReason } from '../../constants.js';
+
+/** The minimal state the gate decision depends on. All inputs are data, not I/O. */
+export interface GateState {
+  /** Decisions in `approved` status (synced to specs not yet done). */
+  approvedCount: number;
+  /** Decisions in `verified` status (await human approval). */
+  verifiedCount: number;
+  /** Decisions in `draft` status (recorded, not yet consolidated). */
+  draftCount: number;
+  /** True when consolidation ran within the grace period — trust it found nothing. */
+  consolidatedRecently: boolean;
+  /** Count of non-inactive decisions (excludes rejected/synced/phantom). */
+  activeCount: number;
+  /** Whether the working directory is a git repo (gates the staged-source check). */
+  isGitRepo: boolean;
+  /** Whether staged changes include a recognized source file. */
+  hasStagedSourceChanges: boolean;
+}
+
+export type GateOutcome =
+  | { gated: false; reason: null }
+  | { gated: true; reason: GateReason };
+
+/**
+ * Classify a gate state into exactly one outcome. The priority order mirrors the
+ * commit gate: a not-yet-synced approval blocks first, then verified decisions
+ * awaiting approval, then unconsolidated drafts, then (only when nothing is
+ * recorded and source is staged) the no-decisions prompt; otherwise it passes.
+ */
+export function classifyGateState(s: GateState): GateOutcome {
+  // 1. Approved but not synced — must write to specs before committing.
+  if (s.approvedCount > 0) return { gated: true, reason: GATE_REASONS.APPROVED_NOT_SYNCED };
+
+  // 2. Verified decisions await human approval.
+  if (s.verifiedCount > 0) return { gated: true, reason: GATE_REASONS.VERIFIED };
+
+  // 3. Drafts recorded but consolidation never completed.
+  if (s.draftCount > 0) return { gated: true, reason: GATE_REASONS.DRAFTS_PENDING_CONSOLIDATION };
+
+  // 4. Consolidation ran recently and found nothing → pass.
+  if (s.consolidatedRecently) return { gated: false, reason: null };
+
+  // 5. Nothing recorded but source is staged → prompt for a fallback extraction.
+  if (s.activeCount === 0 && s.isGitRepo && s.hasStagedSourceChanges) {
+    return { gated: true, reason: GATE_REASONS.NO_DECISIONS_RECORDED };
+  }
+
+  // 6. Otherwise the commit is clean.
+  return { gated: false, reason: null };
+}

--- a/src/core/decisions/memory-store.ts
+++ b/src/core/decisions/memory-store.ts
@@ -8,48 +8,89 @@
  * handlers and the memory-staleness drift detector.
  */
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
-import { logger } from '../../utils/logger.js';
 import { fileExists } from '../../utils/command-helpers.js';
 import {
   OPENLORE_DIR,
   OPENLORE_MEMORY_SUBDIR,
   MEMORY_NOTES_FILE,
 } from '../../constants.js';
+import { atomicWriteFile, casUpdate, quarantineCorrupt } from './atomic-store.js';
 import type { MemoryStore } from '../../types/index.js';
 
 export function memoryDir(rootPath: string): string {
   return join(rootPath, OPENLORE_DIR, OPENLORE_MEMORY_SUBDIR);
 }
 
+function memoryPath(rootPath: string): string {
+  return join(memoryDir(rootPath), MEMORY_NOTES_FILE);
+}
+
 function emptyStore(): MemoryStore {
-  return { version: '1', updatedAt: '', memories: [] };
+  return { version: '1', updatedAt: '', sequence: 0, memories: [] };
 }
 
 export async function loadMemoryStore(rootPath: string): Promise<MemoryStore> {
-  const path = join(memoryDir(rootPath), MEMORY_NOTES_FILE);
+  const path = memoryPath(rootPath);
   if (!(await fileExists(path))) return emptyStore();
+  let raw: string;
   try {
-    const parsed = JSON.parse(await readFile(path, 'utf-8')) as Partial<MemoryStore>;
-    // Defend against a hand-edited / truncated store: a malformed file must not
-    // crash recall or drift — fall back to empty, like the decision store does.
-    if (!parsed || !Array.isArray(parsed.memories)) return emptyStore();
-    return { version: '1', updatedAt: parsed.updatedAt ?? '', memories: parsed.memories };
+    raw = await readFile(path, 'utf-8');
   } catch (err) {
-    logger.warning(
-      `memory store: failed to read ${path} (${(err as Error).message}) — starting fresh`,
-    );
+    // A read error that is not "missing file" is an I/O fault, not corruption —
+    // do not quarantine (the bytes may be fine); degrade to empty loudly.
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return emptyStore();
+    await quarantineCorrupt(path, `read failed: ${(err as Error).message}`);
     return emptyStore();
   }
+  let parsed: Partial<MemoryStore> | null;
+  try {
+    parsed = JSON.parse(raw) as Partial<MemoryStore>;
+  } catch (err) {
+    // Torn / hand-corrupted JSON: quarantine, never silently empty (a torn store
+    // presented as empty is absence-as-current-fact). (harden-memory-integrity-invariant)
+    await quarantineCorrupt(path, `invalid JSON: ${(err as Error).message}`);
+    return emptyStore();
+  }
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.memories)) {
+    await quarantineCorrupt(path, 'invalid shape (missing memories array)');
+    return emptyStore();
+  }
+  return {
+    version: '1',
+    updatedAt: parsed.updatedAt ?? '',
+    sequence: typeof parsed.sequence === 'number' ? parsed.sequence : 0,
+    memories: parsed.memories,
+  };
 }
 
 export async function saveMemoryStore(rootPath: string, store: MemoryStore): Promise<void> {
-  const dir = memoryDir(rootPath);
-  await mkdir(dir, { recursive: true });
-  const updated: MemoryStore = { ...store, updatedAt: new Date().toISOString() };
-  await writeFile(join(dir, MEMORY_NOTES_FILE), JSON.stringify(updated, null, 2) + '\n', 'utf-8');
+  const updated: MemoryStore = {
+    ...store,
+    updatedAt: new Date().toISOString(),
+    sequence: (store.sequence ?? 0) + 1,
+  };
+  await atomicWriteFile(memoryPath(rootPath), JSON.stringify(updated, null, 2) + '\n');
+}
+
+/**
+ * Concurrency-safe read-modify-write of the memory store. Loads, applies
+ * `mutate` (a pure id-keyed merge), and commits under compare-and-swap so that
+ * two concurrent `remember` calls never lose a write — on a conflict the mutate
+ * is re-applied to the newer store. (harden-memory-integrity-invariant)
+ */
+export async function updateMemoryStore(
+  rootPath: string,
+  mutate: (store: MemoryStore) => MemoryStore,
+): Promise<MemoryStore> {
+  return casUpdate<MemoryStore>({
+    storePath: memoryPath(rootPath),
+    load: () => loadMemoryStore(rootPath),
+    mutate: (current) => ({ ...mutate(current), updatedAt: new Date().toISOString() }),
+    serialize: (next) => JSON.stringify(next, null, 2) + '\n',
+  });
 }
 
 /** Stable 8-char id derived from recordedAt + content. */

--- a/src/core/decisions/store.test.ts
+++ b/src/core/decisions/store.test.ts
@@ -338,17 +338,22 @@ describe('loadDecisionStore', () => {
     expect(loaded.decisions[0].id).toBe('aaaabbbb');
   });
 
-  it('warns and returns empty store on JSON parse error', async () => {
+  it('quarantines (never silently empties) a corrupt store on JSON parse error', async () => {
+    // harden-memory-integrity-invariant: a torn store must not be silently
+    // substituted with empty — it is moved aside to *.corrupt-<n> and signaled.
     const { logger } = await import('../../utils/logger.js');
     const dir = decisionsDir(tmpDir);
     await mkdir(dir, { recursive: true });
-    const { writeFile } = await import('node:fs/promises');
+    const { writeFile, readdir } = await import('node:fs/promises');
     await writeFile(join(dir, 'pending.json'), 'not valid json', 'utf-8');
     const store = await loadDecisionStore(tmpDir);
-    expect(store.decisions).toHaveLength(0);
+    expect(store.decisions).toHaveLength(0); // degrades to empty (no crash)
     expect(vi.mocked(logger.warning)).toHaveBeenCalledWith(
-      expect.stringContaining('decisions store: failed to read'),
+      expect.stringContaining('store quarantine'),
     );
+    // The corrupt bytes are preserved on disk, not dropped.
+    const entries = await readdir(dir);
+    expect(entries.some((e) => e.startsWith('pending.json.corrupt-'))).toBe(true);
   });
 });
 

--- a/src/core/decisions/store.ts
+++ b/src/core/decisions/store.ts
@@ -2,58 +2,88 @@
  * Decision store — CRUD for .openlore/decisions/pending.json
  */
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createHash } from 'node:crypto';
-import { logger } from '../../utils/logger.js';
 import {
   OPENLORE_DIR,
   OPENLORE_DECISIONS_SUBDIR,
   DECISIONS_PENDING_FILE,
 } from '../../constants.js';
 import { fileExists } from '../../utils/command-helpers.js';
+import { atomicWriteFile, casUpdate, quarantineCorrupt } from './atomic-store.js';
 import type { PendingDecision, DecisionStore, DecisionStatus } from '../../types/index.js';
 
 export function decisionsDir(rootPath: string): string {
   return join(rootPath, OPENLORE_DIR, OPENLORE_DECISIONS_SUBDIR);
 }
 
+function decisionsPath(rootPath: string): string {
+  return join(decisionsDir(rootPath), DECISIONS_PENDING_FILE);
+}
+
 export async function loadDecisionStore(rootPath: string): Promise<DecisionStore> {
-  const path = join(decisionsDir(rootPath), DECISIONS_PENDING_FILE);
+  const path = decisionsPath(rootPath);
   if (!(await fileExists(path))) {
     return emptyStore();
   }
+  let raw: string;
   try {
-    const raw = await readFile(path, 'utf-8');
-    const parsed: unknown = JSON.parse(raw);
-    // Untrusted artifact: validate top-level shape before use. A malformed store
-    // (non-object, or no `decisions` array) starts fresh rather than letting a
-    // poisoned shape reach `store.decisions.*` downstream (mcp-security).
-    if (parsed === null || typeof parsed !== 'object' || !Array.isArray((parsed as { decisions?: unknown }).decisions)) {
-      logger.warning(`decisions store: ${path} has an invalid shape — starting fresh`);
-      return emptyStore();
-    }
-    return parsed as DecisionStore;
+    raw = await readFile(path, 'utf-8');
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT') {
-      logger.warning(
-        `decisions store: failed to read ${path} (${(err as Error).message}) — starting fresh`
-      );
-    }
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return emptyStore();
+    // A genuine read fault (not corruption) — quarantine so the file is preserved
+    // and the loss is loud, never a silent empty store.
+    await quarantineCorrupt(path, `read failed: ${(err as Error).message}`);
     return emptyStore();
   }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    // Torn / hand-corrupted JSON: quarantine, never silently empty. Silent memory
+    // loss presents absence as current fact. (harden-memory-integrity-invariant)
+    await quarantineCorrupt(path, `invalid JSON: ${(err as Error).message}`);
+    return emptyStore();
+  }
+  // Untrusted artifact: validate top-level shape before use. A malformed store
+  // (non-object, or no `decisions` array) is quarantined rather than letting a
+  // poisoned shape reach `store.decisions.*` downstream (mcp-security).
+  if (parsed === null || typeof parsed !== 'object' || !Array.isArray((parsed as { decisions?: unknown }).decisions)) {
+    await quarantineCorrupt(path, 'invalid shape (missing decisions array)');
+    return emptyStore();
+  }
+  const store = parsed as DecisionStore;
+  if (typeof store.sequence !== 'number') store.sequence = 0; // legacy default
+  return store;
 }
 
 export async function saveDecisionStore(rootPath: string, store: DecisionStore): Promise<void> {
-  const dir = decisionsDir(rootPath);
-  await mkdir(dir, { recursive: true });
-  const updated: DecisionStore = { ...store, updatedAt: new Date().toISOString() };
-  await writeFile(
-    join(dir, DECISIONS_PENDING_FILE),
-    JSON.stringify(updated, null, 2) + '\n',
-    'utf-8'
-  );
+  const updated: DecisionStore = {
+    ...store,
+    updatedAt: new Date().toISOString(),
+    sequence: (store.sequence ?? 0) + 1,
+  };
+  await atomicWriteFile(decisionsPath(rootPath), JSON.stringify(updated, null, 2) + '\n');
+}
+
+/**
+ * Concurrency-safe read-modify-write of the decision store. Loads, applies
+ * `mutate` (a pure id-keyed merge such as {@link upsertDecisions} /
+ * {@link patchDecision}), and commits under compare-and-swap so two concurrent
+ * writers never lose a decision — on a conflict the mutate is re-applied to the
+ * newer store. (harden-memory-integrity-invariant)
+ */
+export async function updateDecisionStore(
+  rootPath: string,
+  mutate: (store: DecisionStore) => DecisionStore,
+): Promise<DecisionStore> {
+  return casUpdate<DecisionStore>({
+    storePath: decisionsPath(rootPath),
+    load: () => loadDecisionStore(rootPath),
+    mutate: (current) => ({ ...mutate(current), updatedAt: new Date().toISOString() }),
+    serialize: (next) => JSON.stringify(next, null, 2) + '\n',
+  });
 }
 
 /**
@@ -143,6 +173,7 @@ function emptyStore(): DecisionStore {
     version: '1',
     sessionId: newSessionId(),
     updatedAt: new Date().toISOString(),
+    sequence: 0,
     decisions: [],
   };
 }

--- a/src/core/decisions/syncer.test.ts
+++ b/src/core/decisions/syncer.test.ts
@@ -293,7 +293,6 @@ describe('syncApprovedDecisions — filesystem writes', () => {
   });
 
   it('purges inactive decisions from store before saving', async () => {
-    const { saveDecisionStore } = await import('./store.js');
     const approved = makeDecision({ id: 'app00001', status: 'approved', affectedDomains: ['services'] });
     const rejected = makeDecision({ id: 'rej00001', status: 'rejected' });
     const synced = makeDecision({ id: 'syn00001', status: 'synced' });
@@ -301,15 +300,14 @@ describe('syncApprovedDecisions — filesystem writes', () => {
     const store = makeStore([approved, rejected, synced, verified]);
     const specMap = makeSpecMap('services', 'openspec/specs/services/spec.md');
 
-    await syncApprovedDecisions(store, {
+    const { store: persisted } = await syncApprovedDecisions(store, {
       rootPath: tmpDir,
       openspecPath: join(tmpDir, 'openspec'),
       specMap,
     });
 
-    const saved = vi.mocked(saveDecisionStore).mock.calls.at(-1)?.[1];
-    expect(saved).toBeDefined();
-    const ids = saved!.decisions.map((d) => d.id);
+    // syncer persists via CAS; the returned store is the committed (purged) result.
+    const ids = persisted.decisions.map((d) => d.id);
     // rejected + synced (original) purged; newly-synced approved also purged; verified kept
     expect(ids).not.toContain('rej00001');
     expect(ids).not.toContain('syn00001');

--- a/src/core/decisions/syncer.ts
+++ b/src/core/decisions/syncer.ts
@@ -12,7 +12,7 @@ import { fileExists } from '../../utils/command-helpers.js';
 import { logger } from '../../utils/logger.js';
 import { parseSpecHeader } from '../drift/spec-mapper.js';
 import type { PendingDecision, DecisionStore, SpecMap, DecisionScope } from '../../types/index.js';
-import { patchDecision, purgeInactiveDecisions, saveDecisionStore } from './store.js';
+import { patchDecision, purgeInactiveDecisions, updateDecisionStore } from './store.js';
 
 /**
  * ADRs are durable architectural memory, not a log of every implementation choice.
@@ -70,7 +70,22 @@ export async function syncApprovedDecisions(
     // Invariant: store and ADR files agree — a decision is removed from store only after
     // status='synced', which is set only after spec + ADR writes succeed (or are skipped).
     // Partial failure leaves the decision in store at status='approved', safe to retry.
-    await saveDecisionStore(options.rootPath, purgeInactiveDecisions(updatedStore));
+    //
+    // CAS persist: the synced snapshot (`updatedStore`) is authoritative for the
+    // decisions being synced, but we graft in any decision present on disk yet
+    // absent from the snapshot — a draft recorded concurrently — so a competing
+    // write is preserved rather than clobbered.
+    const snapshot = updatedStore;
+    const snapshotIds = new Set(snapshot.decisions.map((d) => d.id));
+    updatedStore = await updateDecisionStore(options.rootPath, (disk) => {
+      const extras = disk.decisions.filter((d) => !snapshotIds.has(d.id));
+      return purgeInactiveDecisions({
+        ...snapshot,
+        sessionId: disk.sessionId,
+        lastConsolidatedAt: disk.lastConsolidatedAt ?? snapshot.lastConsolidatedAt,
+        decisions: [...snapshot.decisions, ...extras],
+      });
+    });
   }
 
   return {

--- a/src/core/services/mcp-handlers/decisions.test.ts
+++ b/src/core/services/mcp-handlers/decisions.test.ts
@@ -62,6 +62,7 @@ import {
 import { validateDirectory } from './utils.js';
 import { readOpenLoreConfig } from '../config-manager.js';
 import { syncApprovedDecisions } from '../../decisions/syncer.js';
+import { updateDecisionStore } from '../../decisions/store.js';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -323,6 +324,34 @@ describe('handleApproveDecision', () => {
     expect(result.error).toMatch(/already synced/);
     const store = await readStore(tmpDir);
     expect(store.decisions[0].status).toBe('synced');
+  });
+
+  it('reports honestly (no false success) when the decision is removed during approval', async () => {
+    // C9: the decision passes the pre-check, then a concurrent writer removes it
+    // before the CAS commit. The handler must NOT claim success for a no-op patch.
+    const decision = makeDecision({ id: 'abc12345', status: 'draft', title: 'Race me' });
+    await writeStore(tmpDir, makeStore({ decisions: [decision] }));
+
+    // The wipe goes straight to a CAS write while approve still has loadDecisionStore
+    // ahead of its own CAS, so the wipe wins the lock and the decision is gone at
+    // approve's commit.
+    const [result] = await Promise.all([
+      handleApproveDecision(tmpDir, 'abc12345'),
+      updateDecisionStore(tmpDir, (s) => ({ ...s, decisions: [] })),
+    ]);
+
+    // Honesty invariant: either a clean approval (the decision was present at the
+    // approve commit) or the explicit concurrent-removal error — never a false
+    // 'approved' for a decision that is not actually approved on disk.
+    const r = result as { status?: string; error?: string };
+    const store = await readStore(tmpDir);
+    const onDisk = store.decisions.find((d) => d.id === 'abc12345');
+    if (r.status === 'approved') {
+      expect(onDisk?.status).toBe('approved');
+    } else {
+      expect(r.error).toMatch(/concurrently/);
+      expect(onDisk).toBeUndefined();
+    }
   });
 });
 

--- a/src/core/services/mcp-handlers/decisions.ts
+++ b/src/core/services/mcp-handlers/decisions.ts
@@ -13,7 +13,7 @@ import { validateDirectory, sanitizeMcpError, safeOpenspecDir } from './utils.js
 import { emit } from '../telemetry.js';
 import {
   loadDecisionStore,
-  saveDecisionStore,
+  updateDecisionStore,
   upsertDecisions,
   patchDecision,
   makeDecisionId,
@@ -154,14 +154,22 @@ export async function handleRecordDecision(
       syncedToSpecs: [],
     };
 
-    const updated = upsertDecisions(store, [decision]);
-    await saveDecisionStore(rootPath, updated);
+    // CAS upsert so concurrent record_decision calls never lose a draft: the
+    // id-keyed merge is re-applied to the latest store on a write conflict.
+    // The decision id is derived from the committed store's sessionId (not the
+    // separately-loaded one) so repeated records in a session dedupe correctly —
+    // a fresh load of an absent store mints a new random sessionId. (harden-memory-integrity-invariant)
+    let recordedId = id;
+    await updateDecisionStore(rootPath, (s) => {
+      recordedId = makeDecisionId(s.sessionId, primaryDomain, title.trim());
+      return upsertDecisions(s, [{ ...decision, id: recordedId, sessionId: s.sessionId }]);
+    });
 
     // Consolidate in background so commit-time gate is instant
     spawnConsolidateBackground(rootPath);
 
     return {
-      id,
+      id: recordedId,
       message: `Decision recorded: "${title}". Consolidation running in background.`,
     };
   } catch (err) {
@@ -224,12 +232,11 @@ export async function handleApproveDecision(
     if (!decision) return { error: `Decision ${id} not found.` };
     if (decision.status === 'synced') return { error: `Decision ${id} is already synced to spec files — re-approval not allowed.` };
 
-    const updated = patchDecision(store, id, {
+    await updateDecisionStore(rootPath, (s) => patchDecision(s, id, {
       status: 'approved',
       reviewedAt: new Date().toISOString(),
       reviewNote: note,
-    });
-    await saveDecisionStore(rootPath, updated);
+    }));
     emit(rootPath, 'decisions', { event: 'decision_approved', id, title: decision.title });
 
     return { id, status: 'approved', title: decision.title };
@@ -254,12 +261,11 @@ export async function handleRejectDecision(
     const decision = store.decisions.find((d) => d.id === id);
     if (!decision) return { error: `Decision ${id} not found.` };
 
-    const updated = patchDecision(store, id, {
+    await updateDecisionStore(rootPath, (s) => patchDecision(s, id, {
       status: 'rejected',
       reviewedAt: new Date().toISOString(),
       reviewNote: note,
-    });
-    await saveDecisionStore(rootPath, updated);
+    }));
     emit(rootPath, 'decisions', { event: 'decision_rejected', id, title: decision.title });
 
     return { id, status: 'rejected', title: decision.title };

--- a/src/core/services/mcp-handlers/decisions.ts
+++ b/src/core/services/mcp-handlers/decisions.ts
@@ -232,11 +232,17 @@ export async function handleApproveDecision(
     if (!decision) return { error: `Decision ${id} not found.` };
     if (decision.status === 'synced') return { error: `Decision ${id} is already synced to spec files — re-approval not allowed.` };
 
-    await updateDecisionStore(rootPath, (s) => patchDecision(s, id, {
+    const committed = await updateDecisionStore(rootPath, (s) => patchDecision(s, id, {
       status: 'approved',
       reviewedAt: new Date().toISOString(),
       reviewNote: note,
     }));
+    // The patch no-ops if the decision was concurrently removed/synced — report
+    // honestly rather than a false success.
+    const after = committed.decisions.find((d) => d.id === id);
+    if (!after || after.status !== 'approved') {
+      return { error: `Decision ${id} could not be approved — it was concurrently removed or changed.` };
+    }
     emit(rootPath, 'decisions', { event: 'decision_approved', id, title: decision.title });
 
     return { id, status: 'approved', title: decision.title };
@@ -261,11 +267,15 @@ export async function handleRejectDecision(
     const decision = store.decisions.find((d) => d.id === id);
     if (!decision) return { error: `Decision ${id} not found.` };
 
-    await updateDecisionStore(rootPath, (s) => patchDecision(s, id, {
+    const committed = await updateDecisionStore(rootPath, (s) => patchDecision(s, id, {
       status: 'rejected',
       reviewedAt: new Date().toISOString(),
       reviewNote: note,
     }));
+    const after = committed.decisions.find((d) => d.id === id);
+    if (!after || after.status !== 'rejected') {
+      return { error: `Decision ${id} could not be rejected — it was concurrently removed or changed.` };
+    }
     emit(rootPath, 'decisions', { event: 'decision_rejected', id, title: decision.title });
 
     return { id, status: 'rejected', title: decision.title };

--- a/src/core/services/mcp-handlers/memory-invariant.test.ts
+++ b/src/core/services/mcp-handlers/memory-invariant.test.ts
@@ -1,0 +1,249 @@
+/**
+ * AuthoritativeRecallInvariant — the named, test-enforced brand promise.
+ * (change: harden-memory-integrity-invariant)
+ *
+ * The invariant, verbatim:
+ *
+ *   No memory whose freshness verdict is `drifted` or `orphaned` ever appears in
+ *   an authoritative recall path UNLABELED. An `orphaned` memory is fully withheld
+ *   from the authoritative set; a `drifted` memory may remain only when carrying an
+ *   explicit `verify` label. The authoritative recall paths are the `recall` tool
+ *   and the memory (decision) section of `orient`.
+ *
+ * This is the operational definition of the project promise — *OpenLore never
+ * serves an unverified or stale fact as authoritative* — guarded by a property
+ * test that generates arbitrary memories and arbitrary code mutations and asserts
+ * the property holds for every generated case.
+ *
+ * Plain .test.ts so CI runs it.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// orient gates on "an index exists"; mock only the vector-index surface (orthogonal
+// to freshness). Harmless to the recall path, which does not touch it.
+vi.mock('../../analyzer/vector-index.js', () => ({
+  VectorIndex: { exists: vi.fn(() => true), search: vi.fn(async () => []) },
+}));
+vi.mock('../../analyzer/embedding-service.js', () => ({
+  EmbeddingService: { fromEnv: vi.fn(() => { throw new Error('no env'); }), fromConfig: vi.fn(() => null) },
+}));
+vi.mock('../../analyzer/spec-vector-index.js', () => ({
+  SpecVectorIndex: { exists: vi.fn(() => false), search: vi.fn(async () => []) },
+}));
+
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { EdgeStore } from '../edge-store.js';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_LLM_CONTEXT, MEMORY_NOTES_FILE } from '../../../constants.js';
+import { memoryDir } from '../../decisions/memory-store.js';
+import { handleRemember, handleRecall } from './memory.js';
+import { handleOrient } from './orient.js';
+import type { FunctionNode } from '../../analyzer/call-graph.js';
+
+// ── deterministic PRNG (replayable; no new dependency) ────────────────────────
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const FN_COUNT = 5;
+const fnName = (k: number) => `fn${k}`;
+const fnFile = (k: number) => `src/m${k}.ts`;
+const fnSrc = (k: number, body: string) => `export function ${fnName(k)}() {\n  ${body}\n}\n`;
+
+let root: string;
+const ANALYSIS = () => join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+
+function nodeFor(k: number, src: string): FunctionNode {
+  return {
+    id: `${fnFile(k)}::${fnName(k)}`,
+    name: fnName(k),
+    filePath: fnFile(k),
+    isAsync: false,
+    language: 'typescript',
+    startIndex: 0,
+    endIndex: Buffer.byteLength(src, 'utf-8'),
+    fanIn: 0,
+    fanOut: 0,
+  };
+}
+
+async function buildStore(nodes: FunctionNode[]): Promise<void> {
+  await mkdir(ANALYSIS(), { recursive: true });
+  const store = EdgeStore.open(EdgeStore.dbPath(ANALYSIS()));
+  store.clearAll();
+  store.insertNodes(nodes);
+  store.close();
+  // orient also reads the cached call-graph artifact to decide "analysis exists".
+  const callGraph = {
+    nodes, edges: [], classes: [], inheritanceEdges: [],
+    hubFunctions: [], entryPoints: [], layerViolations: [],
+    stats: { totalNodes: nodes.length, totalEdges: 0, avgFanIn: 0, avgFanOut: 0 },
+  };
+  await writeFile(join(ANALYSIS(), ARTIFACT_LLM_CONTEXT), JSON.stringify({ callGraph }), 'utf-8');
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  root = await mkdtemp(join(tmpdir(), 'openlore-invariant-'));
+  await mkdir(join(root, 'src'), { recursive: true });
+});
+afterEach(async () => { await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 }); });
+
+type RecalledItem = { freshness: string; verify?: boolean; kind?: string; id?: string };
+
+/** Assert the invariant against one recall response. */
+function assertRecallInvariant(r: {
+  authoritative: RecalledItem[];
+  needsReanchoring: RecalledItem[];
+}, label: string): void {
+  for (const item of r.authoritative) {
+    // (1) orphaned is NEVER authoritative — fully withheld.
+    expect(item.freshness, `${label}: orphaned leaked into authoritative`).not.toBe('orphaned');
+    // (2) any non-fresh authoritative entry MUST carry the explicit verify label.
+    if (item.freshness !== 'fresh') {
+      expect(item.verify, `${label}: unlabeled ${item.freshness} in authoritative`).toBe(true);
+    }
+  }
+  // needsReanchoring holds only orphaned memories.
+  for (const item of r.needsReanchoring) {
+    expect(item.freshness, `${label}: non-orphaned in needsReanchoring`).toBe('orphaned');
+  }
+}
+
+describe('AuthoritativeRecallInvariant — recall, property-based over generated mutations', () => {
+  it('the authoritative set never contains an orphaned or unlabeled-drifted memory (120 generated cases)', async () => {
+    for (let trial = 0; trial < 120; trial++) {
+      const rand = rng(0x1000 + trial);
+
+      // Fresh baseline: every function present and unmodified.
+      const baseSrc = Array.from({ length: FN_COUNT }, (_, k) => fnSrc(k, `return ${k};`));
+      for (let k = 0; k < FN_COUNT; k++) await writeFile(join(root, fnFile(k)), baseSrc[k], 'utf-8');
+      await buildStore(baseSrc.map((s, k) => nodeFor(k, s)));
+
+      // Anchor one memory per function (plus an occasional unanchored note).
+      for (let k = 0; k < FN_COUNT; k++) {
+        await handleRemember(root, `memory about ${fnName(k)} number ${trial}`, [{ symbol: fnName(k), file: fnFile(k) }]);
+      }
+      if (rand() < 0.5) await handleRemember(root, `free-floating note ${trial}`);
+
+      // Apply an arbitrary mutation plan: keep / edit-body (→drift) / delete (→orphan).
+      const survivors: FunctionNode[] = [];
+      for (let k = 0; k < FN_COUNT; k++) {
+        const roll = rand();
+        if (roll < 0.34) {
+          // keep fresh
+          survivors.push(nodeFor(k, baseSrc[k]));
+        } else if (roll < 0.67) {
+          // edit body in place → span hash differs → drifted (node stays in store)
+          const edited = fnSrc(k, `return ${k * 100 + trial};`);
+          await writeFile(join(root, fnFile(k)), edited, 'utf-8');
+          survivors.push(nodeFor(k, baseSrc[k])); // stale offsets/hash on purpose
+        } else if (roll < 0.84) {
+          // delete the node from the graph → orphaned
+          // (file may or may not remain; symbol-level anchor still orphans)
+        } else {
+          // delete the whole file too → orphaned
+          await rm(join(root, fnFile(k)), { force: true });
+        }
+      }
+      await buildStore(survivors);
+
+      const r = (await handleRecall(root, undefined, 50)) as {
+        authoritative: RecalledItem[]; needsReanchoring: RecalledItem[];
+      };
+      assertRecallInvariant(r, `recall trial ${trial}`);
+
+      // Reset for the next trial: clear the source tree and the notes store. The
+      // edge store is reset by buildStore's clearAll, so we avoid rm-ing the
+      // .openlore dir (which races with the SQLite file handle on some platforms).
+      await rm(join(root, 'src'), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+      await rm(join(memoryDir(root), MEMORY_NOTES_FILE), { force: true });
+      await mkdir(join(root, 'src'), { recursive: true });
+    }
+  }, 60_000);
+});
+
+// orient surfaces decisions (not notes); the property mirrors recall over the
+// decision store. Decisions are anchored to files via affectedFiles, so a deleted
+// file orphans, a changed-symbol anchor drifts, an untouched file stays fresh.
+async function writeDecisions(decisions: Array<Record<string, unknown>>): Promise<void> {
+  const dir = join(root, OPENLORE_DIR, 'decisions');
+  await mkdir(dir, { recursive: true });
+  const full = decisions.map((d) => ({
+    status: 'approved', title: 'untitled', rationale: '', consequences: '', proposedRequirement: null,
+    affectedDomains: [], affectedFiles: [], sessionId: 's', recordedAt: '2026-01-01T00:00:00Z',
+    confidence: 'medium', syncedToSpecs: [], ...d,
+  }));
+  await writeFile(join(dir, 'pending.json'), JSON.stringify({ version: '1', sessionId: 's', updatedAt: '', decisions: full }), 'utf-8');
+}
+
+describe('AuthoritativeRecallInvariant — orient decision section, property-based', () => {
+  it('pendingDecisions never lists an orphaned decision; staleDecisions holds only orphaned (120 cases)', async () => {
+    for (let trial = 0; trial < 120; trial++) {
+      const rand = rng(0x2000 + trial);
+
+      const baseSrc = Array.from({ length: FN_COUNT }, (_, k) => fnSrc(k, `return ${k};`));
+      for (let k = 0; k < FN_COUNT; k++) await writeFile(join(root, fnFile(k)), baseSrc[k], 'utf-8');
+      await buildStore(baseSrc.map((s, k) => nodeFor(k, s)));
+
+      // One approved decision per function, symbol-anchored to it.
+      const decisions = Array.from({ length: FN_COUNT }, (_, k) => ({
+        id: `dec${k}`,
+        title: `decision about ${fnName(k)}`,
+        affectedFiles: [fnFile(k)],
+        anchors: [{ nodeId: `${fnFile(k)}::${fnName(k)}`, symbolName: fnName(k), filePath: fnFile(k), contentHash: '__RECORDED__' }],
+      }));
+      // Capture the real recorded span hash so "keep" stays fresh.
+      const { hashSpan } = await import('../../decisions/anchor.js');
+      for (let k = 0; k < FN_COUNT; k++) {
+        (decisions[k].anchors[0] as { contentHash: string }).contentHash = hashSpan(baseSrc[k]);
+      }
+
+      const survivors: FunctionNode[] = [];
+      for (let k = 0; k < FN_COUNT; k++) {
+        const roll = rand();
+        if (roll < 0.34) {
+          survivors.push(nodeFor(k, baseSrc[k]));
+        } else if (roll < 0.67) {
+          // change the symbol → drift (node remains, hash differs)
+          const edited = fnSrc(k, `return ${k * 100 + trial};`);
+          survivors.push(nodeFor(k, edited));
+        } else {
+          // delete the node (and sometimes the file) → orphan
+          if (roll > 0.84) await rm(join(root, fnFile(k)), { force: true });
+        }
+      }
+      await buildStore(survivors);
+      await writeDecisions(decisions);
+
+      const r = (await handleOrient(root, `work on ${fnName(0)} ${fnName(1)} ${fnName(2)} ${fnName(3)} ${fnName(4)}`)) as {
+        error?: string;
+        pendingDecisions?: Array<{ id: string; freshness?: string; verify?: boolean }>;
+        staleDecisions?: Array<{ id: string; freshness?: string }>;
+      };
+      expect(r.error, `orient trial ${trial}`).toBeUndefined();
+
+      for (const d of r.pendingDecisions ?? []) {
+        expect(d.freshness, `orient trial ${trial}: orphaned in pendingDecisions`).not.toBe('orphaned');
+        if (d.freshness && d.freshness !== 'fresh') {
+          expect(d.verify, `orient trial ${trial}: unlabeled ${d.freshness} in pendingDecisions`).toBe(true);
+        }
+      }
+      for (const d of r.staleDecisions ?? []) {
+        expect(d.freshness, `orient trial ${trial}: non-orphaned in staleDecisions`).toBe('orphaned');
+      }
+
+      // Reset the source tree only; buildStore.clearAll resets the edge store and
+      // writeDecisions overwrites pending.json next trial.
+      await rm(join(root, 'src'), { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+      await mkdir(join(root, 'src'), { recursive: true });
+    }
+  }, 60_000);
+});

--- a/src/core/services/mcp-handlers/memory.ts
+++ b/src/core/services/mcp-handlers/memory.ts
@@ -16,7 +16,7 @@
 
 import { validateDirectory, sanitizeMcpError } from './utils.js';
 import { loadDecisionStore, INACTIVE_STATUSES } from '../../decisions/store.js';
-import { loadMemoryStore, saveMemoryStore, makeMemoryId } from '../../decisions/memory-store.js';
+import { loadMemoryStore, updateMemoryStore, makeMemoryId } from '../../decisions/memory-store.js';
 import { AnchorContext } from '../../decisions/anchor-adapter.js';
 import { memoryFreshness, decisionAnchors, type GraphFreshnessView } from '../../decisions/anchor.js';
 import type {
@@ -70,9 +70,12 @@ export async function handleRemember(
       tags: tags?.length ? tags : undefined,
     };
 
-    const store = await loadMemoryStore(rootPath);
-    store.memories = [...store.memories.filter((m) => m.id !== memory.id), memory];
-    await saveMemoryStore(rootPath, store);
+    // CAS update so concurrent remember calls never lose a write: the id-keyed
+    // upsert is re-applied to the latest store on a write conflict.
+    await updateMemoryStore(rootPath, (store) => ({
+      ...store,
+      memories: [...store.memories.filter((m) => m.id !== memory.id), memory],
+    }));
 
     return {
       id: memory.id,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -462,6 +462,12 @@ export interface DecisionStore {
   /** Cleared when a new session starts (new commit cycle) */
   sessionId: string;
   updatedAt: string;
+  /**
+   * Monotonic write counter for atomic compare-and-swap on save
+   * (change: harden-memory-integrity-invariant). Additive — defaults to 0 for
+   * legacy stores written before this field existed.
+   */
+  sequence?: number;
   /** Set after consolidation runs — gate uses this to skip no_decisions_recorded warning */
   lastConsolidatedAt?: string;
   decisions: PendingDecision[];
@@ -536,5 +542,11 @@ export interface AnchoredMemory {
 export interface MemoryStore {
   version: '1';
   updatedAt: string;
+  /**
+   * Monotonic write counter for atomic compare-and-swap on save
+   * (change: harden-memory-integrity-invariant). Additive — defaults to 0 for
+   * legacy stores written before this field existed.
+   */
+  sequence?: number;
   memories: AnchoredMemory[];
 }


### PR DESCRIPTION
## Why

OpenLore's one defensible promise is a single sentence: **never serve an unverified or stale fact as authoritative.** The mechanism existed (`anchorFreshness` + the recall withholding path), but two assumptions were unguarded:

1. **The substrate was not safe for concurrent agents.** Both stores (`notes.json`, `pending.json`) were single JSON files rewritten in full — no locking, no atomic replace. Concurrent `remember` / `record_decision` silently dropped writes, and a crash mid-write could leave a torn file that loaded as a **silent empty store**.
2. **The invariant was asserted, not adversarially proven.** Freshness had happy-path coverage but no property tests against the edits that actually break content-addressed anchoring (rename/move/delete, whitespace/comment-only edits, multibyte boundaries, hash collisions).

## What changed

**Invariant (tests prove the promise):**
- `memory-invariant.test.ts` — names and property-tests the **AuthoritativeRecallInvariant** over `recall` and the `orient` memory section: no `drifted`/`orphaned` memory ever appears in an authoritative set unlabeled. Generates arbitrary memories × arbitrary code mutations.
- `anchor-adversarial.test.ts` — rename/move/delete → `orphaned`; whitespace/comment-only edits → `drifted`; multibyte UTF-8 span boundaries hash byte-correctly; truncated-hash collision-freedom property. **Governing rule: a false-`fresh` fails the suite; a false-`orphaned` is acceptable.**

**Durability (`atomic-store.ts`):**
- Atomic temp-write + `fsync` + `rename` + **directory `fsync`**; a crash mid-write leaves the prior committed store intact, never torn. Temp files are uniquely named per write and removed on failure.
- Monotonic `sequence` field (additive, defaults `0`).
- **A single per-store advisory lock is the serialization point**: the whole load→mutate→write runs inside it, so `mutate` always sees the freshest store. The lock carries an **ownership token** (released only if still ours, so a stolen-stale hold can't be freed out from under its new owner); a crashed holder's lock is reclaimed (10s) well before a waiter gives up (30s), and a wait timeout **fails loud** rather than writing unlocked.
- **Every decision-store writer routes through the one CAS path** (record, approve/reject, consolidation, sync, HTTP API, CLI gate-TUI) — a raw lock-free overwrite is prohibited. Closes the cross-path lost-update seam (background consolidation clobbering a concurrent `record_decision`, the spec-15 bug).
- **Corrupt-store quarantine** to `*.corrupt-<n>` with an **atomic claim** (hard link that fails if the path exists), so concurrent loaders never overwrite each other's quarantine file — never silently emptied.
- **Honest status:** approve/reject verify the committed store reflects the change and return an explicit concurrent-removal error instead of a false success.

**Gate (`gate-state.ts`):**
- Extracted the pre-commit gate reason machine into a pure classifier, property-tested for **totality**, **determinism/idempotence**, and **deadlock-freedom**. `decisions.ts` delegates to it (behavior-preserving).

## How it was verified
- **Adversarial review** by an independent reviewer; all critical/high findings (mixed CAS/non-CAS writers, optimistic-snapshot CAS, temp-name collision, lock-release-on-timeout, missing dir fsync) and the medium/low residue (lock-steal token, fail-loud timeout, quarantine overwrite, false-success) are fixed in this PR.
- Full suite: **3738 passing** / 2 skipped (181 files); `tsc` clean; `check_spec_drift` → **no drift**.
- Dogfooded compiled code: 40 concurrent `remember` → 40/40; 10 rapid `record_decision` (each spawning a background consolidation) → 10/10, store intact; consolidation-replace racing concurrent records loses neither; stale lock stolen and released cleanly; concurrent quarantine preserves the bytes exactly once; corrupt store quarantined (not silent-empty); refactored CLI gate → correct `no_decisions_recorded` JSON.

## Constraints honored
- **No new dependency**, **no LLM** — atomic rename + advisory lock + property generators are stdlib/test-stack only.
- **Schema extended additively** — `sequence` defaults to `0`; legacy stores load unchanged.
- **No behavior change to a single-writer session.**

## Specs
`mcp-handlers`: AuthoritativeRecallInvariant, FreshnessFailsSafeTowardDistrust, ConcurrentMemoryWriteSafety. `architecture`: DurableAtomicStorePersistence (single-lock serialization + ownership token + fail-loud + dir fsync + all-writers-CAS), CorruptStoreQuarantineNotSilentEmpty (atomic claim). `cli`: GateReasonMachineIsAPureTotalClassifier, AllDecisionStoreWritersUseAtomicCompareAndSwap. `api`: DecisionApiWritesUseAtomicCompareAndSwap. Linked from `CODEBASE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)