### PR TITLE
feat(pi): readable tool rendering + clearer, trigger-first tool surface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.79.4",
         "@earendil-works/pi-coding-agent": "^0.79.4",
+        "@earendil-works/pi-tui": "^0.79.4",
         "@eslint/js": "^9.17.0",
         "@types/node": "^22.10.5",
         "@vitest/coverage-v8": "^4.0.18",
@@ -520,8 +521,6 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
-      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -534,14 +533,10 @@
     },
     "node_modules/@babel/code-frame/node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -549,8 +544,6 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -586,8 +579,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -602,8 +593,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.7",
@@ -618,8 +607,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -627,8 +614,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -636,8 +621,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
-      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -645,8 +628,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
-      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -658,8 +639,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.29.7",
@@ -682,8 +661,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
-      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -691,8 +668,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
-      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -700,8 +675,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -709,8 +682,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.29.7",
@@ -722,8 +693,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -771,8 +740,6 @@
     },
     "node_modules/@babel/template": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
-      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -785,8 +752,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -803,8 +768,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -823,7 +786,7 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.4",
+      "version": "0.79.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -846,13 +809,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.4",
+      "version": "0.79.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.4",
-        "@earendil-works/pi-ai": "^0.79.4",
-        "@earendil-works/pi-tui": "^0.79.4",
+        "@earendil-works/pi-agent-core": "^0.79.6",
+        "@earendil-works/pi-ai": "^0.79.6",
+        "@earendil-works/pi-tui": "^0.79.6",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -880,26 +843,14 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.4",
+      "version": "0.79.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.4",
+        "@earendil-works/pi-ai": "^0.79.6",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1120,17 +1071,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
       "version": "4.2.11",
       "dev": true,
@@ -1169,17 +1109,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "15.0.12",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -1250,6 +1179,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.79.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1353,6 +1294,8 @@
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1368,8 +1311,6 @@
     },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -2725,6 +2666,8 @@
     },
     "node_modules/@lancedb/lancedb-darwin-arm64": {
       "version": "0.22.4-beta.3",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.22.4-beta.3.tgz",
+      "integrity": "sha512-o7rFPHlpydNq2DbEDf1QBNUhxuvD/7r0jYn7SX42amIeclDGKwevTFIESlBg7Wo/dfpxHNq+x17J6TQJJJbMbQ==",
       "cpu": [
         "arm64"
       ],
@@ -2739,8 +2682,6 @@
     },
     "node_modules/@lancedb/lancedb-darwin-x64": {
       "version": "0.22.4-beta.3",
-      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-x64/-/lancedb-darwin-x64-0.22.4-beta.3.tgz",
-      "integrity": "sha512-TkAz9Eo5Y63xgxQLnw0OOT92IUwRsX39je1TiwcrzI2IqxJ2wD3O1/2Of0UvtlLME2kDEgFyurwrTegYogMoig==",
       "cpu": [
         "x64"
       ],
@@ -3039,6 +2980,8 @@
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -3053,8 +2996,6 @@
     },
     "node_modules/@rolldown/binding-darwin-x64": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -4082,8 +4023,6 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.37",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
-      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4138,8 +4077,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4216,8 +4153,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4520,9 +4455,7 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.373",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
-      "integrity": "sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==",
+      "version": "1.5.374",
       "license": "ISC"
     },
     "node_modules/encodeurl": {
@@ -4603,8 +4536,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5148,7 +5079,7 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.4.0",
+      "version": "1.6.0",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5580,8 +5511,6 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -5648,8 +5577,6 @@
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/jwa": {
@@ -5740,6 +5667,8 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -5758,8 +5687,6 @@
     },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -6040,6 +5967,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
@@ -6235,8 +6173,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.47",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6549,7 +6485,7 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.3",
+      "version": "8.6.4",
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -7520,8 +7456,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -7867,8 +7801,6 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.79.4",
     "@earendil-works/pi-coding-agent": "^0.79.4",
+    "@earendil-works/pi-tui": "^0.79.4",
     "@eslint/js": "^9.17.0",
     "@types/node": "^22.10.5",
     "@vitest/coverage-v8": "^4.0.18",

--- a/src/pi/extension.test.ts
+++ b/src/pi/extension.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { modelsUrl, stripMarker, isUsableConfig, readConfig } from './extension.js';
+import { modelsUrl, stripMarker, isUsableConfig, readConfig, formatToolResult, formatCallArgs } from './extension.js';
 
 describe('modelsUrl', () => {
   it('appends /v1/models to a bare host', () => {
@@ -46,6 +46,192 @@ describe('isUsableConfig', () => {
     expect(isUsableConfig({})).toBe(false);
     expect(isUsableConfig({ generation: {} })).toBe(false);
     expect(isUsableConfig({ generation: { provider: 42 } })).toBe(false);
+  });
+});
+
+describe('formatToolResult', () => {
+  it('passes strings through unchanged', () => {
+    expect(formatToolResult('plain text')).toBe('plain text');
+  });
+
+  it('renders an error shape as a warning line', () => {
+    expect(formatToolResult({ error: 'daemon down' })).toBe('⚠ daemon down');
+  });
+
+  it('handles null/undefined and primitives', () => {
+    expect(formatToolResult(null)).toBe('(no result)');
+    expect(formatToolResult(undefined)).toBe('(no result)');
+    expect(formatToolResult(42)).toBe('42');
+  });
+
+  it('renders arrays as bounded bullet lists capped at 6 with a count', () => {
+    const items = Array.from({ length: 15 }, (_, i) => ({ name: `fn${i}`, fanIn: i }));
+    const out = formatToolResult({ relevantFunctions: items });
+    expect(out).toContain('**relevantFunctions** (15)');
+    expect(out).toContain('• fn0 — fanIn=0');
+    expect(out).toContain('… 9 more'); // 15 - 6
+    expect(out).not.toContain('fn6');
+  });
+
+  it('summarises objects with title + at most two extras, dropping handle noise', () => {
+    const out = formatToolResult({ hits: [{ name: 'doThing', filePath: 'src/a.ts', score: 0.9, expand: 'doThing::src/a.ts', signature: 'function doThing()', language: 'TypeScript' }] });
+    expect(out).toContain('• doThing — filePath=src/a.ts, score=0.9');
+    expect(out).not.toContain('expand=');
+    expect(out).not.toContain('signature=');
+    expect(out).not.toContain('language=');
+  });
+
+  it('rounds non-integer numbers to two decimals', () => {
+    const out = formatToolResult({ hits: [{ name: 'x', score: 7.5214544522383315 }] });
+    expect(out).toContain('score=7.52');
+    expect(out).not.toContain('7.5214');
+  });
+
+  it('renders edge-like rows as "a → b"', () => {
+    const out = formatToolResult({ edges: [{ caller: 'handleOrient', callee: 'validateDirectory', callerFile: 'a.ts', calleeFile: 'b.ts' }] });
+    expect(out).toContain('• handleOrient → validateDirectory');
+    expect(out).not.toContain('callerFile');
+  });
+
+  it('truncates long top-level string fields', () => {
+    const long = 'x'.repeat(1000);
+    const out = formatToolResult({ skeleton: long });
+    expect(out).toContain('…');
+    expect(out.length).toBeLessThan(600);
+  });
+
+  it('renders nested objects as labelled key/value sections', () => {
+    const out = formatToolResult({ summary: { totalFunctions: 100, hubCount: 5 } });
+    expect(out).toContain('**summary**');
+    expect(out).toContain('  totalFunctions: 100');
+    expect(out).toContain('  hubCount: 5');
+  });
+
+  it('skips input-echo / prose / meta keys and empty arrays', () => {
+    const out = formatToolResult({
+      task: 'add auth',
+      searchMode: 'semantic',
+      query: 'auth',
+      guidance: 'some long prose',
+      count: 3,
+      relevantFiles: [],
+      relevantFunctions: [{ name: 'login' }],
+    });
+    expect(out).not.toContain('task');
+    expect(out).not.toContain('searchMode');
+    expect(out).not.toContain('guidance');
+    expect(out).not.toContain('count');
+    expect(out).not.toContain('relevantFiles');
+    expect(out).toContain('**relevantFunctions**'); // kept
+  });
+
+  it('drops orient enrichment from the glance when toolName is "orient"', () => {
+    const payload = {
+      relevantFunctions: [{ name: 'handleOrient', filePath: 'src/o.ts', score: 9.8 }],
+      insertionPoints: [{ name: 'toStderr', rank: 1, filePath: 'src/o.ts' }],
+      callPaths: [{ name: 'handleOrient', filePath: 'src/o.ts' }],
+      suggestedTools: ['record_decision', 'get_subgraph'],
+      governingDecisions: [{ id: 'abc', title: 'X', status: 'verified', governs: ['a'] }],
+      changeCoupling: [{ file: 'src/o.ts', volatility: 'low', changes: 4 }],
+      landmarks: [{ id: 'src/o.ts::avg', name: 'avg', file: 'src/o.ts' }],
+      specLinkedFunctions: Array.from({ length: 130 }, (_, i) => ({ name: `f${i}` })),
+      nextSteps: ['Run check_spec_drift'],
+    };
+    const out = formatToolResult(payload, 'orient');
+    // kept — actionable at a glance
+    expect(out).toContain('**relevantFunctions**');
+    expect(out).toContain('**insertionPoints**');
+    expect(out).toContain('**nextSteps**');
+    // dropped — model-facing enrichment, noise for the human skim
+    for (const k of ['callPaths', 'suggestedTools', 'governingDecisions', 'changeCoupling', 'landmarks', 'specLinkedFunctions']) {
+      expect(out).not.toContain(k);
+    }
+  });
+
+  it('keeps governingDecisions for deliberate analysis tools (per-tool skips)', () => {
+    const payload = {
+      blastRadius: { total: 68, upstream: 8, downstream: 60 },
+      riskLevel: 'critical',
+      governingDecisions: [{ id: 'abc', title: 'Some decision', status: 'verified' }],
+    };
+    // analyze_impact keeps its analytical structure…
+    const impact = formatToolResult(payload, 'analyze_impact');
+    expect(impact).toContain('**governingDecisions**');
+    expect(impact).toContain('**blastRadius**');
+    // …but orient would hide governingDecisions.
+    expect(formatToolResult(payload, 'orient')).not.toContain('governingDecisions');
+  });
+
+  it('trims only language + criticalPathLeaves from analyze_impact', () => {
+    const payload = {
+      file: 'src/o.ts',
+      language: 'TypeScript',
+      blastRadius: { total: 68 },
+      upstreamChain: [{ name: 'dispatchTool', file: 'src/d.ts', depth: 1 }],
+      criticalPathLeaves: ['relMap', 'toRel', 'pathMatches'],
+      recommendedStrategy: { approach: 'split responsibility (SRP)' },
+    };
+    const out = formatToolResult(payload, 'analyze_impact');
+    expect(out).not.toContain('language');
+    expect(out).not.toContain('criticalPathLeaves');
+    // the analytical core stays
+    expect(out).toContain('**blastRadius**');
+    expect(out).toContain('**upstreamChain**');
+    expect(out).toContain('**recommendedStrategy**');
+  });
+
+  it('does not emit raw JSON braces for a typical orient payload', () => {
+    const out = formatToolResult({
+      task: 'add rate limiting',
+      relevantFunctions: [{ name: 'handleRequest', filePath: 'src/server.ts', fanIn: 3 }],
+      specDomains: [{ domain: 'api', specPath: 'openspec/specs/api/spec.md' }],
+      nextSteps: ['Call get_subgraph("handleRequest")'],
+    });
+    expect(out).not.toMatch(/[{}]/);
+    expect(out).toContain('• handleRequest');
+    expect(out).toContain('• Call get_subgraph("handleRequest")');
+  });
+});
+
+describe('formatCallArgs', () => {
+  it('quotes the primary descriptive arg', () => {
+    expect(formatCallArgs({ task: 'add rate limiting' })).toBe('"add rate limiting"');
+    expect(formatCallArgs({ query: 'orient' })).toBe('"orient"');
+    expect(formatCallArgs({ symbol: 'handleOrient' })).toBe('"handleOrient"');
+    expect(formatCallArgs({ filePath: 'src/o.ts' })).toBe('"src/o.ts"');
+  });
+
+  it('renders pathfinding as entry → target', () => {
+    expect(formatCallArgs({ entryFunction: 'main', targetFunction: 'orient' })).toBe('main → orient');
+  });
+
+  it('returns empty when there is no descriptive arg', () => {
+    expect(formatCallArgs({ limit: 5 })).toBe('');
+    expect(formatCallArgs({})).toBe('');
+  });
+
+  it('truncates a long arg', () => {
+    const out = formatCallArgs({ task: 'x'.repeat(200) });
+    expect(out.endsWith('…"')).toBe(true);
+    expect(out.length).toBeLessThan(90);
+  });
+
+  it('prefers task over other keys when several are present', () => {
+    expect(formatCallArgs({ task: 'A', query: 'B' })).toBe('"A"');
+  });
+
+  it('renders select_tests changedSymbols as a name list (capped)', () => {
+    expect(formatCallArgs({ changedSymbols: ['handleRequest'] })).toBe('handleRequest');
+    expect(formatCallArgs({ changedSymbols: ['a', 'b', 'c', 'd', 'e'] })).toBe('a, b, c, +2');
+  });
+
+  it('renders select_tests diffRef as "diff <ref>"', () => {
+    expect(formatCallArgs({ diffRef: 'HEAD' })).toBe('diff HEAD');
+  });
+
+  it('is empty for a bare select_tests call (no args) → bare title', () => {
+    expect(formatCallArgs({ changedSymbols: [] })).toBe('');
+    expect(formatCallArgs({ directory: '/p' })).toBe('');
   });
 });
 

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -28,6 +28,8 @@ import type {
   SessionStartEvent,
 } from '@earendil-works/pi-coding-agent';
 import { StringEnum } from '@earendil-works/pi-ai';
+import { getMarkdownTheme } from '@earendil-works/pi-coding-agent';
+import { Markdown, Text } from '@earendil-works/pi-tui';
 import { Type, type TObject, type TSchema } from 'typebox';
 
 import { spawn } from 'node:child_process';
@@ -414,74 +416,292 @@ async function readSpecIndex(cwd: string): Promise<string> {
 
 interface NavToolSpec { name: string; label: string; description: string; guideline: string; parameters: TObject }
 
+// Descriptions and guidelines are written trigger-first and jargon-light: weak
+// local tool-callers (e.g. codestral) pattern-match on "when the user asks X,
+// call this" far better than on a capability statement full of graph jargon.
 const NAV_TOOLS: NavToolSpec[] = [
   {
     name: 'orient',
     label: 'openlore orient',
-    description: 'START HERE on any new task. Returns relevant functions, files, spec domains, call neighbours, and insertion points in one call.',
-    guideline: 'Use openlore_orient FIRST on any new task before reading files.',
+    description: 'START HERE on any new task. One call returns the functions, files, and specs relevant to the task, plus where to add code.',
+    guideline: 'On any new task, call openlore_orient FIRST — before reading or grepping files.',
     parameters: Type.Object({ task: Type.String({ description: 'Natural-language task description' }), limit: Type.Optional(Type.Number()) }),
   },
   {
     name: 'search_code',
     label: 'openlore search_code',
-    description: 'Semantic + keyword search for functions by meaning or name.',
-    guideline: 'Use openlore_search_code to find where a concept lives instead of grepping.',
-    parameters: Type.Object({ query: Type.String(), limit: Type.Optional(Type.Number()), language: Type.Optional(Type.String()) }),
+    description: 'Find functions by what they do or by name (meaning + keyword search).',
+    guideline: 'When you need to find where something lives in the code, call openlore_search_code with what you are looking for as `query`, instead of grepping.',
+    parameters: Type.Object({
+      query: Type.String({ description: 'REQUIRED. What to look for — a concept or a function/type name, e.g. "rate limiting" or "handleRequest".' }),
+      limit: Type.Optional(Type.Number()),
+      language: Type.Optional(Type.String()),
+    }),
   },
   {
     name: 'get_subgraph',
     label: 'openlore get_subgraph',
-    description: 'Call topology around a function (callers/callees) to a given depth.',
-    guideline: 'Use openlore_get_subgraph to see blast radius before changing a function.',
-    parameters: Type.Object({ functionName: Type.String(), direction: Type.Optional(StringEnum(['downstream', 'upstream', 'both'] as const)), maxDepth: Type.Optional(Type.Number()) }),
+    description: 'See what calls a function and what that function calls.',
+    guideline: 'Before you change a function, call openlore_get_subgraph with that function\'s name (`functionName`) to see what might break. Always pass the function name.',
+    parameters: Type.Object({
+      functionName: Type.String({ description: 'REQUIRED. The exact name of the function to inspect, e.g. "handleRequest".' }),
+      direction: Type.Optional(StringEnum(['downstream', 'upstream', 'both'] as const)),
+      maxDepth: Type.Optional(Type.Number()),
+    }),
   },
   {
     name: 'trace_execution_path',
     label: 'openlore trace_execution_path',
-    description: 'Find call paths from an entry function to a target function.',
-    guideline: 'Use openlore_trace_execution_path to answer "how does X reach Y".',
-    parameters: Type.Object({ entryFunction: Type.String(), targetFunction: Type.String(), maxDepth: Type.Optional(Type.Number()) }),
+    description: 'Show how one function reaches another — the call path between them.',
+    guideline: 'When the question is "how does X reach Y" or you need to trace a flow, call openlore_trace_execution_path with both function names (`entryFunction` = X, `targetFunction` = Y).',
+    parameters: Type.Object({
+      entryFunction: Type.String({ description: 'REQUIRED. The function the path starts FROM, e.g. "main".' }),
+      targetFunction: Type.String({ description: 'REQUIRED. The function the path should reach, e.g. "handleOrient".' }),
+      maxDepth: Type.Optional(Type.Number()),
+    }),
   },
   {
     name: 'analyze_impact',
     label: 'openlore analyze_impact',
-    description: 'Blast radius of changing a symbol (transitive dependents).',
-    guideline: 'Use openlore_analyze_impact before editing a shared/hub symbol.',
-    parameters: Type.Object({ symbol: Type.String(), depth: Type.Optional(Type.Number()) }),
+    description: 'List everything that depends on a function or type (its blast radius).',
+    guideline: 'Before editing a widely-used function or type, call openlore_analyze_impact with its name (`symbol`) to see what depends on it. Always pass the function/type name.',
+    parameters: Type.Object({
+      symbol: Type.String({ description: 'REQUIRED. The exact function or type name to analyze, e.g. "handleRequest".' }),
+      depth: Type.Optional(Type.Number()),
+    }),
+  },
+  {
+    name: 'select_tests',
+    label: 'openlore select_tests',
+    description: 'Find the tests that exercise given functions or a set of changes, so you know exactly what to run. With no arguments, uses your current uncommitted changes.',
+    guideline: 'When asked to test a function, or to verify/validate a change, call openlore_select_tests FIRST to find the tests that cover it — do not guess which tests to run. Pass changedSymbols for specific functions; with no arguments it defaults to your current working-tree changes.',
+    parameters: Type.Object({
+      changedSymbols: Type.Optional(Type.Array(Type.String(), { description: 'Function/type names you changed or want tested. Optional — omit to use your current uncommitted changes (diff vs HEAD).' })),
+      diffRef: Type.Optional(Type.String({ description: 'Git ref to diff the working tree against (e.g. "HEAD", "main"). Optional — defaults to HEAD when no changedSymbols given.' })),
+      maxDepth: Type.Optional(Type.Number()),
+    }),
+  },
+  {
+    name: 'get_test_coverage',
+    label: 'openlore get_test_coverage',
+    description: 'Show which parts of the code have tests and which do not.',
+    guideline: 'To check whether code is tested before changing it or before a PR, call openlore_get_test_coverage.',
+    parameters: Type.Object({
+      domains: Type.Optional(Type.Array(Type.String(), { description: 'Limit to these spec domains' })),
+      minCoverage: Type.Optional(Type.Number()),
+    }),
   },
   {
     name: 'suggest_insertion_points',
     label: 'openlore suggest_insertion_points',
-    description: 'Where to add a feature — ranked file/function insertion candidates.',
-    guideline: 'Use openlore_suggest_insertion_points when planning where new code goes.',
-    parameters: Type.Object({ description: Type.String(), limit: Type.Optional(Type.Number()) }),
+    description: 'Suggest where to add new code — ranked files and functions.',
+    guideline: 'When planning where a new feature or function should go, call openlore_suggest_insertion_points with a short description of the new code.',
+    parameters: Type.Object({
+      description: Type.String({ description: 'REQUIRED. What the new code should do, e.g. "add rate limiting to the API".' }),
+      limit: Type.Optional(Type.Number()),
+    }),
   },
   {
     name: 'get_function_skeleton',
     label: 'openlore get_function_skeleton',
-    description: 'Compact skeleton of a file: signatures + control flow, noise stripped.',
-    guideline: 'Use openlore_get_function_skeleton to read a file cheaply before opening it.',
-    parameters: Type.Object({ filePath: Type.String() }),
+    description: "Show a file's structure — signatures and control flow — without the full bodies.",
+    guideline: 'To understand a file cheaply before opening it, call openlore_get_function_skeleton with its path (`filePath`).',
+    parameters: Type.Object({
+      filePath: Type.String({ description: 'REQUIRED. Path to the file, relative to the repo root, e.g. "src/server.ts".' }),
+    }),
   },
   {
     name: 'get_health_map',
     label: 'openlore get_health_map',
-    description: 'Structural health dashboard: hubs, god functions, bridge nodes, untested hotspots, layer violations — ranked by severity. Start here before a refactor.',
-    guideline: 'Use openlore_get_health_map before any refactor to identify riskiest areas.',
+    description: 'Show the riskiest areas of the codebase, ranked: overloaded, tangled, and untested hotspots.',
+    guideline: 'Before a refactor, call openlore_get_health_map to find the riskiest areas to focus on.',
     parameters: Type.Object({ limit: Type.Optional(Type.Number()) }),
   },
   {
     name: 'get_surprising_connections',
     label: 'openlore get_surprising_connections',
-    description: 'Find unexpected coupling: cross-community edges, peripheral-to-hub calls, cross-test-boundary dependencies — scored by surprise.',
-    guideline: 'Use openlore_get_surprising_connections to spot accidental dependencies before a PR.',
+    description: "Find unexpected dependencies between parts of the code that usually don't interact.",
+    guideline: 'Before a PR, call openlore_get_surprising_connections to spot accidental coupling.',
     parameters: Type.Object({ limit: Type.Optional(Type.Number()) }),
   },
 ];
 
 function toolResult(text: string, details: unknown = null): AgentToolResult<unknown> {
   return { content: [{ type: 'text', text }], details };
+}
+
+// ── Tool-result rendering ──────────────────────────────────────────────────
+// Daemon handlers return structured JSON. Dumping it raw into the console is
+// noise the user has to parse by eye. Render a compact, human-readable summary
+// for display while the full object still rides along in `details` (the model
+// reads that, so no structural fidelity is lost).
+
+const MAX_LIST_ITEMS = 6;
+const MAX_STR = 400;       // cap on a top-level string field
+const MAX_EXTRA_STR = 60;  // cap on a string shown inline as a list-item extra
+const MAX_EXTRAS = 2;      // notable fields appended after an item's title
+
+// Keys that name an item, tried in order when summarising an object in a list.
+const TITLE_KEYS = ['name', 'title', 'label', 'function', 'symbol', 'id', 'file', 'filePath', 'domain', 'path', 'to', 'from'];
+
+// Top-level keys dropped from the console glance — all display-only; the full
+// value always stays in content/`details` for the model.
+//
+// BASE_SKIP applies to every tool: input echoes (Pi already shows the call args)
+// and verbose prose/meta.
+const BASE_SKIP = new Set([
+  // input echoes
+  'task', 'query', 'description', 'symbol', 'functionName', 'direction',
+  'maxDepth', 'depth', 'entryFunction', 'targetFunction', 'filePath', 'limit',
+  // prose / meta
+  'guidance', 'note', 'graphIndexNote', 'searchMode', 'count',
+]);
+
+// Per-tool extra skips. orient is auto-injected at the start of every task, so
+// its glance must stay tight: drop the model-facing enrichment (deep graph/git/
+// spec context, redundant call paths, 100+ rows). Deliberate analysis tools like
+// analyze_impact keep their full structure — there the detail IS the deliverable.
+const SKIP_BY_TOOL: Record<string, Set<string>> = {
+  orient: new Set([
+    'callPaths', 'suggestedTools', 'specLinkedFunctions', 'inlineSpecs',
+    'matchingSpecs', 'provenance', 'changeCoupling', 'landmarks',
+    'governingDecisions', 'staleDecisions', 'relevantFunctionsOmitted',
+  ]),
+  // analyze_impact stays rich (the detail is the deliverable), minus two low-value
+  // bits: `language` (redundant scalar) and `criticalPathLeaves` (a long list of
+  // leaf names, far less actionable than the up/downstream chains above it).
+  analyze_impact: new Set(['language', 'criticalPathLeaves']),
+};
+
+/** Skip set for a tool: base skips plus any tool-specific extras. */
+function skipKeysFor(toolName?: string): Set<string> {
+  const extra = toolName ? SKIP_BY_TOOL[toolName] : undefined;
+  return extra ? new Set([...BASE_SKIP, ...extra]) : BASE_SKIP;
+}
+// Per-item fields that are verbose handles/paths, not glance info.
+const NOISE_EXTRA = new Set(['expand', 'signature', 'language', 'callerFile', 'calleeFile', 'toFile', 'fromFile']);
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function fmtNum(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(2);
+}
+
+/** Render a primitive (or a short summary of a container) on one line. */
+function renderScalar(v: unknown): string {
+  if (v === null || v === undefined) return '';
+  if (typeof v === 'number') return fmtNum(v);
+  if (typeof v === 'boolean') return String(v);
+  if (typeof v === 'string') return v.length > MAX_STR ? v.slice(0, MAX_STR) + '…' : v;
+  if (Array.isArray(v)) return v.length === 0 ? '' : `[${v.length} items]`;
+  if (isPlainObject(v)) return summarizeItem(v);
+  return String(v);
+}
+
+/** One-line summary of an object: title (or `a → b` for edges) plus a couple of fields. */
+function summarizeItem(obj: Record<string, unknown>): string {
+  // Edge-like rows (call graph, surprising connections) read best as a → b.
+  const caller = obj.caller ?? obj.from;
+  const callee = obj.callee ?? obj.to;
+  if (typeof caller === 'string' && typeof callee === 'string') return `${caller} → ${callee}`;
+
+  const titleKey = TITLE_KEYS.find((k) => typeof obj[k] === 'string' || typeof obj[k] === 'number');
+  const title = titleKey ? String(obj[titleKey]) : '';
+  const extras: string[] = [];
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === titleKey || NOISE_EXTRA.has(k)) continue;
+    if (typeof v === 'number') extras.push(`${k}=${fmtNum(v)}`);
+    else if (typeof v === 'string' && v.length > 0 && v.length <= MAX_EXTRA_STR) extras.push(`${k}=${v}`);
+    if (extras.length >= MAX_EXTRAS) break;
+  }
+  const head = title || '(item)';
+  return extras.length ? `${head} — ${extras.join(', ')}` : head;
+}
+
+/** Render a single list element: scalar verbatim, object as a summary line. */
+function renderItem(item: unknown): string {
+  if (isPlainObject(item)) return summarizeItem(item);
+  return renderScalar(item);
+}
+
+/** Fallback for renderResult when `details` is absent (e.g. session reload): the
+ *  joined content text, parsed back to an object if it is JSON. */
+function resultText(result: AgentToolResult<unknown>): unknown {
+  const text = result.content.map((c) => ('text' in c ? c.text : '')).join('\n');
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+// The descriptive argument that names a tool call, tried in order.
+const CALL_ARG_KEYS = ['task', 'query', 'symbol', 'functionName', 'description', 'filePath'];
+const MAX_CALL_ARG = 80;
+
+/**
+ * One-line summary of a tool call's arguments for renderCall — the descriptive
+ * arg, quoted (e.g. orient "add rate limiting"). Pathfinding reads as `a → b`.
+ * Returns '' when there's no descriptive arg (e.g. get_health_map) so the caller
+ * shows the bare tool title.
+ */
+export function formatCallArgs(args: Record<string, unknown>): string {
+  if (typeof args.entryFunction === 'string' && typeof args.targetFunction === 'string') {
+    return `${args.entryFunction} → ${args.targetFunction}`;
+  }
+  // select_tests: a list of changed symbols, or a diff ref.
+  if (Array.isArray(args.changedSymbols)) {
+    const names = args.changedSymbols.filter((s): s is string => typeof s === 'string' && s.length > 0);
+    if (names.length > 0) {
+      const shown = names.slice(0, 3).join(', ');
+      return names.length > 3 ? `${shown}, +${names.length - 3}` : shown;
+    }
+  }
+  if (typeof args.diffRef === 'string' && args.diffRef.length > 0) return `diff ${args.diffRef}`;
+  const key = CALL_ARG_KEYS.find((k) => typeof args[k] === 'string' && (args[k] as string).length > 0);
+  if (!key) return '';
+  const v = String(args[key]);
+  return v.length > MAX_CALL_ARG ? `"${v.slice(0, MAX_CALL_ARG)}…"` : `"${v}"`;
+}
+
+/**
+ * Turn a structured tool result into readable text. Strings pass through;
+ * `{ error }` becomes a warning line; objects render as labelled sections with
+ * arrays shown as bounded bullet lists. `toolName` selects per-tool skips so an
+ * ambient tool (orient) can hide enrichment a deliberate one (analyze_impact)
+ * keeps. Resilient to schema drift — unknown shapes degrade to key/value lines.
+ */
+export function formatToolResult(result: unknown, toolName?: string): string {
+  if (typeof result === 'string') return result;
+  if (result === null || result === undefined) return '(no result)';
+  if (!isPlainObject(result) && !Array.isArray(result)) return String(result);
+  if (isPlainObject(result) && typeof result.error === 'string') return `⚠ ${result.error}`;
+
+  const skip = skipKeysFor(toolName);
+  const entries: Array<[string, unknown]> = Array.isArray(result)
+    ? [['result', result]]
+    : Object.entries(result);
+
+  const lines: string[] = [];
+  for (const [key, value] of entries) {
+    if (value === undefined || value === null) continue;
+    if (skip.has(key)) continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      lines.push(`**${key}** (${value.length})`);
+      for (const item of value.slice(0, MAX_LIST_ITEMS)) lines.push(`  • ${renderItem(item)}`);
+      if (value.length > MAX_LIST_ITEMS) lines.push(`  … ${value.length - MAX_LIST_ITEMS} more`);
+    } else if (isPlainObject(value)) {
+      lines.push(`**${key}**`);
+      for (const [k, v] of Object.entries(value)) {
+        const s = renderScalar(v);
+        if (s) lines.push(`  ${k}: ${s}`);
+      }
+    } else {
+      const s = renderScalar(value);
+      if (s) lines.push(`**${key}**: ${s}`);
+    }
+  }
+
+  return lines.length ? lines.join('\n') : '(empty result)';
 }
 
 // ── Extension entry point ─────────────────────────────────────────────────────
@@ -524,8 +744,27 @@ export default function openlore(pi: ExtensionAPI): void {
         const daemon = await getDaemon(ctx.cwd);
         if (!daemon) return toolResult('openlore daemon unavailable — run `openlore analyze` then retry.');
         const result = await callTool(daemon, tool.name, params as Record<string, unknown>, ctx.cwd, signal ?? undefined);
+        // content[].text is sent to the LLM verbatim — keep the FULL structured
+        // result so the model loses no detail. The compact human view is produced
+        // separately in renderResult (display only). `details` carries the parsed
+        // object so renderResult need not re-parse the JSON text.
         const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
         return toolResult(truncate(text, RESULT_MAX), result);
+      },
+      // Display-only: a clean invocation header — `openlore orient "<task>"` —
+      // instead of the default raw-args dump. Reuses the row's last component.
+      renderCall(args, theme, context) {
+        const text = (context.lastComponent as Text | undefined) ?? new Text('', 0, 0);
+        const title = theme.fg('toolTitle', tool.label);
+        const argStr = formatCallArgs(args as Record<string, unknown>);
+        text.setText(argStr ? `${title} ${theme.fg('dim', argStr)}` : title);
+        return text;
+      },
+      // Display-only: render a tight, glanceable summary in the TUI. The LLM still
+      // reads the full content above; this never touches what the model sees.
+      renderResult(result) {
+        const summary = formatToolResult(result.details ?? resultText(result), tool.name);
+        return new Markdown(summary, 1, 0, getMarkdownTheme());
       },
     });
   }


### PR DESCRIPTION
The Pi extension targets **weak local tool-callers** (Qwen, codestral). This improves three things for that audience.

## 1. Readable rendering (was: raw JSON in the console)

Display-only renderers on each nav tool. Per Pi's contract (`content[].text` → model; `details` + `renderCall`/`renderResult` → display-only), the full structured result still reaches the LLM verbatim — only the console view changed.

- **`renderResult`** — compact Markdown: labelled sections, bounded bullet lists (cap 6), edges as `a → b`, rounded floats, schema-drift-resilient. **Per-tool skips** (`SKIP_BY_TOOL`): `orient` (auto-injected) stays a tight glance; analysis tools like `analyze_impact` keep their full structure.
- **`renderCall`** — clean invocation header instead of the raw-args dump:
  ```
  openlore orient "add rate limiting"
  openlore trace_execution_path main → orient
  ```

## 2. Clearer descriptions + required-argument descriptions

Two sub-fixes, both for weak callers:

- **Trigger-first, jargon-light** descriptions/guidelines — *"Before you change a function, call …"* beats *"call topology / blast radius"*. Each guideline now also **names the argument to pass**.
- **Every required param now has a description with an example.** This is the fix for the **actually-reported failure**: codestral kept calling `analyze_impact` / `get_subgraph` **without the function argument**, because the schema (`symbol: Type.String()`) gave it nothing to fill in. Now:
  ```
  symbol: "REQUIRED. The exact function or type name to analyze, e.g. handleRequest."
  functionName: "REQUIRED. The exact name of the function to inspect, e.g. handleRequest."
  ```

## 3. Expose the test-discovery tools (were missing from Pi)

`select_tests` and `get_test_coverage` weren't in the Pi surface, so a local model had no tool to reach for around tests. Both are now exposed (the daemon already dispatches them; the preset is advisory).

## Changes

- `src/pi/extension.ts` — `renderResult` + `renderCall` on all nav tools; `formatToolResult` (per-tool skips) + `formatCallArgs`; rewritten descriptions/guidelines; required-param descriptions with examples; `select_tests` + `get_test_coverage` added
- `package.json` — `@earendil-works/pi-tui` devDep (Pi provides it at runtime, like `pi-ai`)
- `src/pi/extension.test.ts` — unit tests for `formatToolResult` + `formatCallArgs`

## Test

- 31/31 pi extension tests pass; `tsc --noEmit` + eslint clean; CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)