### PR TITLE
fix(select_tests): default to working-tree diff vs HEAD when no args given

### DIFF
--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -504,11 +504,11 @@ export const TOOL_DEFINITIONS = [
         changedSymbols: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Changed function/method names. Provide this OR diffRef.',
+          description: 'Changed function/method names. Optional — if neither this nor diffRef is given, defaults to your current working-tree changes vs HEAD.',
         },
         diffRef: {
           type: 'string',
-          description: 'Git ref to diff the working tree against (e.g. "HEAD", "main"). Provide this OR changedSymbols.',
+          description: 'Git ref to diff the working tree against (e.g. "HEAD", "main"). Optional — defaults to HEAD when neither this nor changedSymbols is given.',
         },
         maxDepth: { type: 'number', description: 'Backward reachability depth (default 12)' },
         directResolvedOnly: { type: 'boolean', description: 'Traverse only directly-resolved edges, ignoring synthesized dynamic-dispatch edges (default false).' },

--- a/src/core/services/mcp-handlers/test-impact.test.ts
+++ b/src/core/services/mcp-handlers/test-impact.test.ts
@@ -11,8 +11,13 @@ vi.mock('./utils.js', () => ({
   readCachedContext: vi.fn(),
 }));
 
+vi.mock('../../drift/git-diff.js', () => ({
+  getChangedFiles: vi.fn(async () => ({ files: [] })),
+}));
+
 import { handleSelectTests, seedsFromSymbols, seedsFromFiles } from './test-impact.js';
 import { readCachedContext } from './utils.js';
+import { getChangedFiles } from '../../drift/git-diff.js';
 import type { FunctionNode, SerializedCallGraph, CallEdge } from '../../analyzer/call-graph.js';
 
 function node(over: Partial<FunctionNode> & { id: string }): FunctionNode {
@@ -89,9 +94,23 @@ describe('handleSelectTests', () => {
     expect(r.soundness.caveats.join(' ')).toMatch(/no tests were detected/i);
   });
 
-  it('errors when neither changedSymbols nor diffRef is given', async () => {
-    const r = await handleSelectTests({ directory: '/p' }) as { error: string };
-    expect(r.error).toMatch(/changedSymbols|diffRef/);
+  it('defaults to a working-tree diff vs HEAD when no args are given, and flags it', async () => {
+    vi.mocked(getChangedFiles).mockResolvedValueOnce({ files: [{ path: 'src/foo.ts' }] } as never);
+    const r = await handleSelectTests({ directory: '/p' }) as {
+      selectedTests: Array<{ test: string }>; note?: string;
+    };
+    // src/foo.ts changed → seeds foo+bar → both tests reach the change.
+    expect(r.selectedTests.map(t => t.test).sort()).toEqual(['testBar', 'testFoo']);
+    expect(getChangedFiles).toHaveBeenCalledWith(expect.objectContaining({ baseRef: 'HEAD' }));
+    expect(r.note).toMatch(/HEAD/);
+  });
+
+  it('flags the default in the empty-diff message when no args and no changes', async () => {
+    vi.mocked(getChangedFiles).mockResolvedValueOnce({ files: [] } as never);
+    const r = await handleSelectTests({ directory: '/p' }) as { selectedTests: unknown[]; message?: string; note?: string };
+    expect(r.selectedTests).toEqual([]);
+    expect(r.message).toMatch(/defaulted/);
+    expect(r.note).toMatch(/HEAD/);
   });
 
   it('returns a message (not a false-empty) when symbols match no production function', async () => {

--- a/src/core/services/mcp-handlers/test-impact.ts
+++ b/src/core/services/mcp-handlers/test-impact.ts
@@ -95,30 +95,39 @@ export async function handleSelectTests(input: SelectTestsInput): Promise<unknow
   const maxDepth = Math.max(1, Math.min(input.maxDepth ?? 12, SUBGRAPH_MAX_DEPTH_LIMIT));
 
   // ── Resolve the changed set ────────────────────────────────────────────────
+  // Precedence: explicit changedSymbols → diffRef → default to the working-tree
+  // diff vs HEAD. The default matters for weak tool-callers (e.g. a local model
+  // in Pi) that invoke select_tests with NO arguments: rather than erroring,
+  // a bare call answers the most common intent — "which tests cover my current
+  // uncommitted changes?". The result flags that it defaulted, so it's never
+  // mysterious.
+  const hasSymbols = !!(input.changedSymbols && input.changedSymbols.length > 0);
+  const baseRef = input.diffRef && input.diffRef.length > 0 ? input.diffRef : 'HEAD';
+  const defaultedToHead = !hasSymbols && (input.diffRef === undefined || input.diffRef === '');
+
   let seeds: FunctionNode[] = [];
   let changedFiles: string[] = [];
-  if (input.changedSymbols && input.changedSymbols.length > 0) {
-    seeds = seedsFromSymbols(cg, input.changedSymbols);
-  } else if (input.diffRef !== undefined) {
+  if (hasSymbols) {
+    seeds = seedsFromSymbols(cg, input.changedSymbols!);
+  } else {
     try {
       const { getChangedFiles } = await import('../../drift/git-diff.js');
-      const diff = await getChangedFiles({ rootPath: absDir, baseRef: input.diffRef || 'HEAD', includeUnstaged: true });
+      const diff = await getChangedFiles({ rootPath: absDir, baseRef, includeUnstaged: true });
       changedFiles = diff.files.map(f => f.path);
       seeds = seedsFromFiles(cg, changedFiles);
     } catch (err) {
-      return { error: `git diff failed: ${err instanceof Error ? err.message : String(err)}` };
+      return { error: `git diff failed (base ${baseRef}): ${err instanceof Error ? err.message : String(err)}` };
     }
-  } else {
-    return { error: 'Provide changedSymbols (a list of names) or diffRef (a git ref to diff against).' };
   }
 
   if (seeds.length === 0) {
     return {
       changed: changedFiles,
       selectedTests: [],
-      message: input.diffRef !== undefined
-        ? 'No changed production functions matched the call graph. The diff may touch only non-code files, or analyze_codebase is stale.'
-        : 'No matching production functions found for the given symbols.',
+      message: hasSymbols
+        ? 'No matching production functions found for the given symbols.'
+        : `No changed production functions vs ${baseRef}${defaultedToHead ? ' (defaulted — no changedSymbols or diffRef was given)' : ''}. Nothing has changed, the diff touches only non-code files, or analyze_codebase is stale.`,
+      ...(defaultedToHead ? { note: 'Called without changedSymbols/diffRef — diffed the working tree against HEAD. Pass changedSymbols or diffRef to target a specific change.' } : {}),
       soundness: { posture: 'over-approximate', caveats: ['No seeds resolved — nothing to select.'] },
       coverage: { languages: [], testDetection: 'none' as const },
     };
@@ -236,11 +245,10 @@ export async function handleSelectTests(input: SelectTestsInput): Promise<unknow
   }
 
   return {
-    changed: input.changedSymbols && input.changedSymbols.length > 0
-      ? seeds.map(s => s.name)
-      : changedFiles,
+    changed: hasSymbols ? seeds.map(s => s.name) : changedFiles,
     seeds: seeds.map(s => ({ name: s.name, file: s.filePath })),
     selectedTests,
+    ...(defaultedToHead ? { note: 'No changedSymbols/diffRef given — selected tests for your current working-tree changes vs HEAD.' } : {}),
     soundness: { posture: 'over-approximate' as const, caveats },
     coverage: { languages: seedLangs, testDetection },
   };


### PR DESCRIPTION
## Problem

`select_tests` required either `changedSymbols` or `diffRef`; with neither it returned `{ error: "Provide changedSymbols or diffRef." }`. Weak tool-callers (a local model in Pi, but also any agent) frequently call it with **no arguments** — and got an opaque error with no path forward. Observed with codestral in the Pi extension: it invoked `select_tests` bare and the result was incomprehensible.

## Fix

When neither `changedSymbols` nor `diffRef` is given, **default to diffing the working tree against HEAD** — the tool's most common intent ("which tests cover my current changes?"). A bare call now does the useful thing instead of erroring, and the result is self-explanatory:

```jsonc
// select_tests({ directory })  — no other args
{
  "changed": ["src/foo.ts"],
  "selectedTests": [ /* tests reaching those changes */ ],
  "note": "Called without changedSymbols/diffRef — diffed the working tree against HEAD. Pass changedSymbols or diffRef to target a specific change."
}
```

When the tree is clean the empty result's `message` also states it defaulted, so it's never mysterious.

This is daemon-side, so every client benefits — including the Pi extension (which forwards to the daemon) without any extra change.

## Changes

- `src/core/services/mcp-handlers/test-impact.ts` — precedence `changedSymbols → diffRef → HEAD`; `note` + empty-diff `message` flag the default
- `src/cli/commands/mcp.ts` — `changedSymbols`/`diffRef` documented as optional with the HEAD default
- `src/core/services/mcp-handlers/test-impact.test.ts` — replace the "errors with no args" test with: bare call defaults to HEAD (asserts `getChangedFiles` called with `baseRef: 'HEAD'` + `note`), and empty-diff message flags the default

## Test

- 9/9 test-impact tests pass; `tsc --noEmit` clean
- Verified end-to-end through the real `mcp__openlore__select_tests` tool against a daemon on this build: a no-arg call defaults to HEAD with the explanatory note, instead of the old error

🤖 Generated with [Claude Code](https://claude.com/claude-code)