### PR TITLE
fix(docs): correct stale MCP tool-count claims (45/50 → 60) and guard them

### DIFF
--- a/docs/governance-dogfooding.md
+++ b/docs/governance-dogfooding.md
@@ -27,7 +27,7 @@ evidence is the synced spec sections + ADRs.
 | EdgeStore uses SCHEMA_VERSION rebuild-on-bump instead of migrations | component | `openspec/specs/analyzer/spec.md` |
 | BM25 keyword retrieval is the zero-network floor; embeddings optional | component | `openspec/specs/analyzer/spec.md` |
 | North star: a deterministic structural context substrate for agents | system | `openspec/specs/overview/spec.md` + `openspec/decisions/adr-0001-*.md` |
-| MCP exposes a curated navigation tool preset, not all 50 tools (spec 14) | component | `openspec/specs/cli/spec.md` |
+| MCP exposes a curated navigation tool preset, not all 60 tools (spec 14) | component | `openspec/specs/cli/spec.md` |
 
 ¹ recorded as `cross-domain` but the consolidator re-scoped it to `component`.
 

--- a/openspec/changes/DOGFOOD-v2.1.1-tool-count-drift.md
+++ b/openspec/changes/DOGFOOD-v2.1.1-tool-count-drift.md
@@ -86,3 +86,34 @@ two new guards fail — `governance-dogfooding.md cites "50 tools" but the live 
   without it). Correct by design — the server is not cwd-bound.
 - `docs/AGENT-BENCHMARKS.md` cites "~45 tools" / "--minimal (5 tools)": dated benchmark
   measurements (older `--minimal` had no `get_health_map`); left as historical record.
+
+## Round 2 — deeper verification (the LLM, embedding, graph, federation, and governance paths)
+
+The first round ran in BM25/no-LLM mode. This round exercised the paths that round 1 could not,
+using the **Claude Code CLI as the LLM backend** (`generation.provider: "claude-code"` → shells to
+`claude -p … --output-format json`, no API key) and a **local OpenAI-compatible embedding endpoint**
+(deterministic 256-dim hashing vectorizer, so the HTTP→LanceDB→cosine plumbing is real). Driven
+against the built `dist/cli/index.js` (== 2.1.1). No new bugs found; nothing changed in this commit
+beyond this note.
+
+| Path | Check | Result |
+|------|-------|--------|
+| **LLM `generate`** (claude-code) | full pipeline on a 5-function repo | ✓ real, source-accurate specs in **45.7 s** (Account entity, validation rules, GIVEN/WHEN/THEN scenarios) |
+| **LLM `verify`** (claude-code) | sample a file, score spec vs code | ✓ **71% confidence, 1/1 passed in 7.9 s**; correctly caught the spec gap (Exports 3/4 = 86%) after an undocumented method was added |
+| **LLM `drift`** (claude-code) | detect code changes not in specs | ✓ flagged the 1 changed file, mapped it to the `account` spec |
+| **Embedding / vector index** | `analyze --embed` against the embed server | ✓ LanceDB `functions.lance` built; `orient` + `search_code` flip `bm25_fallback → hybrid` |
+| **Graph traversal** | get_subgraph / analyze_impact / find_path / trace_execution_path / suggest_insertion_points / get_map / select_tests / get_function_skeleton / blast_radius | ✓ real topology (63-node subgraph from a fanIn-172 hub; blast radius 350, riskScore 100); honest "no path within depth 6" + soundness caveats |
+| **`verify_claim`** | claim-with-receipt tool | ✓ ambiguous object → `unverifiable` (refuses to guess); "safe-to-change" hub → `refuted` with receipt (indexCommit, lineSpan, contentHash, 170 callers) |
+| **Federation** | `federation add/list/status` + cross-repo `analyze_impact` | ✓ registry + fingerprint staleness; federation-scoped query reports `reposConsulted: ["securifine"]` (genuinely loads the federated index) |
+| **Decisions / governance gate** | record → consolidate → gate → approve → sync | ✓ full cycle: `record_decision` draft → LLM consolidate (also **extracted 2 real decisions from the diff** via claude-code) → `--gate` emits `{gated:true, reason:"verified"}` → approve → `--sync` writes all 3 into `openspec/specs/account/spec.md` → gate clears (exit 0) |
+| **Repo-shape breadth** | analyze + hybrid `orient` | ✓ added two Python repos (securifine, onkos) to round 1's TS + Rust |
+
+Notes / honest limits:
+- `claude-code` is a real **agentic** backend, so `generate` is slow and token-heavy on large repos
+  (securifine's pre-flight estimated ~217k tokens across many sequential `claude -p` turns; the
+  pipeline is resumable via on-disk stage checkpoints, which a kill/restart confirmed). Not a bug —
+  inherent to using an interactive-agent CLI as a batch completion backend. A new user running
+  `openlore generate` from a normal shell (not nested inside a Claude Code session) avoids the
+  session-nesting contention seen here.
+- `verify` filters candidates by a complexity heuristic (`minComplexity: 50`); files too trivial to
+  verify are skipped with a clean exit — exercised only after adding a genuinely complex function.

--- a/openspec/changes/DOGFOOD-v2.1.1-tool-count-drift.md
+++ b/openspec/changes/DOGFOOD-v2.1.1-tool-count-drift.md
@@ -1,0 +1,88 @@
+# Dogfood — published v2.1.1, first-run e2e (2026-06-19)
+
+End-to-end verification of the **published npm artifact** (`npm install openlore@latest` →
+`openlore@2.1.1`, driven via `node node_modules/openlore/dist/cli/index.js`), run against real
+third-party repos — not fixtures. The published `2.1.1` matches `main` HEAD (git clean), so this
+exercises exactly what a new user downloads.
+
+Goal: reproduce the class of first-run breakage earlier passes found ("unknown command 'orient'",
+"--no-embed kills BM25", "watcher EMFILE on target/", "install never builds the index"). None of
+those recurred. One documentation-drift defect was found and fixed.
+
+## Method
+
+- Staged the real package in an isolated dir (`/tmp/ol-stage`, `npm install openlore@latest`).
+- Dogfooded two read-only fixture repos under the parent dir, restored to pristine after:
+  - **vaulytica** (TypeScript, 2,632 files, pre-existing `.claude/settings.json`) — merge + happy path.
+  - **invariant** (Rust, 242 `.rs` files + Python/Lean, **24 GB / 337,581-file gitignored `target/`**) — the build-dir stress case.
+
+## What passed (published 2.1.1 — no regressions)
+
+| Area | Check | Result |
+|------|-------|--------|
+| `install` (full) | one-command setup + index build on vaulytica | ✓ exit 0, 15.0 s, BM25 over 3,719 functions |
+| `settings.json` merge | pre-existing perms (31 allow / 8 deny) + SessionStart hook preserved; `mcpServers.openlore` migrated to `.mcp.json` | ✓ no clobber |
+| `.gitignore` merge | `.openlore/` appended under a comment, nothing overwritten | ✓ append-only |
+| Idempotent re-install | `install --no-analyze` second run | ✓ every surface `[noop] already up to date` |
+| `install --uninstall` | removes OpenLore-only files, strips managed entries, leaves user perms | ✓ clean reversal |
+| `orient --json` (SessionStart hook) | pure JSON on stdout, diagnostics on stderr | ✓ valid JSON, 0 stderr leak |
+| `orient --task` | real query on both repos | ✓ rich structured result (relevant files/functions, signatures, fanIn/fanOut) |
+| `orient --limit` validation | `abc` / `0` / `-5` | ✓ exit 1, error → stderr, empty stdout (correct) |
+| `analyze` on Rust + 24 GB `target/` | does it descend the gitignored build dir? | ✓ **7.9 s**, 4,603 functions, `target/` pruned, peak RSS 671 MB, no EMFILE |
+| `analyze --force` | re-run idempotency | ✓ identical result |
+| File watcher on `target/` | `mcp --watch` on the 337k-file repo | ✓ process healthy, **0 FDs into `target/`**, no EMFILE |
+| MCP stdio | `initialize` → `tools/list` → `tools/call orient` | ✓ 60 tools listed; `orient` works (requires explicit `directory` arg, by design) |
+| Tool presets | `--minimal` / `--preset navigation` / `memory` / `federation` | ✓ 6 / 10 / 3 / 6 tools — all match the help text |
+| `doctor` | environment health check | ✓ clean (one expected warn: no LLM key) |
+| `audit --json` | JSON purity on a progress-heavy command | ✓ 27 KB pure JSON, 0 stderr |
+
+## The defect — full-surface tool count drifted in two unguarded docs
+
+`src/cli/commands/mcp-tool-count-doc.test.ts` pins the user-facing "N tools" full-surface count to
+`TOOL_DEFINITIONS.length` — but only for `README.md`, `docs/mcp-tools.md`, and `docs/cli-reference.md`.
+Two other current-tense surfaces carried the **same architectural claim** and were never tied to the
+code, so they drifted while the guarded README was kept at the live count (60):
+
+| File | Said | Should be | Nature |
+|------|------|-----------|--------|
+| `openspec/specs/cli/spec.md:444` | "not all **45** tools" | 60 | decision *heading* (present-tense), live consolidated spec |
+| `docs/governance-dogfooding.md:30` | "not all **50** tools" | 60 | governance decision table (present-tense), cites the spec above |
+
+Both phrase the decision as a current fact ("MCP exposes a curated navigation preset, not all N
+tools") — the identical sentence `README.md:469` states correctly as "60". Live `tools/list` returns
+60; `TOOL_DEFINITIONS.length === 60`.
+
+Note the deliberate scope line drawn *inside* `cli/spec.md`: the decision **heading** is a
+present-tense claim and is now fixed + guarded, but the decision **body** ("the spec-14 agent
+benchmark showed that loading all ~45 MCP tool **definitions**…") is a dated measurement from
+2026-06-01 and is left untouched — it says "tool definitions" (singular), so the `tools\b` guard
+regex never matches it, preserving the historical record.
+
+### Root cause
+
+The decision (`c04f2b0c`) was consolidated into `cli/spec.md` and `governance-dogfooding.md` once,
+then the surface grew (49 → 50 → 58 → 60) with no test binding these two renderings to the count.
+The README rendering was guarded and stayed correct; these two lagged.
+
+### Fix
+
+1. `openspec/specs/cli/spec.md:444` — heading 45 → 60 (root: this is the canonical home of decision
+   `c04f2b0c`; no draft remains in the decisions store, so the edit is stable across re-sync).
+2. `docs/governance-dogfooding.md:30` — 50 → 60.
+3. `src/cli/commands/mcp-tool-count-doc.test.ts` — widen `GUARDED_DOCS` to include both files so the
+   claim tracks `TOOL_DEFINITIONS.length` going forward.
+
+### Regression evidence
+
+Guard with the fixes applied: **6 passed**. With the two doc edits reverted (`git stash`), exactly the
+two new guards fail — `governance-dogfooding.md cites "50 tools" but the live surface is 60` and
+`cli/spec.md cites "45 tools" but the live surface is 60` — confirming FAIL-before / PASS-after.
+
+## Notes / non-issues observed
+
+- `npm install` emits one non-fatal `ERESOLVE`/peer-dep warning for `tree-sitter` vs
+  `tree-sitter-typescript`; install completes and analysis works. Cosmetic, not addressed here.
+- The MCP `orient` tool requires an explicit `directory` argument (returns JSON-RPC `-32602`
+  without it). Correct by design — the server is not cwd-bound.
+- `docs/AGENT-BENCHMARKS.md` cites "~45 tools" / "--minimal (5 tools)": dated benchmark
+  measurements (older `--minimal` had no `get_health_map`); left as historical record.

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -441,7 +441,7 @@ openlore emits SCIP for interop with external indexers but never imports it; the
 
 **Consequences:** SCIP consumers get a snapshot; openlore never depends on SCIP being read back.
 
-### MCP exposes a curated navigation tool preset, not all 45 tools
+### MCP exposes a curated navigation tool preset, not all 60 tools
 
 **Status:** Approved
 **Date:** 2026-06-01

--- a/src/cli/commands/mcp-tool-count-doc.test.ts
+++ b/src/cli/commands/mcp-tool-count-doc.test.ts
@@ -4,12 +4,21 @@
  * while the surface grew to 58) because nothing tied the prose to the code. This
  * ties them: add or remove a tool and the doc count must move with it, or CI fails.
  *
- * Scope is deliberately limited to the two current-tense surfaces a user reads to
- * learn the live tool count — README.md and docs/mcp-tools.md. In BOTH of those
- * files every `<N> tools` mention refers to the full surface, so the check is exact.
- * Dated point-in-time spec records under docs/specs/** are intentionally excluded:
- * "Spec 28 measured 50 tools / 47,037 bytes" is a historical measurement, not a
- * claim about today, and rewriting it would falsify the record.
+ * Scope is the current-tense surfaces a user (or agent) reads to learn the live tool
+ * count: README.md, docs/mcp-tools.md, docs/cli-reference.md, docs/governance-dogfooding.md,
+ * and the live consolidated spec openspec/specs/cli/spec.md. In each, every `<N> tools`
+ * mention the regex catches is a present-tense claim about the full surface, so the check
+ * is exact. This list was widened after a v2.1.1 e2e dogfood found the same decision —
+ * "MCP exposes a curated navigation preset, not all <N> tools" — drifted to "45" in the
+ * spec heading and "50" in governance-dogfooding.md while README (guarded) correctly said
+ * "60". Nothing tied those two surfaces to the code, so they lagged.
+ *
+ * Dated point-in-time spec records under docs/specs/** stay excluded: "Spec 28 measured
+ * 50 tools / 47,037 bytes" is a historical measurement, not a claim about today, and
+ * rewriting it would falsify the record. The same distinction holds INSIDE cli/spec.md:
+ * the decision *heading* ("not all <N> tools") is a present-tense fact and is guarded,
+ * while its body's dated benchmark line ("loading all ~45 MCP tool definitions") says
+ * "tool definitions" (singular) — the `tools\b` regex skips it, preserving the record.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -20,10 +29,19 @@ import { TOOL_DEFINITIONS, toolAnnotations } from './mcp.js';
 // src/cli/commands/<this> → repo root is three levels up.
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
-// Files whose every "<N> tools" mention is the live full surface. cli-reference.md
-// is included: its sole "<N> tools" mention ("all <count> tools on a fixed port") is the
-// full `serve --preset all` surface, so the exact check holds there too.
-const GUARDED_DOCS = ['README.md', 'docs/mcp-tools.md', 'docs/cli-reference.md'];
+// Files whose every "<N> tools" mention the regex catches is the live full surface.
+// cli-reference.md: its sole match ("all <count> tools on a fixed port") is the full
+// `serve --preset all` surface. governance-dogfooding.md and cli/spec.md each have exactly
+// one match — the present-tense "not all <N> tools" decision claim — so the exact check
+// holds there too (verified: their only other count phrasing, "~45 MCP tool definitions",
+// is singular "tool" and is not matched).
+const GUARDED_DOCS = [
+  'README.md',
+  'docs/mcp-tools.md',
+  'docs/cli-reference.md',
+  'docs/governance-dogfooding.md',
+  'openspec/specs/cli/spec.md',
+];
 
 describe('documented MCP tool count', () => {
   const expected = TOOL_DEFINITIONS.length;


### PR DESCRIPTION
## What

A first-run **e2e dogfood of the published `openlore@2.1.1`** npm artifact surfaced that the full-surface MCP tool count had drifted in two *current-tense* documentation surfaces the existing doc-count guard does not cover:

| File | Said | Should be |
|------|------|-----------|
| `openspec/specs/cli/spec.md:444` | "not all **45** tools" (decision heading) | 60 |
| `docs/governance-dogfooding.md:30` | "not all **50** tools" (decision table) | 60 |

Both render the same decision (`c04f2b0c`) that `README.md:469` already states correctly as "60". Live `tools/list` returns 60 and `TOOL_DEFINITIONS.length === 60`. `README.md` / `docs/mcp-tools.md` / `docs/cli-reference.md` were guarded and stayed correct; these two were never tied to the code, so they lagged as the surface grew (49 → 50 → 58 → 60).

## Fix

1. `openspec/specs/cli/spec.md` — heading 45 → 60 (the canonical home of the decision; no draft remains in the store, so the edit is stable across re-sync).
2. `docs/governance-dogfooding.md` — 50 → 60.
3. `src/cli/commands/mcp-tool-count-doc.test.ts` — widen `GUARDED_DOCS` to include both files so the count tracks `TOOL_DEFINITIONS.length` going forward.

The dated benchmark line in `cli/spec.md` ("loading all ~45 MCP tool **definitions**") is intentionally left untouched — it says "tool definitions" (singular), which the `tools\b` guard regex never matches, preserving the historical measurement.

## Verification

- **Regression guard is honest:** with the fixes, the suite is **6 passed**; reverting the two doc edits (`git stash`) fails exactly the two new guards (`cites "50 tools" … is 60`, `cites "45 tools" … is 60`). FAIL-before / PASS-after.
- `npm run typecheck` — clean (exit 0).
- `vitest run mcp-tool-count-doc + mcp-presets` — 27 passed.
- **Docs-and-test only; no runtime change.**

## Dogfood results (published 2.1.1 — no regressions)

Verified against **vaulytica** (TS, pre-existing `.claude/settings.json`) and **invariant** (Rust, 24 GB / 337,581-file gitignored `target/`):

- `install` full flow: settings.json merged (perms + hooks preserved, mcp block migrated to `.mcp.json`), `.gitignore` appended, idempotent re-install is a clean no-op, `--uninstall` reverses cleanly.
- `orient --json` pure JSON on stdout (0 stderr leak); `--task` returns rich structured results; `--limit` validation correct (exit 1 → stderr).
- `analyze` on the Rust repo: **7.9 s**, 4,603 functions, `target/` correctly pruned, no EMFILE.
- File watcher on the 337k-file `target/`: **0 FDs into `target/`**, no EMFILE.
- MCP stdio: `initialize` → `tools/list` (60) → `tools/call orient` works; presets `--minimal`/`navigation`/`memory`/`federation` = 6/10/3/6, all matching help text.
- `doctor`, `audit --json` clean.

Full write-up: `openspec/changes/DOGFOOD-v2.1.1-tool-count-drift.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)