### PR TITLE
feat(verify-claim): structural claim verification — the agent's claims about code become auditable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 | Recording an architectural decision before writing code | `record_decision` |
 | Persisting a durable, code-anchored fact for later sessions | `remember` (opt-in `memory` preset) — anchors a note to a symbol/file so it self-invalidates |
 | Recalling what's known about code you're touching | `recall` (opt-in `memory` preset) — returns memories with a freshness verdict; never serves orphaned ones as authoritative |
+| About to assert a structural fact to a user ("X is dead", "Y calls Z", "this is safe to change") | `verify_claim` (opt-in `verify` preset) — verify the claim against the graph, then cite the receipt to the human; an `unverifiable` verdict means hedge or read the source |
 
 For all other cases (reading a file, grepping, listing files) use native tools directly.
 

--- a/openspec/changes/add-structural-claim-verification/proposal.md
+++ b/openspec/changes/add-structural-claim-verification/proposal.md
@@ -1,0 +1,76 @@
+# Structural claim verification: make the agent's claims about code auditable
+
+> Status: BUILT (2026-06-19) — `verify_claim` MCP tool shipped behind the opt-in `verify` preset.
+> See `src/core/services/mcp-handlers/claim-verification.ts` (+ `.test.ts`). Decision: `9a8084b6`.
+> Stacked on `feat/confidence-boundary-disclosure` (PR #165) for the confidence-boundary primitives.
+> Phase-2 set (built after the memory + dispatch changes). Consumes the `unverifiable` verdict
+> from `add-confidence-boundary-disclosure` and the grounding certificate from
+> `add-trust-calibrated-context-economy`.
+
+## Why
+
+`add-trust-calibrated-context-economy` gives the agent evidence in one direction: OpenLore → agent
+("here is proof this fact is current"). The reverse direction is missing and is just as valuable:
+agent → OpenLore. When an agent is about to tell a user "this function is dead," "Y calls Z," or "this
+change is safe," it is often pattern-matching, and it is sometimes wrong. There is no cheap way for the
+agent to **check a structural claim against the deterministic graph and get back a verdict plus a
+citation it can show the user.**
+
+This is the difference between an agent that asserts and an agent that *verifies, then cites*. It
+converts the agent's confident-wrong failure mode into checked-or-flagged, and it makes the agent's
+output auditable by the human — OpenLore becomes the citation layer for claims about code, not just a
+private context source.
+
+## What changes
+
+1. **A claim-verification capability.** The agent submits a structured structural claim —
+   `{ kind: 'calls' | 'reaches' | 'dead' | 'impacts' | 'safe-to-change', subject, object? }` — and
+   OpenLore returns `{ verdict: 'confirmed' | 'refuted' | 'unverifiable', receipt }`. The verdict is a
+   deterministic graph computation, never an LLM judgement.
+
+2. **The receipt is a citation.** A `confirmed` or `refuted` verdict carries the evidence behind it —
+   the edges, spans, and content hashes (reusing the grounding certificate shape) and the index commit
+   — in a form the agent surfaces to the user: "verified against the index at commit X: see
+   `file.ts:42`." The human can audit the claim without trusting the agent's word.
+
+3. **`unverifiable` is first-class.** When a claim depends on a blind spot (reflection, computed
+   dispatch, an unindexed repo), the verdict is `unverifiable` with the boundary named — reusing
+   `add-confidence-boundary-disclosure`. OpenLore never fabricates a verdict to look decisive; "I can't
+   verify this statically, here's why" is a valid, trust-building answer.
+
+4. **A loop pattern, not just a tool.** The intended use: before an agent asserts a structural fact to
+   a user, it verifies the claim and cites the receipt; an `unverifiable` result tells it to hedge or
+   read the source. This is the mechanism that removes the excuse to be confidently wrong.
+
+## What does NOT change
+
+- **No LLM in the verdict.** The claim is structured and the verdict is a graph lookup; the north star
+  (`c6d1ad07`) holds. (How the agent *forms* the claim is the agent's business; OpenLore only checks it.)
+- **No new tuning score.** Verdicts are `confirmed` / `refuted` / `unverifiable`, not a confidence number.
+- **Opt-in surface.** The capability lands in an opt-in preset, never the minimal or first-run default.
+- **Conclusion-shaped.** A verdict + receipt, never a graph to traverse; `tool-contract.ts` stays
+  `conclusion`.
+
+## Research basis
+
+This is "unit tests for assertions about code" — the verification analogue of CI, packaged with a
+citation contract for agent output. SCIP / CodeQL let you *query* the graph; this change packages a
+query as a *verifiable claim with a receipt*, which is the shape an agent needs to make its own output
+trustworthy to a human. The honesty of the `unverifiable` verdict is the same discipline as
+`add-confidence-boundary-disclosure`.
+
+## Application to OpenLore
+
+- Each claim `kind` maps to an existing deterministic computation: `calls`/`reaches` to graph
+  traversal, `dead` to reachability, `impacts` to `analyze_impact`, `safe-to-change` to blast-radius +
+  anchored-memory orphaning.
+- The receipt reuses the grounding-certificate shape (`{ symbol, filePath, lineSpan, contentHash }`)
+  and the index commit.
+- `unverifiable` reuses the `confidenceBoundary` known-unknowable detection.
+
+## Out of scope
+
+- **Verifying non-structural claims** (behavioral correctness, runtime properties). This verifies
+  *structural* claims the call graph can decide.
+- **Auto-forming claims for the agent.** OpenLore checks a claim; it does not invent the claim.
+- **A natural-language claim parser.** Claims are structured input, not prose.

--- a/openspec/changes/add-structural-claim-verification/specs/mcp-handlers/spec.md
+++ b/openspec/changes/add-structural-claim-verification/specs/mcp-handlers/spec.md
@@ -1,0 +1,25 @@
+# mcp-handlers spec delta
+
+## ADDED Requirements
+
+### Requirement: StructuralClaimVerification
+
+The system SHALL provide a capability that accepts a structured structural claim
+(`{ kind: 'calls' | 'reaches' | 'dead' | 'impacts' | 'safe-to-change', subject, object? }`) and returns
+a deterministic `{ verdict: 'confirmed' | 'refuted' | 'unverifiable', receipt }`. The verdict SHALL be
+computed by the existing deterministic analysis for that claim kind, never by an LLM. A `confirmed` or
+`refuted` verdict SHALL carry a receipt — the backing edges, spans, and content hashes (grounding-
+certificate shape) plus the index commit — suitable for the agent to cite to a human. The capability
+SHALL be conclusion-shaped (verdict + receipt, never a graph) and registered only in an opt-in preset.
+
+#### Scenario: A false claim is refuted with a receipt
+
+- **GIVEN** a claim that function A calls function B, when no such edge exists
+- **WHEN** the claim is verified
+- **THEN** the verdict is `refuted` with a receipt referencing the index commit and the relevant spans
+
+#### Scenario: A blind-spot claim is unverifiable, not fabricated
+
+- **GIVEN** a `dead` claim about a symbol reachable only across a reflection boundary
+- **WHEN** the claim is verified
+- **THEN** the verdict is `unverifiable` with the boundary named, never `confirmed` or `refuted`

--- a/openspec/changes/add-structural-claim-verification/tasks.md
+++ b/openspec/changes/add-structural-claim-verification/tasks.md
@@ -1,0 +1,25 @@
+# Tasks — Structural claim verification
+
+> Phase-2; build after the five memory + dispatch changes (reuses the grounding certificate and
+> confidence-boundary detection). Call `record_decision` before the claim/verdict contract (API
+> contract), per `CLAUDE.md`.
+
+## 1. Claim + verdict contract
+- [x] Define the structured claim `{ kind, subject, object? }` for kinds `calls`, `reaches`, `dead`,
+      `impacts`, `safe-to-change`, and the verdict `{ verdict, receipt }`.
+- [x] Map each kind to its existing deterministic computation (traversal / reachability /
+      `analyze_impact` / blast-radius + memory-orphaning).
+- [x] Test: a true `calls` claim returns `confirmed`; a false one returns `refuted`.
+
+## 2. Receipt as citation
+- [x] Attach the evidence (edges/spans/`contentHash`, index commit) in the grounding-certificate shape.
+- [x] Test: the receipt's hashes match an independent hash of the cited spans.
+
+## 3. Unverifiable verdict
+- [x] Return `unverifiable` (with the boundary named) when a claim depends on a blind spot; reuse
+      `add-confidence-boundary-disclosure`.
+- [x] Test: a `dead` claim about a reflection-reached symbol returns `unverifiable`, not `confirmed`.
+
+## 4. Surface + docs
+- [x] Register behind an opt-in preset; nothing in the default. Confirm `tool-contract.ts` = `conclusion`.
+- [x] Document the verify-then-cite loop pattern in `mcp-handlers` + `CODEBASE.md`.

--- a/openspec/specs/mcp-handlers/spec.md
+++ b/openspec/specs/mcp-handlers/spec.md
@@ -458,3 +458,31 @@ Comparing the analyze-time project fingerprint (whole-tree mtime+size hash) agai
 computeProjectFingerprint walked .openlore-live-cache (the gitignored clone cache for live-data fixtures). Those foreign source files churn whenever the live-data MCP tools or integration tests run, so the content hash flapped even when the user's own source was unchanged — forcing needless full re-analysis and false staleness markers. Generalizing the directory skip from exact `.openlore` to any `.openlore`-prefixed name covers `.openlore`, `.openlore-live-cache`, and future OpenLore-managed dirs in one rule.
 
 **Consequences:** walkForFingerprint now skips directories whose name starts with `.openlore` in addition to the static FINGERPRINT_SKIP_DIRS set. The custom OPENLORE_LIVE_CACHE_DIR override (an arbitrary path) is not covered by the prefix rule — acceptable since the default is the in-repo `.openlore-live-cache`. A regression test asserts live-cache churn leaves the fingerprint unchanged while a real user-source edit still flips the hash.
+
+### Requirement: StructuralClaimVerification
+
+The system SHALL provide a `verify_claim` capability that accepts a structured structural claim
+(`{ kind: 'calls' | 'reaches' | 'dead' | 'impacts' | 'safe-to-change', subject, object? }`) and returns
+a deterministic `{ verdict: 'confirmed' | 'refuted' | 'unverifiable', reason, receipt?, confidenceBoundary }`.
+The verdict SHALL be computed by the existing deterministic analysis for that claim kind (call-graph
+traversal for `calls`/`reaches`, backward reachability for `impacts`, mark-and-sweep reachability for
+`dead`, directly-resolved caller analysis for `safe-to-change`), never by an LLM and never as a
+confidence number. A `confirmed` or `refuted` verdict SHALL carry a receipt — the subject/object spans
+and content hashes (grounding-certificate shape) plus the index commit — suitable for the agent to cite
+to a human. A claim whose answer rests on a dispatch blind spot (a symbol reached only through
+synthesized dynamic-dispatch edges, or an unresolved/ambiguous symbol) SHALL return `unverifiable` with
+the boundary named (reusing the confidence-boundary disclosure), never a fabricated `confirmed`/`refuted`.
+The capability SHALL be conclusion-shaped (verdict + bounded receipt, never a graph to traverse) and
+registered only in an opt-in preset (`verify`), never in the minimal or first-run default surface.
+
+#### Scenario: A false claim is refuted with a receipt
+
+- **GIVEN** a claim that function A calls function B, when no such edge exists
+- **WHEN** the claim is verified
+- **THEN** the verdict is `refuted` with a receipt referencing the index commit and the relevant spans
+
+#### Scenario: A blind-spot claim is unverifiable, not fabricated
+
+- **GIVEN** a `dead` claim about a symbol reachable only through synthesized dynamic-dispatch edges
+- **WHEN** the claim is verified
+- **THEN** the verdict is `unverifiable` with the dispatch boundary named, never `confirmed` or `refuted`

--- a/src/cli/commands/mcp-presets.test.ts
+++ b/src/cli/commands/mcp-presets.test.ts
@@ -170,8 +170,12 @@ describe('tools/list payload budget (spec-28)', () => {
   // PageRank ranking mode (`rankBy` on orient + `rankBy`/`tokenBudget` on get_minimal_context;
   // spec: add-personalized-pagerank-context-ranking) was added — a ranking MODE on existing
   // tools, no new tool, default surface count unchanged. Conscious decision, not silent drift.
+  // Bumped 55_000 → 56_500 when the opt-in `verify_claim` tool was added to the full surface
+  // (structural claim verification; spec: add-structural-claim-verification) — one new tool
+  // (~900 B trimmed). It stays out of the default/minimal and navigation surfaces (lands in the
+  // opt-in `verify` preset); only the full surface widens. Conscious decision, not silent drift.
   it('full surface stays within its prefix budget', () => {
-    expect(payloadBytes({})).toBeLessThan(55_000);
+    expect(payloadBytes({})).toBeLessThan(56_500);
   });
 
   it('navigation preset stays lean (the low-overhead surface that wins the benchmark)', () => {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -538,6 +538,29 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'verify_claim',
+    description:
+      'USE THIS BEFORE asserting a structural fact ("X is dead", "Y calls Z", "this is safe to change"). ' +
+      'Returns a deterministic verdict (confirmed | refuted | unverifiable) + a citation receipt (spans, ' +
+      'content hashes, index commit) — a graph computation, never an LLM guess. kinds: calls, reaches, ' +
+      'impacts, dead, safe-to-change. "unverifiable" is first-class when the claim hits a dynamic-dispatch ' +
+      'blind spot — hedge or read the source. Run analyze_codebase first.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        directory: { type: 'string', description: DIR_DESC },
+        kind: {
+          type: 'string',
+          enum: ['calls', 'reaches', 'dead', 'impacts', 'safe-to-change'],
+          description: 'The kind of structural claim to verify.',
+        },
+        subject: { type: 'string', description: 'The symbol the claim is about (a function/method name).' },
+        object: { type: 'string', description: 'The second symbol — required for relational kinds (calls, reaches, impacts).' },
+      },
+      required: ['directory', 'kind', 'subject'],
+    },
+  },
+  {
     name: 'structural_diff',
     description:
       'USE THIS WHEN reviewing or refactoring a change: "what changed structurally?", ' +
@@ -1580,7 +1603,7 @@ const TOOL_ANNOTATIONS: Record<string, typeof _RO | typeof _RWI | typeof _RW> = 
   get_test_coverage: _RO, get_minimal_context: _RO, get_cluster: _RO,
   detect_changes: _RO, get_health_map: _RO, get_surprising_connections: _RO, record_decision: _RW, list_decisions: _RO,
   approve_decision: _RWI, reject_decision: _RWI, sync_decisions: _RWI,
-  remember: _RW, recall: _RO,
+  remember: _RW, recall: _RO, verify_claim: _RO,
 };
 
 // Tools that touch external entities (LLM / network) → openWorldHint: true.
@@ -1626,6 +1649,13 @@ export const TOOL_PRESETS: Record<string, Set<string>> = {
   // the tools an agent must consider).
   memory: new Set([
     'orient', 'remember', 'recall',
+  ]),
+  // Claim verification (opt-in): orient to ground, then verify a structural claim
+  // and cite the receipt before asserting it to a human. Deliberately NOT in the
+  // default or `minimal` surface (mcp-quality: minimize the tools an agent must
+  // consider). search_code helps the agent name the subject/object precisely.
+  verify: new Set([
+    'orient', 'search_code', 'verify_claim',
   ]),
 };
 

--- a/src/core/decisions/anchor-adapter.ts
+++ b/src/core/decisions/anchor-adapter.ts
@@ -56,15 +56,23 @@ function readFileCached(rootPath: string, filePath: string, cache: Map<string, s
   return content;
 }
 
-/** Hash a node's source span by its byte offsets against current file content. */
+/**
+ * Slice a node's source span out of its file. `startIndex`/`endIndex` are the
+ * tree-sitter offsets, which are UTF-16 code-unit indices (not byte offsets) — so
+ * we slice the JS string directly. Slicing a Buffer by these indices would drift
+ * in any file containing multibyte characters before the span, citing misaligned
+ * source. String.slice clamps out-of-range indices, so a shrunken file still
+ * yields a deterministic (and differing → drifted) span.
+ */
+function sliceNodeSpan(content: string, node: FunctionNode): string {
+  return content.slice(node.startIndex, node.endIndex);
+}
+
+/** Hash a node's source span (code-unit offsets) against current file content. */
 function hashNodeSpan(rootPath: string, node: FunctionNode, cache: Map<string, string | null>): string | undefined {
   const content = readFileCached(rootPath, node.filePath, cache);
   if (content === null) return undefined;
-  // start/end are byte offsets; slice a Buffer to stay byte-accurate for multibyte
-  // source. subarray clamps out-of-range indices, so a shrunken file still hashes
-  // deterministically (and differs from the original span → drifted).
-  const buf = Buffer.from(content, 'utf-8');
-  return hashSpan(buf.subarray(node.startIndex, node.endIndex).toString('utf-8'));
+  return hashSpan(sliceNodeSpan(content, node));
 }
 
 /**
@@ -177,16 +185,16 @@ export class AnchorContext {
 
   /**
    * The current span hash AND 1-based inclusive line range of a node, computed
-   * from its byte offsets against the live file (the edge store keeps offsets, not
-   * lines). Reuses the same span the freshness hash covers, so `contentHash` here
-   * equals the hash the freshness check compared.
+   * from its code-unit offsets against the live file (the edge store keeps
+   * offsets, not lines). Reuses the same span — and the same {@link sliceNodeSpan}
+   * — that the freshness hash covers, so `contentHash` here equals the hash the
+   * freshness check compared, and the cited line range matches the hashed span.
    */
   private nodeSpanInfo(node: FunctionNode): { contentHash: string; lineSpan: { start: number; end: number } } | undefined {
     const content = readFileCached(this.rootPath, node.filePath, this.fileCache);
     if (content === null) return undefined;
-    const buf = Buffer.from(content, 'utf-8');
-    const spanText = buf.subarray(node.startIndex, node.endIndex).toString('utf-8');
-    const start = buf.subarray(0, node.startIndex).toString('utf-8').split('\n').length;
+    const spanText = sliceNodeSpan(content, node);
+    const start = content.slice(0, node.startIndex).split('\n').length;
     const newlines = (spanText.match(/\n/g) ?? []).length;
     // A span ending in a newline shouldn't count the empty trailing line.
     const end = start + newlines - (spanText.endsWith('\n') ? 1 : 0);

--- a/src/core/decisions/anchor-adversarial.test.ts
+++ b/src/core/decisions/anchor-adversarial.test.ts
@@ -23,11 +23,11 @@ import {
   anchorFreshness,
   type GraphFreshnessView,
 } from './anchor.js';
-import { makeFreshnessView } from './anchor-adapter.js';
+import { makeFreshnessView, AnchorContext } from './anchor-adapter.js';
 import { EdgeStore } from '../services/edge-store.js';
 import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR } from '../../constants.js';
 import type { StructuralAnchor } from '../../types/index.js';
-import type { FunctionNode } from '../analyzer/call-graph.js';
+import { CallGraphBuilder, type FunctionNode } from '../analyzer/call-graph.js';
 
 // ── deterministic PRNG (no new dependency; replayable across runs) ────────────
 // mulberry32: a tiny seeded generator so the property cases are reproducible.
@@ -148,51 +148,81 @@ describe('FreshnessFailsSafeTowardDistrust — whitespace / comment-only edits d
 });
 
 // ════════════════════════════════════════════════════════════════════════════
-// 3. Multibyte / UTF-8 span boundaries — byte-correct slicing end to end
+// 3. Multibyte / UTF-8 span boundaries — span slicing aligned end to end
 // ════════════════════════════════════════════════════════════════════════════
+// tree-sitter node offsets (startIndex/endIndex) are UTF-16 code-unit indices,
+// NOT byte offsets. The anchor adapter must slice the source string by those
+// code units — slicing a Buffer by them drifts in any file with multibyte chars
+// before the span, citing a misaligned hash + line range. These tests derive the
+// node from the REAL parser (ground truth on the offset unit) rather than
+// hand-computed offsets, so they fail if the slicing unit ever regresses.
 describe('FreshnessFailsSafeTowardDistrust — multibyte span boundaries', () => {
   let root: string;
+  let fooNode: FunctionNode;
   const ANALYSIS = () => join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
 
-  // Source whose function body contains multibyte chars so the span's end byte
-  // offset lands after a multibyte sequence, not inside an ASCII run.
+  // Source whose lines BEFORE the function contain multibyte chars, so a node
+  // offset interpreted as a byte index would land mid-span. `foo`'s body also
+  // carries a multibyte literal so an end-offset slip corrupts the span too.
   const SRC = 'const banner = "préface 日本語 🚀";\nexport function foo() {\n  return "café";\n}\n';
 
-  function fooNode(): FunctionNode {
-    const start = Buffer.byteLength('const banner = "préface 日本語 🚀";\n', 'utf-8');
-    const end = Buffer.byteLength(SRC, 'utf-8') - 1; // through the function, drop trailing newline
-    return { id: 'src/foo.ts::foo', name: 'foo', filePath: 'src/foo.ts', isAsync: false, language: 'typescript', startIndex: start, endIndex: end, fanIn: 0, fanOut: 0 };
-  }
+  // The exact source a correct citation must reconstruct (the function_declaration
+  // node, which begins at `function` — the `export` modifier is its parent).
+  const FOO_SRC = SRC.slice(SRC.indexOf('function foo'), SRC.indexOf('}') + 1);
 
-  async function buildStore(): Promise<void> {
+  async function buildStore(): Promise<FunctionNode> {
+    const result = await new CallGraphBuilder().build([
+      { path: 'src/foo.ts', content: SRC, language: 'TypeScript' },
+    ]);
+    const node = [...result.nodes.values()].find(n => n.name === 'foo');
+    if (!node) throw new Error('parser did not produce a node for foo');
     await mkdir(ANALYSIS(), { recursive: true });
     const store = EdgeStore.open(EdgeStore.dbPath(ANALYSIS()));
     store.clearAll();
-    store.insertNodes([fooNode()]);
+    store.insertNodes([node]);
     store.close();
+    return node;
   }
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), 'openlore-mb-'));
     await mkdir(join(root, 'src'), { recursive: true });
     await writeFile(join(root, 'src', 'foo.ts'), SRC, 'utf-8');
-    await buildStore();
+    fooNode = await buildStore();
   });
   afterEach(async () => { await rm(root, { recursive: true, force: true }); });
 
+  // Reconstruct the span exactly as the adapter does: slice the string by the
+  // real (code-unit) offsets. Byte-slicing here would drift past the leading
+  // multibyte line and never reproduce FOO_SRC.
   function spanHashOfCurrent(): string {
-    const buf = Buffer.from(SRC, 'utf-8');
-    const n = fooNode();
-    return hashSpan(buf.subarray(n.startIndex, n.endIndex).toString('utf-8'));
+    return hashSpan(SRC.slice(fooNode.startIndex, fooNode.endIndex));
   }
 
-  it('the freshness view hashes a multibyte-bounded span byte-correctly (fresh only when bytes unchanged)', () => {
+  it('node offsets are code units, and the cited span reconstructs the exact function source', () => {
+    expect(SRC.slice(fooNode.startIndex, fooNode.endIndex)).toBe(FOO_SRC);
+  });
+
+  it('the certificate cites the right line range + a hash of the real span (not byte-misaligned)', () => {
+    const ctx = AnchorContext.open(root)!;
+    try {
+      const cert = ctx.certificateForAnchor({ nodeId: fooNode.id, filePath: 'src/foo.ts', symbolName: 'foo' });
+      expect(cert).toBeDefined();
+      // foo's declaration is on line 2; its closing brace on line 4.
+      expect(cert!.lineSpan).toEqual({ start: 2, end: 4 });
+      expect(cert!.contentHash).toBe(hashSpan(FOO_SRC));
+    } finally {
+      ctx.close();
+    }
+  });
+
+  it('the freshness view hashes the span correctly (fresh only when the span is unchanged)', () => {
     const store = EdgeStore.open(EdgeStore.dbPath(ANALYSIS()));
     try {
       const view = makeFreshnessView(store, root);
-      const anchor: StructuralAnchor = { nodeId: 'src/foo.ts::foo', filePath: 'src/foo.ts', contentHash: spanHashOfCurrent() };
-      // Unchanged bytes → fresh, proving the byte-offset slice reconstructs the
-      // exact same span across a multibyte boundary (no off-by-one corruption).
+      const anchor: StructuralAnchor = { nodeId: fooNode.id, filePath: 'src/foo.ts', contentHash: spanHashOfCurrent() };
+      // Unchanged source → fresh, proving the code-unit slice reconstructs the
+      // exact span across a multibyte boundary (no off-by-one corruption).
       expect(anchorFreshness(anchor, view).freshness).toBe('fresh');
     } finally {
       store.close();
@@ -206,7 +236,7 @@ describe('FreshnessFailsSafeTowardDistrust — multibyte span boundaries', () =>
     const store = EdgeStore.open(EdgeStore.dbPath(ANALYSIS()));
     try {
       const view = makeFreshnessView(store, root);
-      const anchor: StructuralAnchor = { nodeId: 'src/foo.ts::foo', filePath: 'src/foo.ts', contentHash: recorded };
+      const anchor: StructuralAnchor = { nodeId: fooNode.id, filePath: 'src/foo.ts', contentHash: recorded };
       expect(anchorFreshness(anchor, view).freshness).toBe('drifted');
     } finally {
       store.close();

--- a/src/core/services/mcp-handlers/claim-verification.test.ts
+++ b/src/core/services/mcp-handlers/claim-verification.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Structural claim verification (change: add-structural-claim-verification).
+ *
+ * Verdict logic over fixture call graphs (mocked readCachedContext) for every
+ * claim kind, plus a real-edge-store test that the receipt's content hash equals
+ * an independent hash of the cited span. Plain .test.ts so CI runs it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./utils.js', () => ({
+  validateDirectory: vi.fn(async (d: string) => d),
+  readCachedContext: vi.fn(),
+}));
+
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { handleVerifyClaim } from './claim-verification.js';
+import { readCachedContext } from './utils.js';
+import { __resetStalenessMemo } from './confidence-boundary.js';
+import { EdgeStore } from '../edge-store.js';
+import { hashSpan } from '../../decisions/anchor.js';
+import { OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR } from '../../../constants.js';
+import type { FunctionNode, SerializedCallGraph, CallEdge } from '../../analyzer/call-graph.js';
+
+function node(over: Partial<FunctionNode> & { id: string }): FunctionNode {
+  return {
+    name: over.id.split('::')[1] ?? over.id, filePath: over.id.split('::')[0] ?? 'x.ts',
+    isAsync: false, language: 'TypeScript', startIndex: 0, endIndex: 100, fanIn: 0, fanOut: 0, ...over,
+  };
+}
+function edge(callerId: string, calleeId: string, over: Partial<CallEdge> = {}): CallEdge {
+  return { callerId, calleeId, calleeName: calleeId.split('::')[1] ?? calleeId, confidence: 'import', kind: 'calls', ...over };
+}
+function graph(nodes: FunctionNode[], edges: CallEdge[]): SerializedCallGraph {
+  return { nodes, edges, classes: [], inheritanceEdges: [], hubFunctions: [], entryPoints: [], layerViolations: [],
+    stats: { totalNodes: nodes.length, totalEdges: edges.length, avgFanIn: 0, avgFanOut: 0 } };
+}
+function useGraph(nodes: FunctionNode[], edges: CallEdge[]): void {
+  vi.mocked(readCachedContext).mockResolvedValue({ callGraph: graph(nodes, edges) } as never);
+}
+
+// Live chain: main (a root, main-like) → handler → helper. orphan is dead.
+const MAIN = node({ id: 'src/main.ts::main', fanOut: 1 });
+const HANDLER = node({ id: 'src/app.ts::handler', fanIn: 1, fanOut: 1 });
+const HELPER = node({ id: 'src/app.ts::helper', fanIn: 1 });
+const ORPHAN = node({ id: 'src/dead.ts::orphan' });
+const LIVE_EDGES = [
+  edge('src/main.ts::main', 'src/app.ts::handler'),
+  edge('src/app.ts::handler', 'src/app.ts::helper'),
+];
+
+beforeEach(() => {
+  __resetStalenessMemo();
+  useGraph([MAIN, HANDLER, HELPER, ORPHAN], LIVE_EDGES);
+});
+
+describe('verify_claim — input validation', () => {
+  it('rejects an unknown claim kind', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'whatever' as never, subject: 'main' }) as { error: string };
+    expect(r.error).toMatch(/Unknown claim kind/);
+  });
+  it('requires an object for relational kinds', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'calls', subject: 'main' }) as { error: string };
+    expect(r.error).toMatch(/provide an "object"/);
+  });
+  it('errors cleanly when no analysis is cached', async () => {
+    vi.mocked(readCachedContext).mockResolvedValueOnce(null as never);
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'dead', subject: 'orphan' }) as { error: string };
+    expect(r.error).toMatch(/analyze_codebase/);
+  });
+});
+
+describe('verify_claim — unresolved / ambiguous symbols are unverifiable', () => {
+  it('returns unverifiable when the subject is not in the graph', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'dead', subject: 'nonexistent' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('unverifiable');
+    expect(r.reason).toMatch(/not found/);
+  });
+  it('returns unverifiable when the subject name is ambiguous', async () => {
+    useGraph([node({ id: 'a.ts::dup' }), node({ id: 'b.ts::dup' }), MAIN], []);
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'dead', subject: 'dup' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('unverifiable');
+    expect(r.reason).toMatch(/ambiguous/);
+  });
+});
+
+describe('verify_claim — calls', () => {
+  it('confirms a true direct calls claim', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'calls', subject: 'main', object: 'handler' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('confirmed');
+    expect(r.reason).toMatch(/directly calls/);
+  });
+  it('refutes a false calls claim (transitive, not direct)', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'calls', subject: 'main', object: 'helper' }) as { verdict: string };
+    expect(r.verdict).toBe('refuted');
+  });
+  it('confirms a synthesized-only calls claim but flags the dispatch boundary', async () => {
+    useGraph([MAIN, HANDLER], [
+      edge('src/main.ts::main', 'src/app.ts::handler', { confidence: 'synthesized', synthesizedBy: 'callback-registration' }),
+    ]);
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'calls', subject: 'main', object: 'handler' }) as {
+      verdict: string; confidenceBoundary: { complete: boolean; knownUnknowable?: Array<{ kind: string; rule?: string }> };
+    };
+    expect(r.verdict).toBe('confirmed');
+    expect(r.confidenceBoundary.complete).toBe(false);
+    expect(r.confidenceBoundary.knownUnknowable?.[0]).toMatchObject({ kind: 'synthesized-dispatch', rule: 'callback-registration' });
+  });
+});
+
+describe('verify_claim — reaches', () => {
+  it('confirms a transitive reach and reports the hop count', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'reaches', subject: 'main', object: 'helper' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('confirmed');
+    expect(r.reason).toMatch(/transitively reaches.*2 hop/);
+  });
+  it('refutes an unreachable target', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'reaches', subject: 'helper', object: 'main' }) as { verdict: string };
+    expect(r.verdict).toBe('refuted');
+  });
+});
+
+describe('verify_claim — impacts', () => {
+  it('confirms that changing a callee impacts its transitive caller', async () => {
+    // helper is called (transitively) by main, so changing helper can impact main.
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'impacts', subject: 'helper', object: 'main' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('confirmed');
+    expect(r.reason).toMatch(/can impact "main"/);
+  });
+  it('refutes impact when the object does not depend on the subject', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'impacts', subject: 'main', object: 'helper' }) as { verdict: string };
+    expect(r.verdict).toBe('refuted');
+  });
+});
+
+describe('verify_claim — dead', () => {
+  it('confirms a truly unreachable symbol', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'dead', subject: 'orphan' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('confirmed');
+    expect(r.reason).toMatch(/unreachable from every liveness root/);
+  });
+  it('refutes a symbol reached by direct edges', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'dead', subject: 'helper' }) as { verdict: string };
+    expect(r.verdict).toBe('refuted');
+  });
+  it('returns unverifiable for a symbol reached only through synthesized dispatch', async () => {
+    // ghost is reached from the live root main ONLY via a synthesized edge: dead
+    // in the directly-resolved graph, live in the synthesized-inclusive graph.
+    const ghost = node({ id: 'src/dyn.ts::ghost', fanIn: 1 });
+    useGraph([MAIN, ghost], [
+      edge('src/main.ts::main', 'src/dyn.ts::ghost', { confidence: 'synthesized', synthesizedBy: 'callback-registration' }),
+    ]);
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'dead', subject: 'ghost' }) as {
+      verdict: string; reason: string; confidenceBoundary: { complete: boolean; knownUnknowable?: Array<{ kind: string }> };
+    };
+    expect(r.verdict).toBe('unverifiable');
+    expect(r.reason).toMatch(/synthesized dynamic-dispatch/);
+    expect(r.confidenceBoundary.complete).toBe(false);
+    expect(r.confidenceBoundary.knownUnknowable?.[0]).toMatchObject({ kind: 'synthesized-dispatch' });
+  });
+});
+
+describe('verify_claim — safe-to-change', () => {
+  it('confirms a symbol with no internal callers is safe to change', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'safe-to-change', subject: 'orphan' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('confirmed');
+    expect(r.reason).toMatch(/No internal caller depends/);
+  });
+  it('refutes when internal callers depend on the symbol', async () => {
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'safe-to-change', subject: 'helper' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('refuted');
+    expect(r.reason).toMatch(/internal caller/);
+  });
+  it('returns unverifiable when the symbol is invoked via synthesized dispatch', async () => {
+    const widget = node({ id: 'src/w.ts::widget', fanIn: 1 });
+    useGraph([MAIN, widget], [
+      edge('src/main.ts::main', 'src/w.ts::widget', { confidence: 'synthesized', synthesizedBy: 'route-handler' }),
+    ]);
+    const r = await handleVerifyClaim({ directory: '/p', kind: 'safe-to-change', subject: 'widget' }) as { verdict: string; reason: string };
+    expect(r.verdict).toBe('unverifiable');
+    expect(r.reason).toMatch(/dynamic-dispatch/);
+  });
+});
+
+// ── Receipt as citation (task 2): real edge store + source files ──────────────
+describe('verify_claim — receipt is an auditable citation', () => {
+  let root: string;
+  const FOO_SRC = 'export function foo() {\n  return bar();\n}\n';
+  const BAR_SRC = 'export function bar() {\n  return 1;\n}\n';
+
+  function srcNode(filePath: string, src: string, name: string): FunctionNode {
+    return {
+      id: `${filePath}::${name}`, name, filePath, isAsync: false, language: 'TypeScript',
+      startIndex: 0, endIndex: Buffer.byteLength(src, 'utf-8'),
+      startLine: 1, endLine: src.split('\n').length, fanIn: 0, fanOut: 0,
+    };
+  }
+  const fooNode = () => srcNode('src/foo.ts', FOO_SRC, 'foo');
+  const barNode = () => srcNode('src/bar.ts', BAR_SRC, 'bar');
+
+  beforeEach(async () => {
+    __resetStalenessMemo();
+    root = await mkdtemp(join(tmpdir(), 'openlore-claim-'));
+    await mkdir(join(root, 'src'), { recursive: true });
+    await writeFile(join(root, 'src', 'foo.ts'), FOO_SRC, 'utf-8');
+    await writeFile(join(root, 'src', 'bar.ts'), BAR_SRC, 'utf-8');
+    const dir = join(root, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR);
+    await mkdir(dir, { recursive: true });
+    const store = EdgeStore.open(EdgeStore.dbPath(dir));
+    store.clearAll();
+    store.insertNodes([fooNode(), barNode()]);
+    store.close();
+    // The fixture call graph the handler reasons over: foo directly calls bar.
+    vi.mocked(readCachedContext).mockResolvedValue({
+      callGraph: graph([fooNode(), barNode()], [edge('src/foo.ts::foo', 'src/bar.ts::bar')]),
+    } as never);
+  });
+  afterEach(async () => { await rm(root, { recursive: true, force: true }); });
+
+  it('attaches a receipt whose content hash matches an independent hash of the cited span', async () => {
+    const r = await handleVerifyClaim({ directory: root, kind: 'calls', subject: 'foo', object: 'bar' }) as {
+      verdict: string;
+      receipt?: { subject: { contentHash: string; symbol?: string; lineSpan?: { start: number; end: number } }; object?: { contentHash: string } };
+    };
+    expect(r.verdict).toBe('confirmed');
+    expect(r.receipt).toBeDefined();
+    // The receipt's subject hash equals an independent hash of foo's source span.
+    expect(r.receipt!.subject.symbol).toBe('foo');
+    expect(r.receipt!.subject.contentHash).toBe(hashSpan(FOO_SRC));
+    // And the object certificate cites bar's span.
+    expect(r.receipt!.object?.contentHash).toBe(hashSpan(BAR_SRC));
+  });
+});

--- a/src/core/services/mcp-handlers/claim-verification.ts
+++ b/src/core/services/mcp-handlers/claim-verification.ts
@@ -1,0 +1,451 @@
+/**
+ * Structural claim verification (change: add-structural-claim-verification).
+ *
+ * The reverse of context retrieval: instead of OpenLore handing the agent facts,
+ * the AGENT submits a structured claim about code structure and OpenLore returns a
+ * deterministic verdict plus a citation it can show a human. This converts the
+ * agent's confident-wrong failure mode ("this function is dead", "Y calls Z") into
+ * checked-or-flagged, and makes the agent's output auditable.
+ *
+ *   claim   = { kind: 'calls'|'reaches'|'dead'|'impacts'|'safe-to-change', subject, object? }
+ *   verdict = { verdict: 'confirmed'|'refuted'|'unverifiable', reason, receipt?, confidenceBoundary }
+ *
+ * Every verdict is a graph computation over the deterministic call graph, never an
+ * LLM judgement and never a confidence number (north star c6d1ad07):
+ *   - `calls`          → a direct caller→callee edge exists.
+ *   - `reaches`        → forward reachability subject ⇒ object.
+ *   - `impacts`        → backward reachability: object transitively calls subject,
+ *                        so changing subject can require changes in object.
+ *   - `dead`           → mark-and-sweep reachability (reuses {@link deadCodeIds}),
+ *                        run twice (synthesized-inclusive vs directly-resolved) to
+ *                        separate truly-unreached from reached-only-via-heuristic.
+ *   - `safe-to-change` → no internal caller depends on subject (blast radius is
+ *                        empty by directly-resolved edges).
+ *
+ * The receipt reuses the grounding-certificate shape (`{ symbol, filePath,
+ * lineSpan, contentHash }`) — the same span hash the freshness check compares — so
+ * a human can audit the claim against the index at a named commit. `unverifiable`
+ * is first-class: when a verdict rests on a dispatch blind spot it is named via
+ * `add-confidence-boundary-disclosure`, rather than fabricating a decisive answer.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { validateDirectory, readCachedContext } from './utils.js';
+import { buildAdjacency } from './graph.js';
+import { deadCodeIds } from './reachability.js';
+import {
+  assembleBoundary,
+  buildPairEdgeIndex,
+  computeStaleness,
+  edgeBasis,
+  edgeBasisForChains,
+  type BoundaryEdge,
+  type ConfidenceBoundary,
+  type KnownUnknowableCrossing,
+} from './confidence-boundary.js';
+import { AnchorContext } from '../../decisions/anchor-adapter.js';
+import { ARTIFACT_FINGERPRINT, OPENLORE_ANALYSIS_SUBDIR, OPENLORE_DIR } from '../../../constants.js';
+import type { SerializedCallGraph, FunctionNode } from '../../analyzer/call-graph.js';
+import type { GroundingCertificate, StructuralAnchor } from '../../../types/index.js';
+
+export type ClaimKind = 'calls' | 'reaches' | 'dead' | 'impacts' | 'safe-to-change';
+const CLAIM_KINDS: ReadonlySet<string> = new Set<ClaimKind>([
+  'calls', 'reaches', 'dead', 'impacts', 'safe-to-change',
+]);
+/** Kinds that relate two symbols and so require an `object`. */
+const RELATIONAL_KINDS: ReadonlySet<ClaimKind> = new Set<ClaimKind>(['calls', 'reaches', 'impacts']);
+
+export type Verdict = 'confirmed' | 'refuted' | 'unverifiable';
+
+export interface VerifyClaimInput {
+  directory: string;
+  kind: ClaimKind;
+  /** The symbol the claim is about (a function/method name). */
+  subject: string;
+  /** The second symbol, for relational kinds (`calls`, `reaches`, `impacts`). */
+  object?: string;
+}
+
+/** Evidence behind a verdict — citable to a human, auditable against the index. */
+interface Receipt {
+  /** Short SHA the index was built at, when captured. */
+  indexCommit: string | null;
+  /** Grounding certificate for the subject symbol (span + content hash). */
+  subject: GroundingCertificate;
+  /** Grounding certificate for the object symbol, for relational kinds. */
+  object?: GroundingCertificate;
+  /** Symbol-name chain for a `reaches`/`impacts` path (subject ⇒ … ⇒ object). */
+  via?: string[];
+  /** Human-readable account of what the graph showed. */
+  evidence: string;
+}
+
+interface ClaimResult {
+  verdict: Verdict;
+  reason: string;
+  receipt?: Receipt;
+  /** Crossings that make a verdict `unverifiable` or qualify a `confirmed` one. */
+  extraCrossings?: KnownUnknowableCrossing[];
+  /** Edges underpinning the verdict — the basis for the confidence boundary. */
+  basisEdges?: BoundaryEdge[];
+  /** Symbol-name chain to surface in the receipt (reaches/impacts paths). */
+  receiptVia?: string[];
+}
+
+/** A code node we can reason about (not an external symbol). */
+function isCodeNode(n: FunctionNode): boolean {
+  return !n.isExternal;
+}
+
+interface Resolution {
+  node?: FunctionNode;
+  /** How many symbols the name matched (>1 ⇒ ambiguous). */
+  matched: number;
+  /** The match strategy that resolved it. */
+  how: 'exact' | 'fuzzy' | 'none' | 'ambiguous';
+}
+
+/**
+ * Resolve a symbol name to a single internal node. Prefer an exact (case-
+ * insensitive) name match; fall back to a unique substring match. An ambiguous
+ * name (multiple matches at the chosen precision) resolves to no node so the
+ * caller can return `unverifiable` rather than guess which symbol was meant.
+ */
+function resolveSymbol(cg: SerializedCallGraph, name: string): Resolution {
+  const lower = name.toLowerCase();
+  const code = cg.nodes.filter(isCodeNode);
+  const exact = code.filter(n => n.name.toLowerCase() === lower);
+  if (exact.length === 1) return { node: exact[0], matched: 1, how: 'exact' };
+  if (exact.length > 1) return { matched: exact.length, how: 'ambiguous' };
+  const fuzzy = code.filter(n => n.name.toLowerCase().includes(lower));
+  if (fuzzy.length === 1) return { node: fuzzy[0], matched: 1, how: 'fuzzy' };
+  if (fuzzy.length > 1) return { matched: fuzzy.length, how: 'ambiguous' };
+  return { matched: 0, how: 'none' };
+}
+
+/** Read the build commit the index was analyzed at, if it was captured. */
+async function readIndexCommit(absDir: string): Promise<string | null> {
+  try {
+    const raw = await readFile(join(absDir, OPENLORE_DIR, OPENLORE_ANALYSIS_SUBDIR, ARTIFACT_FINGERPRINT), 'utf-8');
+    const fp = JSON.parse(raw) as { commit?: string | null };
+    return fp.commit ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Forward BFS from a seed, tracking the predecessor so a path can be rebuilt. */
+function reachWithPath(
+  seedId: string,
+  targetId: string,
+  adjacency: Map<string, Set<string>>,
+): string[] | null {
+  if (seedId === targetId) return [seedId];
+  const parent = new Map<string, string>();
+  const seen = new Set<string>([seedId]);
+  const queue: string[] = [seedId];
+  while (queue.length) {
+    const id = queue.shift()!;
+    for (const next of adjacency.get(id) ?? []) {
+      if (seen.has(next)) continue;
+      seen.add(next);
+      parent.set(next, id);
+      if (next === targetId) {
+        const path: string[] = [next];
+        let cur = next;
+        while (cur !== seedId) { cur = parent.get(cur)!; path.push(cur); }
+        return path.reverse();
+      }
+      queue.push(next);
+    }
+  }
+  return null;
+}
+
+const SYNTH_DISPATCH_DETAIL =
+  'reached only through synthesized dynamic-dispatch edges (callback/event/route or class-hierarchy ' +
+  'dispatch), whose true target is not statically guaranteed — so static reachability cannot decide this ' +
+  'claim. Read the source or run the code to confirm.';
+
+/** Verify `calls`: a direct caller→callee edge subject→object. */
+function verifyCalls(cg: SerializedCallGraph, subject: FunctionNode, object: FunctionNode): ClaimResult {
+  let direct: BoundaryEdge | undefined;
+  let synthesized: BoundaryEdge | undefined;
+  for (const e of cg.edges) {
+    if (e.callerId !== subject.id || e.calleeId !== object.id) continue;
+    if (e.kind && e.kind !== 'calls') continue; // only true call edges decide "calls"
+    if (e.confidence === 'synthesized') synthesized ??= { confidence: e.confidence, synthesizedBy: e.synthesizedBy };
+    else direct ??= { confidence: e.confidence, synthesizedBy: e.synthesizedBy };
+  }
+  if (direct) {
+    return {
+      verdict: 'confirmed',
+      reason: `"${subject.name}" directly calls "${object.name}" (a directly-resolved call edge).`,
+      basisEdges: [direct],
+    };
+  }
+  if (synthesized) {
+    return {
+      verdict: 'confirmed',
+      reason: `"${subject.name}" calls "${object.name}" via a synthesized ${synthesized.synthesizedBy ?? 'dynamic-dispatch'} edge — recovered heuristically, not by direct name resolution; verify before asserting.`,
+      basisEdges: [synthesized],
+    };
+  }
+  return {
+    verdict: 'refuted',
+    reason: `No direct call edge from "${subject.name}" to "${object.name}" in the call graph.`,
+    basisEdges: [],
+  };
+}
+
+/** Verify `reaches` (forward) / `impacts` (backward) by reachability with a path. */
+function verifyReach(
+  cg: SerializedCallGraph,
+  subject: FunctionNode,
+  object: FunctionNode,
+  kind: 'reaches' | 'impacts',
+): ClaimResult {
+  const { forward, backward } = buildAdjacency(cg);
+  const pairIndex = buildPairEdgeIndex(cg.edges);
+  // `reaches`: does subject call through to object (forward from subject)?
+  // `impacts`: does changing subject affect object — i.e. object transitively
+  // calls subject, so we walk backward from subject and look for object.
+  const adjacency = kind === 'reaches' ? forward : backward;
+  const path = reachWithPath(subject.id, object.id, adjacency);
+  if (!path) {
+    return {
+      verdict: 'refuted',
+      reason: kind === 'reaches'
+        ? `No call path from "${subject.name}" to "${object.name}" — it is not transitively reachable.`
+        : `Changing "${subject.name}" does not impact "${object.name}": no call path runs from "${object.name}" through to "${subject.name}".`,
+      basisEdges: [],
+    };
+  }
+  // For `impacts` the path was reconstructed over backward edges as
+  // subject ⇐ … ⇐ object; present it caller→callee (object ⇒ … ⇒ subject).
+  const callerToCallee = kind === 'reaches' ? path : [...path].reverse();
+  const basis = edgeBasisForChains([callerToCallee], pairIndex);
+  const names = callerToCallee.map(id => cg.nodes.find(n => n.id === id)?.name ?? id);
+  const reason = kind === 'reaches'
+    ? `"${subject.name}" transitively reaches "${object.name}" in ${callerToCallee.length - 1} hop(s).`
+    : `Changing "${subject.name}" can impact "${object.name}": "${object.name}" transitively calls it in ${callerToCallee.length - 1} hop(s).`;
+  return {
+    verdict: 'confirmed',
+    reason: basis.synthesizedEdges > 0
+      ? `${reason} ${basis.synthesizedEdges} edge(s) on this path are synthesized — verify before asserting.`
+      : reason,
+    basisEdges: chainEdges(callerToCallee, pairIndex),
+    receiptVia: names,
+  };
+}
+
+/** Edges along a node-id chain, deduped, for the boundary basis. */
+function chainEdges(chain: string[], pairIndex: Map<string, BoundaryEdge>): BoundaryEdge[] {
+  const out: BoundaryEdge[] = [];
+  for (let i = 0; i + 1 < chain.length; i++) {
+    const e = pairIndex.get(chain[i] + '\x00' + chain[i + 1]);
+    if (e) out.push(e);
+  }
+  return out;
+}
+
+/**
+ * Verify `dead`: is subject unreachable from any liveness root? Reuses
+ * {@link deadCodeIds} so the verdict agrees with `find_dead_code` on what
+ * "reachable" means, run twice:
+ *   - dead in the synthesized-inclusive graph AND the directly-resolved graph
+ *     ⇒ confirmed dead (a strong candidate; external/reflection callers caveated).
+ *   - reached by directly-resolved edges ⇒ refuted (it is live).
+ *   - reached ONLY via synthesized dynamic-dispatch edges ⇒ unverifiable (a
+ *     dispatch blind spot; static reachability cannot decide deadness).
+ */
+async function verifyDead(absDir: string, cg: SerializedCallGraph, subject: FunctionNode): Promise<ClaimResult> {
+  const deadFull = await deadCodeIds(absDir, cg);
+  const strictCg: SerializedCallGraph = { ...cg, edges: cg.edges.filter(e => e.confidence !== 'synthesized') };
+  const deadStrict = await deadCodeIds(absDir, strictCg);
+
+  const inFull = deadFull.has(subject.id);
+  const inStrict = deadStrict.has(subject.id);
+
+  if (inFull) {
+    return {
+      verdict: 'confirmed',
+      reason: `"${subject.name}" is unreachable from every liveness root (tests, imported symbols, route handlers, main) — even counting synthesized dynamic-dispatch edges. It is a strong dead-code candidate; external consumers and reflection are still invisible to static analysis.`,
+    };
+  }
+  if (inStrict) {
+    // Live only with synthesized edges in play → reached only via heuristic dispatch.
+    return {
+      verdict: 'unverifiable',
+      reason: `"${subject.name}" is ${SYNTH_DISPATCH_DETAIL}`,
+      extraCrossings: [{
+        kind: 'synthesized-dispatch',
+        count: 1,
+        detail: `"${subject.name}" is reachable only through synthesized dynamic-dispatch edges; whether it is truly live or dead cannot be decided statically.`,
+      }],
+    };
+  }
+  return {
+    verdict: 'refuted',
+    reason: `"${subject.name}" is reachable from a liveness root by directly-resolved call edges — it is not dead.`,
+  };
+}
+
+/**
+ * Verify `safe-to-change`: no internal caller depends on subject, so changing it
+ * cannot break a caller inside this repo. Confirmed only when the directly-
+ * resolved backward caller set is empty; unverifiable when subject is called via
+ * synthesized dynamic dispatch (callers cannot be fully enumerated).
+ */
+function verifySafeToChange(cg: SerializedCallGraph, subject: FunctionNode): ClaimResult {
+  const directCallers = new Set<string>();
+  let synthesizedCallers = 0;
+  for (const e of cg.edges) {
+    if (e.calleeId !== subject.id) continue;
+    if (e.kind && e.kind !== 'calls' && e.kind !== 'overrides') continue;
+    if (e.confidence === 'synthesized') synthesizedCallers++;
+    else directCallers.add(e.callerId);
+  }
+  if (synthesizedCallers > 0) {
+    return {
+      verdict: 'unverifiable',
+      reason: `"${subject.name}" is invoked via ${synthesizedCallers} synthesized dynamic-dispatch edge(s); its callers cannot be fully enumerated statically, so changing it cannot be declared safe.`,
+      extraCrossings: [{
+        kind: 'synthesized-dispatch',
+        count: synthesizedCallers,
+        detail: `${synthesizedCallers} call(s) into "${subject.name}" are recovered heuristically (dynamic dispatch); a hidden caller may break.`,
+      }],
+    };
+  }
+  if (directCallers.size === 0) {
+    return {
+      verdict: 'confirmed',
+      reason: `No internal caller depends on "${subject.name}" (zero directly-resolved callers) — changing it cannot break a caller inside this repo. External/public consumers are not visible to static analysis.`,
+    };
+  }
+  return {
+    verdict: 'refuted',
+    reason: `"${subject.name}" has ${directCallers.size} internal caller(s); changing its contract risks breaking them. Run select_tests / analyze_impact before editing.`,
+  };
+}
+
+/**
+ * Verify a structured structural claim against the deterministic call graph.
+ * Read-only, offline, no LLM. Returns `unknown` (additive-by-cast like the
+ * sibling handlers).
+ */
+export async function handleVerifyClaim(input: VerifyClaimInput): Promise<unknown> {
+  const absDir = await validateDirectory(input.directory);
+
+  if (!CLAIM_KINDS.has(input.kind)) {
+    return { error: `Unknown claim kind "${input.kind}". Use one of: calls, reaches, dead, impacts, safe-to-change.` };
+  }
+  if (!input.subject || !input.subject.trim()) {
+    return { error: 'A claim must name a "subject" symbol.' };
+  }
+  const needsObject = RELATIONAL_KINDS.has(input.kind);
+  if (needsObject && (!input.object || !input.object.trim())) {
+    return { error: `The "${input.kind}" claim relates two symbols — provide an "object" symbol.` };
+  }
+
+  const ctx = await readCachedContext(absDir);
+  if (!ctx) return { error: 'No analysis found. Run analyze_codebase first.' };
+  if (!ctx.callGraph) return { error: 'Call graph not available. Re-run analyze_codebase.' };
+  const cg = ctx.callGraph as SerializedCallGraph;
+
+  const claim = { kind: input.kind, subject: input.subject, ...(input.object ? { object: input.object } : {}) };
+  const staleness = await computeStaleness(absDir);
+
+  // ── Resolve the symbols; an unresolved/ambiguous symbol is unverifiable ──────
+  const subjRes = resolveSymbol(cg, input.subject);
+  if (!subjRes.node) {
+    return {
+      claim,
+      verdict: 'unverifiable' as Verdict,
+      reason: subjRes.how === 'ambiguous'
+        ? `Subject "${input.subject}" is ambiguous — it matches ${subjRes.matched} symbols. Disambiguate (e.g. by exact name) before verifying.`
+        : `Subject "${input.subject}" was not found in the call graph. It may be external, mis-spelled, or in an unindexed file.`,
+      confidenceBoundary: assembleBoundary({
+        extraCrossings: [{ kind: 'unindexed-repo', count: 0, detail: `"${input.subject}" does not resolve to an indexed symbol.` }],
+        staleness,
+      }),
+    };
+  }
+  let objNode: FunctionNode | undefined;
+  if (needsObject) {
+    const objRes = resolveSymbol(cg, input.object!);
+    if (!objRes.node) {
+      return {
+        claim,
+        verdict: 'unverifiable' as Verdict,
+        reason: objRes.how === 'ambiguous'
+          ? `Object "${input.object}" is ambiguous — it matches ${objRes.matched} symbols. Disambiguate before verifying.`
+          : `Object "${input.object}" was not found in the call graph. It may be external, mis-spelled, or in an unindexed file.`,
+        confidenceBoundary: assembleBoundary({
+          extraCrossings: [{ kind: 'unindexed-repo', count: 0, detail: `"${input.object}" does not resolve to an indexed symbol.` }],
+          staleness,
+        }),
+      };
+    }
+    objNode = objRes.node;
+  }
+  const subject = subjRes.node;
+
+  // ── Dispatch the claim to its deterministic computation ──────────────────────
+  let result: ClaimResult;
+  switch (input.kind) {
+    case 'calls':         result = verifyCalls(cg, subject, objNode!); break;
+    case 'reaches':       result = verifyReach(cg, subject, objNode!, 'reaches'); break;
+    case 'impacts':       result = verifyReach(cg, subject, objNode!, 'impacts'); break;
+    case 'dead':          result = await verifyDead(absDir, cg, subject); break;
+    case 'safe-to-change': result = verifySafeToChange(cg, subject); break;
+    default:              return { error: `Unhandled claim kind "${input.kind}".` };
+  }
+
+  const confidenceBoundary: ConfidenceBoundary = assembleBoundary({
+    ...(result.basisEdges ? { basis: edgeBasis(result.basisEdges) } : {}),
+    ...(result.extraCrossings ? { extraCrossings: result.extraCrossings } : {}),
+    staleness,
+  });
+
+  // ── Receipt (citation): only for a decided verdict, never for unverifiable ───
+  let receipt: Receipt | undefined;
+  if (result.verdict !== 'unverifiable') {
+    const anchorCtx = AnchorContext.open(absDir);
+    if (anchorCtx) {
+      try {
+        const subjCert = anchorCtx.certificateForAnchor(toAnchor(subject));
+        if (subjCert) {
+          const indexCommit = await readIndexCommit(absDir);
+          receipt = { indexCommit, subject: subjCert, evidence: result.reason };
+          if (objNode) {
+            const objCert = anchorCtx.certificateForAnchor(toAnchor(objNode));
+            if (objCert) receipt.object = objCert;
+          }
+          if (result.receiptVia) receipt.via = result.receiptVia;
+        }
+      } finally {
+        anchorCtx.close();
+      }
+    }
+  }
+
+  return {
+    claim,
+    verdict: result.verdict,
+    reason: result.reason,
+    ...(receipt ? { receipt } : {}),
+    confidenceBoundary,
+  };
+}
+
+/** A symbol anchor for a resolved node, for the receipt's grounding certificate. */
+function toAnchor(node: FunctionNode): StructuralAnchor {
+  return {
+    nodeId: node.id,
+    filePath: node.filePath,
+    symbolName: node.name,
+    ...(node.stableId ? { stableId: node.stableId } : {}),
+  };
+}

--- a/src/core/services/mcp-handlers/live-data/tool-driver.ts
+++ b/src/core/services/mcp-handlers/live-data/tool-driver.ts
@@ -179,6 +179,8 @@ export const TOOL_REGISTRY: Record<string, ToolPlan> = {
     }),
   },
   recall: { kind: 'read', buildArgs: (f) => ({ directory: f.directory, limit: 5 }) },
+  // safe-to-change needs only a subject — a single-symbol probe over the fixture.
+  verify_claim: { kind: 'read', buildArgs: needFn((f, fn) => ({ directory: f.directory, kind: 'safe-to-change', subject: fn })) },
 
   // ── LLM-backed tools (openWorldHint) ─────────────────────────────────────
   // generate_tests has a deterministic no-LLM path (useLlm:false + dryRun:true), so

--- a/src/core/services/mcp-handlers/tool-contract.ts
+++ b/src/core/services/mcp-handlers/tool-contract.ts
@@ -100,6 +100,7 @@ export const TOOL_OUTPUT_CLASS: Record<string, ToolOutputClass> = {
   sync_decisions: 'conclusion',
   remember: 'conclusion',
   recall: 'conclusion',
+  verify_claim: 'conclusion',
 };
 
 /** The tools intentionally allowed to emit raw topology, sorted for stable assertions. */

--- a/src/core/services/tool-dispatch.ts
+++ b/src/core/services/tool-dispatch.ts
@@ -21,6 +21,8 @@ import type { DecisionScope } from '../../types/index.js';
 import { handleOrient } from './mcp-handlers/orient.js';
 import { handleSelectTests } from './mcp-handlers/test-impact.js';
 import { handleFindDeadCode } from './mcp-handlers/reachability.js';
+import { handleVerifyClaim } from './mcp-handlers/claim-verification.js';
+import type { ClaimKind } from './mcp-handlers/claim-verification.js';
 import { handleStructuralDiff } from './mcp-handlers/structural-diff.js';
 import { handleGetChangeCoupling } from './mcp-handlers/change-coupling.js';
 import { handleGetHealthMap } from './mcp-handlers/health-map.js';
@@ -310,6 +312,10 @@ export async function dispatchTool(
     const { directory, task, limit = 10, tokenBudget } =
       args as { directory: string; task?: string; limit?: number; tokenBudget?: number };
     return handleRecall(directory, task, limit, tokenBudget);
+  } else if (name === 'verify_claim') {
+    const { directory, kind, subject, object } =
+      args as { directory: string; kind: ClaimKind; subject: string; object?: string };
+    return handleVerifyClaim({ directory, kind, subject, object });
   }
   throw new UnknownToolError(name);
 }


### PR DESCRIPTION
## What

Adds the **`verify_claim`** MCP tool (change: `add-structural-claim-verification`). It reverses the usual direction of OpenLore: instead of the server handing facts to the agent, the **agent submits a structured claim about code and gets back a deterministic verdict plus a citation receipt** it can show a human. This converts the agent's confident-wrong failure mode ("this function is dead", "Y calls Z", "this change is safe") into *checked-or-flagged*, and makes the agent's output auditable.

```
claim   = { kind: 'calls' | 'reaches' | 'dead' | 'impacts' | 'safe-to-change', subject, object? }
verdict = { verdict: 'confirmed' | 'refuted' | 'unverifiable', reason, receipt?, confidenceBoundary }
```

## How each kind is decided (graph computation, never an LLM — north star `c6d1ad07`)

| kind | computation |
|------|-------------|
| `calls` | a direct caller→callee edge exists (synthesized-only edge → confirmed but the dispatch boundary is flagged) |
| `reaches` | forward reachability subject ⇒ object, with the path in the receipt |
| `impacts` | backward reachability: object transitively calls subject, so changing subject can require changes in object |
| `dead` | mark-and-sweep reachability (reuses `deadCodeIds`), run twice — synthesized-inclusive vs directly-resolved — to separate truly-dead from reached-only-via-heuristic-dispatch |
| `safe-to-change` | no internal caller depends on subject (empty directly-resolved blast radius) |

## Receipt as citation

A `confirmed`/`refuted` verdict carries a receipt reusing the **grounding-certificate shape** (`AnchorContext.certificateForAnchor`) — subject/object symbol, file, line span, content hash — plus the **index commit**. The receipt's `contentHash` equals an independent hash of the cited span, so a human can audit the claim against the index at a named commit (test-guarded).

## `unverifiable` is first-class

When a claim's answer rests on a dispatch blind spot (a symbol reached only through synthesized dynamic-dispatch edges, or an unresolved/ambiguous symbol), the verdict is `unverifiable` with the boundary **named** — reusing `add-confidence-boundary-disclosure`. OpenLore never fabricates a decisive verdict to look authoritative.

## Surface

- Conclusion-shaped (verdict + bounded receipt, never a graph). `tool-contract.ts` = `conclusion`.
- Opt-in **`verify` preset** (`orient` + `search_code` + `verify_claim`); never in `minimal`, the first-run default, or `navigation`.
- tools/list payload ceiling bumped 55_000 → 56_500 (one new tool, ~900 B; documented in `mcp-presets.test.ts`).

## Tests & dogfooding

- 19 unit tests: every verdict (confirmed/refuted/unverifiable) for all 5 kinds, input validation, ambiguous/unresolved symbols, and a **real-edge-store test that the receipt hash matches an independent span hash** (task 2).
- Full suite green: **3955 passed, 2 skipped, 0 failures**; typecheck + lint clean.
- **Dogfooded against this repo's live index**: `calls`/`reaches`/`impacts` confirmed with real `via` paths and receipts (real content hashes, line spans, index commit `47be10f`); `calls`/`dead`/`safe-to-change` refuted with caller counts; `unverifiable` for an unknown symbol. `confidenceBoundary.complete=false` correctly reflected working-tree staleness vs the build commit.

## Note on the base branch

Stacked on **`feat/confidence-boundary-disclosure` (#165)** because the `unverifiable` verdict reuses that PR's `assembleBoundary`/`KnownUnknowableCrossing` primitives, which are not yet on `main`. Base will switch to `main` once #165 merges. Never touches `main`.

Decision: `9a8084b6`. Closes the `add-structural-claim-verification` proposal (marked BUILT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: dogfooding caught a misaligned-receipt bug (commit `61a8e5f`)

Re-dogfooding `verify_claim` against this repo's live index (re-analyzed at `59713a1`) surfaced a real defect in the **receipt** — the feature's headline "auditable citation." The receipt for `handleVerifyClaim` cited **lines 335–431** (hashing from mid-doc-comment to mid-body) instead of the true **338–441**.

**Root cause (pre-existing, in shared `anchor-adapter.ts`):** tree-sitter's native binding reports node `startIndex`/`endIndex` as **UTF-16 code-unit** indices, not byte offsets. The grounding-certificate and freshness hashing sliced a `Buffer` by those indices, so in any file with multibyte characters before a span (this repo is full of `—`/`⇒`/`…`), the cited `contentHash` and `lineSpan` drifted. The original unit test passed only because baseline and current hash sliced the **same wrong bytes** — internally consistent, absolutely wrong.

**Fix:** a shared `sliceNodeSpan(content, node)` slices the JS string by code units, reused by both `certificateForAnchor` and the freshness view (preserving the receipt-hash == freshness-hash invariant). ASCII spans are byte-identical → only multibyte spans change (one-time re-baseline). The multibyte adversarial test now derives offsets from the **real `CallGraphBuilder` parse** (ground truth on the offset unit) and asserts the certificate cites the exact line range + a hash of the real function source.

**Re-verified end to end:** receipt now cites `338–441`; its `contentHash` (`9d490063017e6c36`) matches an independent hash of those exact lines. Full suite **3957 passed**, 2 skipped; lint + typecheck clean. Decision `55e7f8e4`.