### PR TITLE
fix(serve): idle self-shutdown + keepalive so orphaned daemons can't pile up in RAM

### DIFF
--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -7,13 +7,13 @@
  * .openlore. We assert transport behaviour, not handler output.
  */
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtemp, rm, readFile, access, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { request as httpRequest } from 'node:http';
 import { DatabaseSync } from 'node:sqlite';
-import { startServe, readDescriptor, type ServeHandle } from './serve.js';
+import { startServe, readDescriptor, idleTimeoutMs, type ServeHandle } from './serve.js';
 import { EdgeStore } from '../../core/services/edge-store.js';
 import { openloreAnalyze } from '../../api/analyze.js';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR } from '../../constants.js';
@@ -72,6 +72,87 @@ function rawGet(
     req.end();
   });
 }
+
+describe('idleTimeoutMs', () => {
+  it('defaults to 15 minutes when the option is absent or empty', () => {
+    expect(idleTimeoutMs(undefined)).toBe(15 * 60_000);
+    expect(idleTimeoutMs('')).toBe(15 * 60_000);
+  });
+
+  it('converts a positive minute value to milliseconds', () => {
+    expect(idleTimeoutMs('5')).toBe(5 * 60_000);
+    expect(idleTimeoutMs('0.5')).toBe(30_000);
+  });
+
+  it('treats 0 and negative values as disabled', () => {
+    expect(idleTimeoutMs('0')).toBe(0);
+    expect(idleTimeoutMs('-1')).toBe(0);
+  });
+
+  it('falls back to the default on non-numeric input', () => {
+    expect(idleTimeoutMs('abc')).toBe(15 * 60_000);
+  });
+});
+
+describe('idle self-shutdown', () => {
+  const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+  // The idle path ends in process.exit(0) (correct for the real detached daemon).
+  // Stub it so teardown still runs but the test runner survives, then assert the
+  // observable effects: the discovery file is removed and the port stops serving.
+  it('tears down and removes serve.json after the idle timeout with no requests', async () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const dir = await mkdtemp(join(tmpdir(), 'openlore-idle-'));
+    try {
+      // 0.01 min = 600ms idle window.
+      const h = await startServe({ directory: dir, port: '0', watch: false, idleTimeout: '0.01' });
+      expect(h).toBeTruthy();
+      expect((await fetch(`${h!.baseUrl}/health`)).status).toBe(200);
+
+      // No further requests → timer (last reset by the /health above) fires.
+      await sleep(1000);
+      expect(exit).toHaveBeenCalled();
+      expect(await readDescriptor(dir)).toBeNull(); // teardown unlinked serve.json
+    } finally {
+      exit.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the daemon alive while requests keep arriving (timer resets)', async () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const dir = await mkdtemp(join(tmpdir(), 'openlore-idle-'));
+    try {
+      const h = await startServe({ directory: dir, port: '0', watch: false, idleTimeout: '0.02' }); // 1200ms
+      // Ping every 400ms for ~1.6s — comfortably under the 1200ms window each
+      // time, so the timer keeps resetting. Without resets it would die at 1200ms.
+      for (let i = 0; i < 4; i++) {
+        await sleep(400);
+        expect((await fetch(`${h!.baseUrl}/health`)).status).toBe(200);
+      }
+      expect(exit).not.toHaveBeenCalled();
+      await h!.close();
+    } finally {
+      exit.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('never arms the timer when disabled (--idle-timeout 0)', async () => {
+    const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    const dir = await mkdtemp(join(tmpdir(), 'openlore-idle-'));
+    try {
+      const h = await startServe({ directory: dir, port: '0', watch: false, idleTimeout: '0' });
+      await sleep(700);
+      expect(exit).not.toHaveBeenCalled();
+      expect(await readDescriptor(dir)).not.toBeNull(); // still serving
+      await h!.close();
+    } finally {
+      exit.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('openlore serve', () => {
   it('GET /health reports version, preset, and active tools', async () => {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -50,6 +50,39 @@ import { TOOL_DEFINITIONS, TOOL_PRESETS, selectActiveTools } from './mcp.js';
  */
 const REANALYZE_DEBOUNCE_MS = 4000;
 
+/**
+ * Default minutes of request inactivity before the daemon self-terminates.
+ *
+ * The daemon is spawned detached by clients (the Pi extension, MCP server) and
+ * is deliberately NOT a child of any one of them, so when a client closes it is
+ * not signalled. On Windows especially, a flaky health check can make a client
+ * (or the single-instance guard) miss the live daemon, spawn a fresh one, and
+ * orphan the previous — orphans hold their port + caches forever and pile up in
+ * RAM. Idle self-shutdown bounds every daemon's lifetime: orphans receive zero
+ * requests and reap themselves; the in-use daemon is kept alive by tool calls
+ * and the Pi extension's /health keepalive. Disable with --idle-timeout 0.
+ *
+ * INVARIANT: stays comfortably above the extension keepalive interval (Pi pings
+ * every 5 min); at ~3× it tolerates two consecutive missed pings before an
+ * in-use daemon would wrongly reap. Don't lower this without lowering the ping.
+ */
+const DEFAULT_IDLE_TIMEOUT_MIN = 15;
+
+/**
+ * Resolve the idle-shutdown interval (ms) from the `--idle-timeout` option, in
+ * minutes. Absent or non-numeric → the default; zero/negative → 0 (disabled).
+ */
+export function idleTimeoutMs(option?: string): number {
+  if (option === undefined || option === '') return DEFAULT_IDLE_TIMEOUT_MIN * 60_000;
+  const min = Number(option);
+  if (!Number.isFinite(min)) return DEFAULT_IDLE_TIMEOUT_MIN * 60_000; // non-numeric → default
+  return min > 0 ? min * 60_000 : 0; // explicit 0 / negative disables
+}
+
+/** Health-probe timeout. Generous enough for a cold Node HTTP server on Windows
+ *  so a slow first response isn't misread as "dead" (which orphans daemons). */
+const HEALTH_PROBE_TIMEOUT_MS = 2500;
+
 const _require = createRequire(import.meta.url);
 const _pkgVersion = (_require('../../../package.json') as { version: string }).version;
 
@@ -72,6 +105,8 @@ interface ServeCliOptions {
   stop?: boolean;
   /** false (via --no-watch) disables the freshness watcher + re-analyze lane. */
   watch?: boolean;
+  /** Minutes of request inactivity before the daemon self-terminates. 0 disables. */
+  idleTimeout?: string;
 }
 
 /** Live daemon handle. Returned by {@link startServe} so callers (tests) can
@@ -242,7 +277,7 @@ export async function readDescriptor(root: string): Promise<ServeDescriptor | nu
 async function daemonAlive(desc: ServeDescriptor): Promise<boolean> {
   try {
     const res = await fetch(`http://${desc.host}:${desc.port}/health`, {
-      signal: AbortSignal.timeout(1000),
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
     });
     if (!res.ok) return false;
     const body = (await res.json().catch(() => null)) as { ok?: boolean } | null;
@@ -321,6 +356,23 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
     ).map((t) => t.name),
   );
 
+  // Idle self-shutdown: a request resets the timer; firing tears down and exits.
+  // Bounds orphaned-daemon lifetime so they can't accumulate in RAM (see
+  // DEFAULT_IDLE_TIMEOUT_MIN). Declared here so handleRequest can reset it; armed
+  // after listen, once exitAfterTeardown exists.
+  const idleMs = idleTimeoutMs(options.idleTimeout);
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+  function touchActivity(): void {
+    if (idleMs <= 0) return;
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      logger.discovery(`[serve] idle ${idleMs / 60_000}min with no requests — shutting down to free memory.`);
+      void exitAfterTeardown();
+    }, idleMs);
+    // Don't keep the event loop alive for the idle timer alone.
+    idleTimer.unref?.();
+  }
+
   // Don't start a second daemon for a root already served by a healthy one —
   // a concurrent spawn (two MCP clients, or pi + MCP) would otherwise leave two
   // watchers racing on the same .openlore/analysis. Reuse the live one instead.
@@ -387,6 +439,7 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   });
 
   async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    touchActivity(); // any request (incl. /health) keeps an in-use daemon alive
     const url = new URL(req.url ?? '/', `http://${host}`);
 
     // DNS-rebinding / cross-origin defense — runs before ANY dispatch, including
@@ -583,6 +636,7 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
     shuttingDown = true;
     process.off('SIGINT',  onSigInt);
     process.off('SIGTERM', onSigTerm);
+    if (idleTimer) clearTimeout(idleTimer);
     if (reanalyzeTimer) clearTimeout(reanalyzeTimer);
     if (watcher) await watcher.stop().catch(() => {});
     await unlink(serveFilePath(root)).catch(() => {});
@@ -596,6 +650,12 @@ export async function startServe(options: ServeCliOptions): Promise<ServeHandle 
   const onSigTerm = () => void exitAfterTeardown();
   process.on('SIGINT',  onSigInt);
   process.on('SIGTERM', onSigTerm);
+
+  // Arm the idle timer now that teardown exists. Until the first request, the
+  // daemon already counts as idle — a client that spawns one but never calls it
+  // (e.g. a crashed session) will still be reaped.
+  touchActivity();
+  if (idleMs > 0) logger.discovery(`[serve] idle shutdown after ${idleMs / 60_000}min of inactivity`);
 
   return {
     port: boundPort,
@@ -619,6 +679,7 @@ export const serveCommand = new Command('serve')
   )
   .option('--token <token>', 'Require this token as the x-openlore-token header (default: $OPENLORE_SERVE_TOKEN)')
   .option('--no-watch', 'Disable the freshness watcher + debounced call-graph re-analyze')
+  .option('--idle-timeout <minutes>', `Self-terminate after this many minutes with no requests, so orphaned daemons can't pile up in RAM (0 disables). Default: ${DEFAULT_IDLE_TIMEOUT_MIN}`)
   .option('--stop', 'Stop a running daemon for --directory and exit')
   .addHelpText(
     'after',

--- a/src/core/services/serve-client.ts
+++ b/src/core/services/serve-client.ts
@@ -32,6 +32,10 @@ export interface ServeEndpoint {
 
 const SPAWN_HEALTH_TIMEOUT_MS = 8000;
 const HEALTH_POLL_MS = 150;
+// Per-probe timeout for the reuse check. Generous so a cold Node HTTP server on
+// Windows isn't misread as dead — a false negative spawns a second daemon and
+// orphans the first (orphans pile up in RAM). Matches serve.ts / the Pi extension.
+const HEALTH_PROBE_TIMEOUT_MS = 2500;
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
@@ -62,7 +66,7 @@ async function readDescriptor(directory: string): Promise<ServeDescriptor | null
 async function healthy(desc: ServeDescriptor): Promise<boolean> {
   try {
     const res = await fetch(`http://${desc.host}:${desc.port}/health`, {
-      signal: AbortSignal.timeout(1000),
+      signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
     });
     if (!res.ok) return false;
     const body = (await res.json().catch(() => null)) as { ok?: boolean } | null;

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -25,6 +25,7 @@ import type {
   BeforeAgentStartEventResult,
   ExtensionAPI,
   ExtensionContext,
+  SessionShutdownEvent,
   SessionStartEvent,
 } from '@earendil-works/pi-coding-agent';
 import { StringEnum } from '@earendil-works/pi-ai';
@@ -344,6 +345,16 @@ interface Daemon { baseUrl: string; token?: string }
 
 const HEALTH_TIMEOUT_MS = 8000;
 const HEALTH_POLL_MS = 150;
+// Generous per-probe timeout: a cold Node HTTP server on Windows can be slow to
+// answer the first /health. Too short a timeout misreads a live daemon as dead,
+// so we spawn a fresh one and orphan the previous — orphans pile up in RAM.
+const HEALTH_PROBE_TIMEOUT_MS = 2500;
+// Keepalive: while a session is open, ping the daemon's /health on this interval
+// so the in-use daemon never hits the serve idle-shutdown (default 15 min) mid-
+// session. Must stay well below that window — at ~1/3 of it, two pings can be
+// missed before a wrongful reap. Only daemons this extension knows are pinged —
+// orphans get no ping and still reap, so this can't resurrect the RAM pileup.
+const KEEPALIVE_MS = 5 * 60_000;
 const RESULT_MAX = 50_000;
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
@@ -355,7 +366,7 @@ async function readDescriptor(cwd: string): Promise<ServeDescriptor | null> {
 
 async function healthy(desc: ServeDescriptor): Promise<boolean> {
   try {
-    const res = await fetch(`http://${desc.host}:${desc.port}/health`, { signal: AbortSignal.timeout(1000) });
+    const res = await fetch(`http://${desc.host}:${desc.port}/health`, { signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS) });
     if (!res.ok) return false;
     return ((await res.json().catch(() => null)) as { ok?: boolean } | null)?.ok === true;
   } catch { return false; }
@@ -511,6 +522,24 @@ export default function openlore(pi: ExtensionAPI): void {
     return d;
   }
 
+  // Keepalive: ping every known daemon's /health so the in-use one survives the
+  // serve idle-shutdown while this session is open. A daemon that no longer
+  // answers (reaped/crashed) is dropped from the cache so the next tool call
+  // re-spawns it. Fire-and-forget; failures are expected and ignored.
+  let keepalive: ReturnType<typeof setInterval> | undefined;
+  function startKeepalive(): void {
+    if (keepalive || daemons.size === 0) return;
+    keepalive = setInterval(() => {
+      for (const [cwd, daemon] of daemons) {
+        const headers = daemon.token ? { 'x-openlore-token': daemon.token } : undefined;
+        void fetch(`${daemon.baseUrl}/health`, { headers, signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS) })
+          .then((res) => { if (!res.ok) daemons.delete(cwd); })
+          .catch(() => daemons.delete(cwd));
+      }
+    }, KEEPALIVE_MS);
+    keepalive.unref?.(); // never keep the host process alive for the keepalive alone
+  }
+
   // ── B: navigation tools ──
   for (const tool of NAV_TOOLS) {
     pi.registerTool({
@@ -570,7 +599,15 @@ export default function openlore(pi: ExtensionAPI): void {
 
     if (ctx.mode !== 'json' && ctx.mode !== 'print') {
       await getDaemon(ctx.cwd);
+      startKeepalive();
     }
+  });
+
+  // Stop pinging when the session ends gracefully so the now-unused daemon can
+  // idle out and free its RAM. (On a hard kill the interval dies with the host
+  // process anyway — either way pings stop and the daemon reaps.)
+  pi.on('session_shutdown', (_event: SessionShutdownEvent) => {
+    if (keepalive) { clearInterval(keepalive); keepalive = undefined; }
   });
 
   // ── C: context injection on the first turn ──


### PR DESCRIPTION
## Problem

On Windows, opening and closing Pi repeatedly leaves ghost `openlore serve` processes that accumulate and exhaust RAM.

**Mechanism:** the warm daemon is spawned **detached** by clients (Pi extension, MCP server) and is not a child of any of them — closing a client never signals it. A slow/flaky first `/health` probe (cold Node HTTP server on Windows often exceeds the 1 s timeout) makes a client *and* the existing single-instance guard misread a live daemon as dead. They spawn a fresh daemon, overwrite `serve.json`, and **orphan** the previous one. Orphans hold their port + caches forever and are never referenced again → pileup.

## Fix

1. **Idle self-shutdown** (`serve`): a timer tears down and exits after N minutes with no requests (default **15**, `--idle-timeout <minutes>`, `0` disables). Any request — including `/health` — resets it. Orphans get zero requests and reap themselves; the in-use daemon is kept alive by tool calls. Timer is `unref`'d and cleared on teardown.
2. **Keepalive** (Pi extension): while a session is open, ping the known daemon's `/health` every **5 min** (well under the idle window) so the in-use daemon never idle-reaps mid-session. Cleared on `session_shutdown`; on a hard kill the interval dies with the host process — either way pings stop and the now-unused daemon reaps. **Only daemons the extension knows are pinged**, so orphans still get zero pings and still reap — keepalive cannot resurrect the pileup it's paired with.
3. **Bump the `/health` probe timeout** 1000 ms → 2500 ms at **all three call sites** (serve single-instance guard, Pi extension, MCP `serve-client`) so a cold server on Windows isn't misread as dead — fewer orphans created.

**Invariant:** the idle timeout stays ~3× the keepalive interval (15 min vs 5 min), so two consecutive missed pings can't wrongly reap an in-use daemon. Lowering one without the other is called out in the code comments.

Cross-platform: idle shutdown bounds every daemon's lifetime regardless of client behaviour or OS signal quirks (on Windows `process.kill`/SIGTERM on a detached, shell-wrapped PID is unreliable). The fix deliberately does **not** rely on signals.

## Lifecycle summary

```
Pi open    → daemon warm, keepalive pings every 5 min → never idle-reaps
Pi closes  → session_shutdown clears keepalive (or process dies) → pings stop
15 min later (no tool calls, no pings) → daemon idle-reaps, serve.json removed
Pi reopens → serve.json gone/dead → one clean spawn
orphan (never in serve.json) → never pinged, never called → reaps on its own
```

## Scope: why keepalive is Pi-only (not the MCP server)

Keepalive lives with whoever **owns** (spawned) the daemon and wants it warm across idle gaps. That's Pi.

The MCP server (KiloCode, Claude Code, Cline) behaves differently:

- **By default it does not spawn a daemon at all** — it reuses one only if already running (e.g. started by Pi or an explicit `openlore serve`), otherwise it dispatches **in-process**. So a plain MCP session creates no detached process and contributes nothing to the pileup.
- When it reuses Pi's daemon, that daemon is **already kept warm by Pi's keepalive**.
- During active use, every tool call (`POST /tool/*`) resets the idle timer, so the daemon stays warm without any keepalive.

The only gap an MCP-side keepalive would close is `openlore mcp --daemon` running solo (no Pi) and sitting idle past the timeout — which costs a single respawn on the next call, not a pileup. Adding an interval + lifecycle teardown to `serve-client`/`mcp.ts` for that niche isn't worth the surface. Correctness is unaffected either way: idle-reap + respawn always works; keepalive is purely a warm-start optimisation for the interactive Pi case. The `/health` timeout bump (item 3) **is** applied to the MCP path, since that prevents orphan *creation* and is cheap.

## Changes

- `src/cli/commands/serve.ts` — idle timer + `touchActivity()` reset per request; `--idle-timeout`; `idleTimeoutMs()` parser; `HEALTH_PROBE_TIMEOUT_MS`; default 15 min
- `src/pi/extension.ts` — keepalive interval (5 min, cleared on `session_shutdown`); health probe 1000 → 2500 ms
- `src/core/services/serve-client.ts` — health probe 1000 → 2500 ms (MCP path)
- `src/cli/commands/serve.test.ts` — `idleTimeoutMs` unit tests + functional idle tests (reap / timer-reset / disabled), `process.exit` stubbed so teardown runs without killing the runner

## Test

- 24/24 serve tests + 7/7 serve-client tests pass; `tsc --noEmit` + eslint clean; CI green
- Functional idle tests assert: serve.json removed after timeout, daemon survives while pinged, never reaps when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)