### PR TITLE
feat(search): literal-text line index for strings symbols can't hold

### DIFF
--- a/openspec/changes/add-literal-text-search-index/proposal.md
+++ b/openspec/changes/add-literal-text-search-index/proposal.md
@@ -1,0 +1,83 @@
+# Literal-text search: a separate BM25-only line index for the strings symbols can't hold
+
+> Status: DRAFT (2026-06-20). Decision `fd256fde` recorded before any code.
+> Motivated by a real failure: an agent asked to find a green "Message completed" banner in a web app
+> ran `orient` then churned greps and never found it; the string lived as static text in `index.html`.
+> A human's VSCode find-in-files located it in seconds.
+
+## Why
+
+`search_code`'s corpus is **symbol-derived**. Every searchable row is built from a call-graph node or a
+signature entry — `[lang] path qualifiedName signature docstring skeleton`
+(`vector-index.ts:256,399,603`). A file that yields no extracted symbols produces **zero rows** and is
+invisible to search. Static markup, UI copy, hard-coded error strings, config text — none of it is a
+function, class, or signature, so none of it is indexed.
+
+This is not a ranking miss; the text is **never in the index**. The failure mode is severe because it is
+*silent*: `search_code` returns confident symbol matches, the agent trusts the tool over a plain grep,
+and burns the loop hunting in the wrong index. The deterministic-substrate north star (`c6d1ad07`) is
+undermined when the substrate quietly omits an entire class of content the user can see on screen.
+
+## What changes
+
+1. **A separate raw-line text index.** A new LanceDB table holds raw lines of text/markup/config files
+   (HTML, CSS, plain text, templates, and the non-symbol remainder of any file), keyed by
+   `filePath` + `lineNumber`, with the line text. **BM25-only — no embeddings.** Literal-string lookup
+   wants exact lexical match, not vector similarity.
+
+2. **`search_code` falls back to it.** Symbol search runs first; on **zero symbol hits** (or an explicit
+   `mode: 'text'`), `search_code` queries the line index and returns `file:line` matches. One tool, same
+   call shape — the agent that hit zero symbol results now gets the string instead of a dead end.
+
+3. **The call graph stays pure by construction.** Text lines are a separate store. They are **never**
+   nodes, never fed to fanIn/fanOut, hubs, entrypoints, communities, PageRank, `orient`, or `get_map`.
+   Purity is structural, not a filter applied at each call site.
+
+4. **Reuse existing BM25 machinery.** `buildBm25Corpus`, `tokenize`, `bm25Score`, and the
+   `patchBm25Cache` incremental path already exist in `vector-index.ts`. The text index reuses them
+   against its own table rather than inventing a second BM25 implementation.
+
+## What does NOT change
+
+- **No LLM.** Pure lexical indexing and retrieval. North star holds.
+- **No new node kind.** Text is not a pseudo-symbol; the graph and all node-level metrics are untouched
+  (this is the explicit rejection of option 2a in decision `fd256fde`).
+- **No embeddings for text.** BM25-only keeps build cost and index size bounded and keeps results
+  deterministic.
+- **`search_code`'s symbol path is unchanged** when symbol hits exist; the text index is a fallback, not
+  a reranking of code results.
+
+## Why not index text as graph nodes (option 2a, rejected)
+
+Injecting text as pseudo-symbols reuses the existing table and incremental path, but the call graph is
+computed *over nodes*: every text line would pollute fanIn/fanOut, hubs, entrypoints, communities,
+PageRank, `orient`, `get_map`, `get_critical_hubs`, and force a "is this a text node?" filter at every
+present and future call site — a permanent tax that directly contradicts a deterministic structural
+substrate. A separate store pays a one-time plumbing cost to keep the graph pure forever. See decision
+`fd256fde`.
+
+## Application to OpenLore
+
+- **Index build**: the `FileWalker` already walks `.html`/`.css`/text files (they are not in
+  `SKIP_EXTENSIONS`); they are simply dropped today because `detectLanguage` returns `unknown` and no
+  symbols extract. The text index consumes exactly those file contents.
+- **Incremental update**: the `McpWatcher` already patches the symbol index on file change; it gains a
+  parallel patch of the text table (reusing `patchBm25Cache`).
+- **Query surface**: `handleSearchCode` (`mcp.ts`) gains the zero-hit fallback and the `mode: 'text'`
+  flag; the tool contract classification (`conclusion`) is unchanged — it still returns the computed
+  answer (`file:line` hits), not a graph.
+
+## Out of scope
+
+- **Inline `<script>` JS as call-graph symbols** (the separate "#1" improvement). Worthwhile but
+  orthogonal: it gives structural reach into inline JS, whereas this change is about literal-string
+  retrieval. Tracked separately.
+- **Semantic/NL search over text.** This is exact-lexical only. Embedding text is deliberately excluded.
+- **Indexing binary or generated files** already excluded by `SKIP_EXTENSIONS` / `SKIP_FILENAMES`.
+
+## Research basis
+
+Classic inverted-index lexical retrieval (BM25) applied to the content class a symbol index structurally
+cannot represent. The design choice mirrors how IDEs keep a separate full-text index (find-in-files)
+distinct from their symbol index (go-to-definition) — the two answer different questions and conflating
+them degrades both.

--- a/openspec/changes/add-literal-text-search-index/specs/analyzer/spec.md
+++ b/openspec/changes/add-literal-text-search-index/specs/analyzer/spec.md
@@ -1,0 +1,37 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: LiteralTextLineIndex
+
+The system SHALL maintain a literal-text line index separate from the symbol (call-graph / signature)
+index. The text index SHALL store raw lines of walked files whose content is not represented as
+extracted symbols — markup, stylesheet, template, and plain-text files — keyed by file path and line
+number, holding the line text. The index SHALL be BM25-only (lexical), with no vector embeddings, and
+SHALL be queryable by exact-lexical match. Lines that are blank or whitespace-only SHALL be skipped;
+over-long lines SHALL be truncated, not dropped.
+
+#### Scenario: A static markup string is indexed
+
+- **GIVEN** an `index.html` containing the static text `Message completed`
+- **WHEN** the analysis builds its indexes
+- **THEN** the literal-text line index contains a row for that line with its file path and line number
+
+#### Scenario: Text lines are not graph nodes
+
+- **GIVEN** the literal-text line index is populated
+- **WHEN** the call graph and its node-level metrics (fanIn, fanOut, hubs, entrypoints, communities,
+  PageRank) are computed
+- **THEN** no text line appears as a node and no text line contributes to any node-level metric
+
+### Requirement: LiteralTextLineIndexIncrementalUpdate
+
+The literal-text line index SHALL be updated incrementally when watched files change. On a changed or
+added text file the index SHALL replace that file's lines; on a deleted file the index SHALL remove that
+file's lines. The symbol index's incremental update SHALL be unaffected.
+
+#### Scenario: Editing a text file updates its lines
+
+- **GIVEN** an indexed text file
+- **WHEN** the file is edited and the watcher processes the change
+- **THEN** the text index reflects the new lines and no stale lines for that file remain

--- a/openspec/changes/add-literal-text-search-index/specs/mcp-handlers/spec.md
+++ b/openspec/changes/add-literal-text-search-index/specs/mcp-handlers/spec.md
@@ -1,0 +1,31 @@
+# mcp-handlers spec delta
+
+## MODIFIED Requirements
+
+### Requirement: handleSearchCode
+
+The `search_code` handler SHALL search the symbol-derived index first. When the symbol search returns
+zero results, OR when an explicit `mode: 'text'` is supplied, the handler SHALL query the literal-text
+line index and return matching `file:line` results carrying the matched line text. The handler SHALL
+remain conclusion-shaped: it returns the computed matches (symbol results or `file:line` text results),
+never a graph for the agent to traverse. When symbol results exist and `mode: 'text'` is not set, the
+text index SHALL NOT be queried and behavior SHALL be unchanged.
+
+#### Scenario: Literal string found via zero-hit fallback
+
+- **GIVEN** the string `Message completed` exists only as static text in `index.html`
+- **WHEN** `search_code` is called with that query and symbol search returns no results
+- **THEN** the handler falls back to the literal-text line index and returns the `index.html` location
+  with its line number and text
+
+#### Scenario: Forced text mode bypasses symbol search
+
+- **GIVEN** a query for a known literal string
+- **WHEN** `search_code` is called with `mode: 'text'`
+- **THEN** the handler queries the literal-text line index directly and returns `file:line` matches
+
+#### Scenario: Code search with hits is unchanged
+
+- **GIVEN** a query that matches one or more code symbols
+- **WHEN** `search_code` is called without `mode: 'text'`
+- **THEN** the handler returns the symbol results and does not query the literal-text line index

--- a/openspec/changes/add-literal-text-search-index/tasks.md
+++ b/openspec/changes/add-literal-text-search-index/tasks.md
@@ -1,0 +1,57 @@
+# Tasks — Literal-text search line index
+
+> Status: DRAFT (2026-06-20). Decision `fd256fde` recorded before code. BM25-only, separate store,
+> call graph untouched. Reuses `buildBm25Corpus` / `tokenize` / `bm25Score` / `patchBm25Cache`.
+
+## 1. Text corpus build
+- [ ] Define the file set: walked files whose content is not already captured as symbols — markup
+      (`.html`, `.css`, `.scss`), templates, plain text, and the non-symbol remainder. Reuse
+      `FileWalker` output; exclude what `SKIP_EXTENSIONS`/`SKIP_FILENAMES` already drop.
+- [ ] Build the line records: `{ filePath, lineNumber, text }`, skipping blank/whitespace-only lines
+      and lines over a max length (truncate, don't drop).
+- [ ] Write a new LanceDB table (e.g. `text_lines`) — **BM25-only, no vector column**. Reuse
+      `buildBm25Corpus` + `tokenize` against this table; do not duplicate the BM25 implementation.
+- [ ] Persist alongside the existing index under the analysis output dir; record table meta for
+      freshness.
+
+## 2. Query path
+- [ ] Add a BM25-only `searchText(outputDir, query, opts)` to the text index module returning
+      `{ filePath, lineNumber, text, score }[]`.
+- [ ] In `handleSearchCode` (`mcp.ts`): run the existing symbol search first; if it yields **zero**
+      hits, fall back to `searchText` and return `file:line` results tagged as text matches.
+- [ ] Add an explicit `mode: 'text'` flag to `search_code` to force the text path (bypassing symbol
+      search) for known literal-string lookups.
+- [ ] Ensure the response stays conclusion-shaped (`file:line` hits with the matched line), never a
+      graph. Tool-contract classification unchanged.
+
+## 3. Incremental update (watcher)
+- [x] In `McpWatcher.handleBatch`: on changed/added source files, re-extract their lines and patch the
+      text table. → `updateTextLines`, runs regardless of the embed setting.
+- [x] `TextLineIndex.updateFiles` supports `deletedPaths` (drops a path's rows) — unit-tested.
+- [~] Feeding deletions FROM the watcher: not wired. The watcher is change-only (no `'unlink'`
+      handler), so deleted-file lines — like the symbol index's deleted-file nodes — linger until the
+      next full `analyze` overwrites the table. Documented at the call site. Wiring an `'unlink'` path
+      (for both indexes) is a separate change.
+- [x] Symbol-index incremental path is unaffected (text update is a separate store + separate call).
+
+## 4. Purity guard (the load-bearing invariant)
+- [ ] Assert in tests that text lines are **never** present as call-graph nodes and do not appear in
+      `orient`, `get_map`, `get_critical_hubs`, fanIn/fanOut, communities, or PageRank inputs.
+- [ ] No new node kind is introduced anywhere in the graph types.
+
+## 5. Tests
+- [ ] Unit: a string in an `.html` file (static markup) is found via `search_code` zero-hit fallback —
+      the exact regression for the motivating failure ("Message completed" in `index.html`).
+- [ ] Unit: a string present only inside an inline `<script>` literal is found via the text index
+      (covers the case `#1`/skeletons would miss).
+- [ ] Unit: symbol search with hits does NOT trigger the text fallback (no behavior change for code).
+- [ ] Unit: `mode: 'text'` forces the text path.
+- [ ] Incremental: editing a text file updates its lines; deleting removes them.
+- [ ] Purity: the assertions from task 4.
+- [ ] Full suite green.
+
+## 6. Docs
+- [ ] Update `search_code`'s tool description: now also finds literal strings in markup/text via a
+      separate line index when symbol search returns nothing.
+- [ ] Update the CLAUDE.md tools table row for `search_code` accordingly.
+- [ ] Dogfood report: reproduce the original failure on a fixture, show it now resolves.

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -852,12 +852,57 @@ async function runEmbedStep(
       console.log(`    → ${outputPath.replace(rootPath + '/', '')}vector-index/`);
     }
 
+    // Build the literal-text line index (BM25-only, separate from the symbol
+    // index) so literal strings in markup/text — UI copy, error messages — are
+    // findable even when they extract no symbols. Non-fatal.
+    await runTextLineIndexing(rootPath, outputPath);
+
     // Also index specs if they exist
     await runSpecIndexing(rootPath, outputPath, openloreConfig, keywordOnly);
   } catch (embedErr) {
     console.log(`    ✗ Vector index failed: ${(embedErr as Error).message}`);
   }
   console.log('');
+}
+
+// ============================================================================
+// TEXT-LINE INDEXING HELPER
+// ============================================================================
+
+/** Skip individual files larger than this when building the text-line index. */
+const TEXT_INDEX_MAX_FILE_BYTES = 2_000_000;
+
+/**
+ * Build the literal-text line index over all walked files. Reuses the same
+ * FileWalker as analysis (so it honours ignore rules and skips binaries), reads
+ * each file, and indexes its non-blank lines. Non-fatal: a failure here never
+ * breaks `analyze`.
+ */
+async function runTextLineIndexing(rootPath: string, outputPath: string): Promise<void> {
+  try {
+    const { FileWalker } = await import('../../core/analyzer/file-walker.js');
+    const { TextLineIndex } = await import('../../core/analyzer/text-line-index.js');
+    const { readFile: read } = await import('node:fs/promises');
+
+    const walk = await new FileWalker(rootPath).walk();
+    const files: { filePath: string; content: string }[] = [];
+    await Promise.all(
+      walk.files.map(async (f) => {
+        if (f.size > TEXT_INDEX_MAX_FILE_BYTES) return;
+        try {
+          files.push({ filePath: f.path, content: await read(f.absolutePath, 'utf-8') });
+        } catch {
+          /* skip unreadable files */
+        }
+      }),
+    );
+
+    const { lines, files: indexedFiles } = await TextLineIndex.build(outputPath, files);
+    console.log(`    ✓ Text line index built (${lines} lines across ${indexedFiles} files)`);
+    console.log(`    → ${outputPath.replace(rootPath + '/', '')}text-line-index/`);
+  } catch (err) {
+    console.log(`    ⚠ Text line index skipped: ${(err as Error).message}`);
+  }
 }
 
 // ============================================================================

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -832,7 +832,9 @@ export const TOOL_DEFINITIONS = [
       'USE THIS WHEN: you don\'t know which file or function handles a concept — ' +
       '"where is rate limiting implemented?", "which function validates tokens?", ' +
       '"what handles authentication?". Beats grep when the function name is unknown. ' +
-      'Falls back to keyword search automatically if the embedding server is down. ' +
+      'Falls back to keyword search if the embedding server is down, and to a ' +
+      'literal-text index on zero hits so strings in markup/text are still found ' +
+      '(mode:"text" forces it). ' +
       'Requires "openlore analyze --embed" to have been run at least once.',
     inputSchema: {
       type: 'object',
@@ -860,6 +862,11 @@ export const TOOL_DEFINITIONS = [
         tokenBudget: {
           type: 'number',
           description: 'Optional: cap results to ~this many tokens (highest-scored kept, exact duplicates collapsed); each hit carries an `expand` handle for get_function_body',
+        },
+        mode: {
+          type: 'string',
+          enum: ['text'],
+          description: 'Set "text" to search literal strings in markup/text directly; returns file:line matches.',
         },
       },
       required: ['directory', 'query'],

--- a/src/core/analyzer/text-line-index.test.ts
+++ b/src/core/analyzer/text-line-index.test.ts
@@ -1,0 +1,122 @@
+/**
+ * TextLineIndex — literal-text line index (decision fd256fde).
+ *
+ * Proves the regression that motivated the feature: a literal string living in
+ * static markup (a "Message completed" banner in index.html) is findable, even
+ * though it extracts no symbols and is invisible to the symbol index. Also
+ * covers inline <script> literals, incremental update, and line extraction.
+ * BM25-only — needs no embedding service.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  TextLineIndex,
+  extractLines,
+  _resetTextLineIndexCachesForTesting,
+} from './text-line-index.js';
+
+let outputDir: string;
+
+beforeEach(async () => {
+  outputDir = await mkdtemp(join(tmpdir(), 'ol-text-idx-'));
+  _resetTextLineIndexCachesForTesting();
+});
+
+afterEach(async () => {
+  _resetTextLineIndexCachesForTesting();
+  await rm(outputDir, { recursive: true, force: true });
+});
+
+describe('extractLines', () => {
+  it('skips blank lines and numbers from 1', () => {
+    const recs = extractLines('a.html', 'first\n\n   \nfourth');
+    expect(recs.map((r) => r.lineNumber)).toEqual([1, 4]);
+    expect(recs.map((r) => r.text)).toEqual(['first', 'fourth']);
+    expect(recs[0].id).toBe('a.html:1');
+  });
+
+  it('truncates over-long lines instead of dropping them', () => {
+    const long = 'x'.repeat(5000);
+    const recs = extractLines('a.txt', long);
+    expect(recs).toHaveLength(1);
+    expect(recs[0].text.length).toBe(1000);
+  });
+});
+
+describe('TextLineIndex — literal search', () => {
+  it('finds a static-markup string the symbol index cannot hold', async () => {
+    // The motivating failure: "Message completed" lives as static text in index.html.
+    const html = [
+      '<!DOCTYPE html>',
+      '<html>',
+      '  <body>',
+      '    <div class="status status--ok">Message completed</div>',
+      '  </body>',
+      '</html>',
+    ].join('\n');
+    const built = await TextLineIndex.build(outputDir, [{ filePath: 'index.html', content: html }]);
+    expect(built.files).toBe(1);
+    expect(built.lines).toBeGreaterThan(0);
+    _resetTextLineIndexCachesForTesting();
+
+    const hits = await TextLineIndex.searchText(outputDir, 'Message completed');
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].filePath).toBe('index.html');
+    expect(hits[0].lineNumber).toBe(4);
+    expect(hits[0].text).toContain('Message completed');
+  });
+
+  it('finds a literal inside an inline <script> string', async () => {
+    const html = [
+      '<html><head><script>',
+      '  function onDone() {',
+      '    banner.textContent = "Message completed";',
+      '  }',
+      '</script></head></html>',
+    ].join('\n');
+    await TextLineIndex.build(outputDir, [{ filePath: 'page.html', content: html }]);
+    _resetTextLineIndexCachesForTesting();
+
+    const hits = await TextLineIndex.searchText(outputDir, 'completed');
+    expect(hits.some((h) => h.text.includes('Message completed'))).toBe(true);
+  });
+
+  it('returns nothing for a blank query', async () => {
+    await TextLineIndex.build(outputDir, [{ filePath: 'a.txt', content: 'hello world' }]);
+    _resetTextLineIndexCachesForTesting();
+    expect(await TextLineIndex.searchText(outputDir, '   ')).toEqual([]);
+  });
+
+  it('exists() is false before build', () => {
+    expect(TextLineIndex.exists(outputDir)).toBe(false);
+  });
+});
+
+describe('TextLineIndex.updateFiles — incremental', () => {
+  it('replaces a changed file lines; sibling survives; delete removes', async () => {
+    await TextLineIndex.build(outputDir, [
+      { filePath: 'a.html', content: '<p>alpha banner</p>' },
+      { filePath: 'b.html', content: '<p>beta banner</p>' },
+    ]);
+    _resetTextLineIndexCachesForTesting();
+
+    expect((await TextLineIndex.searchText(outputDir, 'alpha')).length).toBeGreaterThan(0);
+
+    // Edit a.html — old "alpha" line replaced by "gamma".
+    await TextLineIndex.updateFiles(outputDir, [{ filePath: 'a.html', content: '<p>gamma banner</p>' }]);
+    _resetTextLineIndexCachesForTesting();
+
+    expect(await TextLineIndex.searchText(outputDir, 'alpha')).toEqual([]);
+    expect((await TextLineIndex.searchText(outputDir, 'gamma')).length).toBeGreaterThan(0);
+    // Sibling untouched.
+    expect((await TextLineIndex.searchText(outputDir, 'beta')).length).toBeGreaterThan(0);
+    _resetTextLineIndexCachesForTesting();
+
+    // Delete b.html — its lines go away.
+    await TextLineIndex.updateFiles(outputDir, [], ['b.html']);
+    _resetTextLineIndexCachesForTesting();
+    expect(await TextLineIndex.searchText(outputDir, 'beta')).toEqual([]);
+  });
+});

--- a/src/core/analyzer/text-line-index.ts
+++ b/src/core/analyzer/text-line-index.ts
@@ -1,0 +1,300 @@
+/**
+ * TextLineIndex
+ *
+ * A literal-text line index kept **separate** from the symbol (call-graph /
+ * signature) index in `vector-index.ts`. It stores raw lines of walked files —
+ * markup, stylesheets, templates, plain text, and the non-symbol remainder of
+ * code files — so that literal strings the user can see on screen (UI copy,
+ * error messages, hard-coded labels) are findable even when they live in static
+ * markup that extracts no symbols (e.g. a "Message completed" banner in
+ * index.html).
+ *
+ * Design (decision fd256fde):
+ *  - **Separate LanceDB table** (`text_lines`), never the call graph. Text lines
+ *    are never nodes and never contribute to fanIn/fanOut, hubs, entrypoints,
+ *    communities or PageRank — graph purity by construction, not by per-call-site
+ *    filtering.
+ *  - **BM25-only, no embeddings.** Literal lookup wants exact lexical match, not
+ *    vector similarity; this keeps build cost and index size bounded and results
+ *    deterministic.
+ *  - Reuses the BM25 machinery already in `vector-index.ts`
+ *    (`buildBm25Corpus` / `tokenize` / `bm25Score`) rather than reimplementing it.
+ *
+ * Storage: <outputDir>/text-line-index/  (LanceDB database folder)
+ * Table name: "text_lines"
+ */
+
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  buildBm25Corpus,
+  tokenize,
+  bm25Score,
+  type Bm25Corpus,
+} from './vector-index.js';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/** One indexed line of a text file. */
+export interface TextLineRecord {
+  /** `${filePath}:${lineNumber}` — unique per line. */
+  id: string;
+  filePath: string;
+  /** 1-based line number. */
+  lineNumber: number;
+  /** The raw line text (truncated if very long). */
+  text: string;
+}
+
+export interface TextSearchResult {
+  filePath: string;
+  lineNumber: number;
+  text: string;
+  /** BM25 relevance score, higher = more relevant. */
+  score: number;
+}
+
+/** A file to index: its repo-relative path and full content. */
+export interface TextFileInput {
+  filePath: string;
+  content: string;
+}
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const DB_FOLDER = 'text-line-index';
+const TABLE_NAME = 'text_lines';
+
+/** Lines longer than this are truncated (not dropped) to keep rows bounded. */
+const MAX_LINE_LEN = 1000;
+
+// Module-level BM25 corpus cache, keyed by dbPath. Invalidated by build();
+// patched in place by updateFiles().
+const _bm25Cache = new Map<
+  string,
+  { corpus: Bm25Corpus; rows: TextLineRecord[] }
+>();
+
+/** Test-only: clear the in-memory BM25 cache to force the cold path. */
+export function _resetTextLineIndexCachesForTesting(): void {
+  _bm25Cache.clear();
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Split a file into indexable line records. Blank / whitespace-only lines are
+ * skipped; over-long lines are truncated, never dropped.
+ */
+export function extractLines(filePath: string, content: string): TextLineRecord[] {
+  const out: TextLineRecord[] = [];
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    if (raw.trim().length === 0) continue;
+    const text = raw.length > MAX_LINE_LEN ? raw.slice(0, MAX_LINE_LEN) : raw;
+    const lineNumber = i + 1;
+    out.push({ id: `${filePath}:${lineNumber}`, filePath, lineNumber, text });
+  }
+  return out;
+}
+
+/**
+ * Build a LanceDB `` `filePath` IN (...) `` predicate, SQL-escaping each path.
+ * Backtick-quoting is required to bind to the camelCase column (see the matching
+ * note in vector-index.ts).
+ */
+function filePathInPredicate(paths: Set<string>): string | null {
+  if (paths.size === 0) return null;
+  const list = Array.from(paths)
+    .map((p) => `'${p.replace(/'/g, "''")}'`)
+    .join(', ');
+  return `\`filePath\` IN (${list})`;
+}
+
+function recordsToCorpusInput(rows: TextLineRecord[]): Array<{ id: string; text: string }> {
+  return rows.map((r) => ({ id: r.id, text: r.text }));
+}
+
+// ============================================================================
+// TEXT LINE INDEX
+// ============================================================================
+
+export class TextLineIndex {
+  /** Returns true if a text-line index has been built for this output dir. */
+  static exists(outputDir: string): boolean {
+    return existsSync(join(outputDir, DB_FOLDER));
+  }
+
+  /**
+   * Build (or rebuild) the text-line index from a set of files. Overwrites any
+   * existing table. Files that yield no indexable lines contribute nothing.
+   * Returns the number of lines indexed.
+   */
+  static async build(outputDir: string, files: TextFileInput[]): Promise<{ lines: number; files: number }> {
+    const records: TextLineRecord[] = [];
+    let indexedFiles = 0;
+    for (const f of files) {
+      const lines = extractLines(f.filePath, f.content);
+      if (lines.length > 0) indexedFiles++;
+      for (const l of lines) records.push(l);
+    }
+
+    const dbPath = join(outputDir, DB_FOLDER);
+    const { connect } = await import('@lancedb/lancedb');
+    const db = await connect(dbPath);
+
+    if (records.length === 0) {
+      // Nothing to index. If a stale table exists, overwrite it with an empty
+      // schema-bearing row set by dropping it; otherwise leave it absent.
+      _bm25Cache.delete(dbPath);
+      try {
+        await db.dropTable(TABLE_NAME);
+      } catch {
+        /* table did not exist */
+      }
+      return { lines: 0, files: 0 };
+    }
+
+    await db.createTable(TABLE_NAME, records as unknown as Record<string, unknown>[], {
+      mode: 'overwrite',
+    });
+    _bm25Cache.delete(dbPath);
+    return { lines: records.length, files: indexedFiles };
+  }
+
+  /**
+   * Incrementally update the index for changed and deleted files. Changed files
+   * have their old lines replaced; deleted files have their lines removed. The
+   * cached BM25 corpus is patched in place. No-op if the index does not exist.
+   */
+  static async updateFiles(
+    outputDir: string,
+    changed: TextFileInput[],
+    deletedPaths: string[] = [],
+  ): Promise<{ lines: number }> {
+    if (!TextLineIndex.exists(outputDir)) return { lines: 0 };
+
+    const dbPath = join(outputDir, DB_FOLDER);
+    const { connect } = await import('@lancedb/lancedb');
+    const db = await connect(dbPath);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let table: any;
+    try {
+      table = await db.openTable(TABLE_NAME);
+    } catch {
+      // No table yet (e.g. previous build had zero lines) — build from scratch
+      // using just the changed files.
+      return TextLineIndex.build(outputDir, changed).then((r) => ({ lines: r.lines }));
+    }
+
+    const affectedPaths = new Set<string>([
+      ...changed.map((c) => c.filePath),
+      ...deletedPaths,
+    ]);
+
+    const newRecords: TextLineRecord[] = [];
+    for (const f of changed) {
+      for (const l of extractLines(f.filePath, f.content)) newRecords.push(l);
+    }
+
+    const predicate = filePathInPredicate(affectedPaths);
+    if (predicate) await table.delete(predicate);
+    if (newRecords.length > 0) {
+      await table.add(newRecords as unknown as Record<string, unknown>[]);
+    }
+
+    TextLineIndex._patchCache(dbPath, affectedPaths, newRecords);
+    return { lines: newRecords.length };
+  }
+
+  /**
+   * BM25-only search over the text lines. Returns up to `limit` `file:line`
+   * matches ordered by relevance. Optionally restrict to a single file.
+   */
+  static async searchText(
+    outputDir: string,
+    query: string,
+    opts: { limit?: number; filePath?: string } = {},
+  ): Promise<TextSearchResult[]> {
+    const { limit = 10, filePath } = opts;
+    if (!TextLineIndex.exists(outputDir)) return [];
+
+    const dbPath = join(outputDir, DB_FOLDER);
+    let cached = _bm25Cache.get(dbPath);
+    if (!cached) {
+      const { connect } = await import('@lancedb/lancedb');
+      const db = await connect(dbPath);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let table: any;
+      try {
+        table = await db.openTable(TABLE_NAME);
+      } catch {
+        return [];
+      }
+      const rows = (await table.query().toArray()) as Record<string, unknown>[];
+      const records: TextLineRecord[] = rows.map((r) => ({
+        id: r.id as string,
+        filePath: r.filePath as string,
+        lineNumber: r.lineNumber as number,
+        text: r.text as string,
+      }));
+      cached = { corpus: buildBm25Corpus(recordsToCorpusInput(records)), rows: records };
+      _bm25Cache.set(dbPath, cached);
+    }
+
+    const { corpus, rows } = cached;
+    const queryTokens = tokenize(query);
+    if (queryTokens.length === 0) return [];
+
+    const recById = new Map(rows.map((r) => [r.id, r]));
+
+    return corpus.docs
+      .map((_, i) => ({ idx: i, score: bm25Score(corpus, queryTokens, i) }))
+      .filter(({ score }) => score > 0)
+      // Deterministic ordering: score desc, then id asc on ties.
+      .sort((a, b) =>
+        b.score - a.score ||
+        (corpus.docs[a.idx].id < corpus.docs[b.idx].id ? -1 : 1),
+      )
+      .map(({ idx, score }) => {
+        const rec = recById.get(corpus.docs[idx].id);
+        return rec ? { rec, score } : null;
+      })
+      .filter((x): x is { rec: TextLineRecord; score: number } => x !== null)
+      .filter(({ rec }) => (filePath ? rec.filePath === filePath : true))
+      .slice(0, limit)
+      .map(({ rec, score }) => ({
+        filePath: rec.filePath,
+        lineNumber: rec.lineNumber,
+        text: rec.text,
+        score,
+      }));
+  }
+
+  /**
+   * Patch the cached BM25 corpus: drop rows for `affectedPaths`, splice in
+   * `newRecords`, rebuild the corpus. No-op when nothing is cached (the next
+   * search rebuilds from the table).
+   */
+  private static _patchCache(
+    dbPath: string,
+    affectedPaths: Set<string>,
+    newRecords: TextLineRecord[],
+  ): void {
+    const entry = _bm25Cache.get(dbPath);
+    if (!entry) return;
+    const kept = entry.rows.filter((r) => !affectedPaths.has(r.filePath));
+    for (const r of newRecords) kept.push(r);
+    _bm25Cache.set(dbPath, {
+      corpus: buildBm25Corpus(recordsToCorpusInput(kept)),
+      rows: kept,
+    });
+  }
+}

--- a/src/core/services/mcp-handlers/search-code-text-fallback.test.ts
+++ b/src/core/services/mcp-handlers/search-code-text-fallback.test.ts
@@ -1,0 +1,109 @@
+/**
+ * search_code literal-text fallback (decision fd256fde).
+ *
+ * The symbol index is symbol-derived, so a literal string in static markup
+ * (a "Message completed" banner in index.html) produces no symbol rows and is
+ * invisible. These tests prove handleSearchCode falls back to the separate
+ * literal-text line index on zero symbol hits, honours mode:'text', and does
+ * NOT touch the text index when symbol hits exist. BM25-only — no embedder.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { VectorIndex, _resetVectorIndexCachesForTesting } from '../../analyzer/vector-index.js';
+import { TextLineIndex, _resetTextLineIndexCachesForTesting } from '../../analyzer/text-line-index.js';
+import type { FunctionNode } from '../../analyzer/call-graph.js';
+
+function makeNode(o: Partial<FunctionNode>): FunctionNode {
+  return {
+    id: 'x', name: 'x', filePath: 'src/x.ts', language: 'TypeScript',
+    isAsync: false, startIndex: 0, endIndex: 0, fanIn: 0, fanOut: 0, ...o,
+  } as FunctionNode;
+}
+
+const NODES: FunctionNode[] = [
+  makeNode({ id: 'src/auth.ts::authenticate', name: 'authenticate', filePath: 'src/auth.ts', fanIn: 5 }),
+];
+
+describe('search_code → literal-text fallback', () => {
+  let projectDir: string;
+  let outputDir: string;
+
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), 'openlore-text-fallback-'));
+    outputDir = join(projectDir, '.openlore', 'analysis');
+    vi.stubEnv('EMBED_BASE_URL', '');
+    vi.stubEnv('EMBED_MODEL', '');
+    _resetVectorIndexCachesForTesting();
+    _resetTextLineIndexCachesForTesting();
+    // Symbol index (BM25-only) + a separate text-line index over index.html.
+    await VectorIndex.build(outputDir, NODES, [], new Set(), new Set(), null);
+    await TextLineIndex.build(outputDir, [
+      { filePath: 'public/index.html', content: '<div class="ok">Message completed</div>' },
+    ]);
+    _resetVectorIndexCachesForTesting();
+    _resetTextLineIndexCachesForTesting();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    _resetVectorIndexCachesForTesting();
+    _resetTextLineIndexCachesForTesting();
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('falls back to the text index when symbol search returns zero hits', async () => {
+    const { handleSearchCode } = await import('./semantic.js');
+    const res = await handleSearchCode(projectDir, 'Message completed banner', 5) as {
+      searchMode: string; count: number;
+      results: Array<{ filePath: string; line: number; text: string; kind: string }>;
+    };
+    expect(res.searchMode).toBe('text_fallback');
+    expect(res.count).toBeGreaterThan(0);
+    expect(res.results[0].filePath).toBe('public/index.html');
+    expect(res.results[0].kind).toBe('text');
+    expect(res.results[0].text).toContain('Message completed');
+    expect(res.results[0].line).toBe(1);
+  });
+
+  it('mode:"text" searches the text index directly', async () => {
+    const { handleSearchCode } = await import('./semantic.js');
+    const res = await handleSearchCode(projectDir, 'completed', 5, undefined, undefined, undefined, 'text') as {
+      searchMode: string; results: Array<{ text: string; kind: string }>;
+    };
+    expect(res.searchMode).toBe('text');
+    expect(res.results.some((r) => r.text.includes('Message completed'))).toBe(true);
+  });
+
+  it('zero symbol hits with no text index returns a normal empty response, not an error', async () => {
+    // Build a fresh project with ONLY a symbol index (no text-line index), so the
+    // fallback finds nothing to query and must degrade to the empty symbol result.
+    const bareDir = await mkdtemp(join(tmpdir(), 'openlore-no-text-'));
+    const bareOut = join(bareDir, '.openlore', 'analysis');
+    await VectorIndex.build(bareOut, NODES, [], new Set(), new Set(), null);
+    _resetVectorIndexCachesForTesting();
+    try {
+      const { handleSearchCode } = await import('./semantic.js');
+      const res = await handleSearchCode(bareDir, 'zzzznomatch literal banner', 5) as {
+        error?: string; searchMode: string; count: number; results: unknown[];
+      };
+      expect(res.error).toBeUndefined();
+      expect(res.searchMode).toBe('bm25_fallback');
+      expect(res.count).toBe(0);
+      expect(res.results).toEqual([]);
+    } finally {
+      await rm(bareDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does NOT fall back when symbol search has hits', async () => {
+    const { handleSearchCode } = await import('./semantic.js');
+    const res = await handleSearchCode(projectDir, 'authenticate', 5) as {
+      searchMode: string; results: Array<{ name?: string; kind?: string }>;
+    };
+    expect(res.searchMode).toBe('bm25_fallback');
+    expect(res.results.length).toBeGreaterThan(0);
+    expect(res.results.every((r) => r.kind !== 'text')).toBe(true);
+  });
+});

--- a/src/core/services/mcp-handlers/semantic.ts
+++ b/src/core/services/mcp-handlers/semantic.ts
@@ -133,13 +133,51 @@ export function compositeScore(semanticRelevance: number, role: InsertionRole): 
  * - callers / callees from the call graph (graph-first context)
  * - linkedSpecs from mapping.json (bidirectional code↔spec linking)
  */
+/**
+ * Query the literal-text line index and shape the response. Returns the result
+ * object, or — in `text_fallback` mode only — `null` when the index is absent or
+ * yields no matches, so the caller can fall through to its normal empty
+ * response. In forced `text` mode it always returns an object.
+ */
+async function searchTextLines(
+  outputDir: string,
+  query: string,
+  limit: number,
+  searchMode: 'text' | 'text_fallback',
+): Promise<unknown | null> {
+  const { TextLineIndex } = await import('../../analyzer/text-line-index.js');
+  if (!TextLineIndex.exists(outputDir)) {
+    return searchMode === 'text'
+      ? { query, searchMode, count: 0, results: [], note: 'No text line index found. Run "openlore analyze".' }
+      : null;
+  }
+  const hits = await TextLineIndex.searchText(outputDir, query, { limit: Math.max(1, Math.min(limit, 100)) });
+  if (hits.length === 0 && searchMode === 'text_fallback') return null;
+  return {
+    query,
+    searchMode,
+    ...(searchMode === 'text_fallback'
+      ? { note: 'No code symbols matched; these are literal-text matches from markup/text files.' }
+      : {}),
+    count: hits.length,
+    results: hits.map((h) => ({
+      filePath: h.filePath,
+      line: h.lineNumber,
+      text: h.text,
+      score: h.score,
+      kind: 'text' as const,
+    })),
+  };
+}
+
 export async function handleSearchCode(
   directory: string,
   query: string,
   limit = 10,
   language?: string,
   minFanIn?: number,
-  tokenBudget?: number
+  tokenBudget?: number,
+  mode?: 'text'
 ): Promise<unknown> {
   const tooLong = queryTooLongError(query); if (tooLong) return tooLong;
   const absDir = await validateDirectory(directory);
@@ -147,6 +185,12 @@ export async function handleSearchCode(
 
   const { VectorIndex } = await import('../../analyzer/vector-index.js');
   const { EmbeddingService } = await import('../../analyzer/embedding-service.js');
+
+  // Forced literal-text mode: query the separate line index directly, bypassing
+  // symbol search. Use when hunting a literal string (UI copy, error text).
+  if (mode === 'text') {
+    return searchTextLines(outputDir, query, limit, 'text');
+  }
 
   if (!VectorIndex.exists(outputDir)) {
     return {
@@ -177,6 +221,20 @@ export async function handleSearchCode(
     loadMappingIndex(absDir),
     readCachedContext(absDir),
   ]);
+
+  // Zero symbol hits: the string may live in static markup/text that extracts
+  // no symbols (UI copy, error messages). Fall back to the literal-text line
+  // index rather than returning a dead end. This is an optional enrichment —
+  // its failure must never turn a valid empty symbol result into a tool error,
+  // so a throw degrades silently to the normal empty response below.
+  if (results.length === 0) {
+    try {
+      const textFallback = await searchTextLines(outputDir, query, limit, 'text_fallback');
+      if (textFallback) return textFallback;
+    } catch {
+      /* text index unavailable/corrupt — fall through to the empty symbol response */
+    }
+  }
 
   type Neighbour = { name: string; filePath: string };
 

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -460,6 +460,17 @@ export class McpWatcher {
     }
     await this.persistContext(context);
 
+    // 3.5. Literal-text line index — keep it fresh for the changed files. Runs
+    //      regardless of the embed setting (the text index is BM25-only).
+    //      Scope (consistent with the symbol index in watch mode): the watcher
+    //      reacts only to 'change' events on SOURCE_EXTENSIONS files — there is
+    //      no 'unlink' handler — so neither markup/stylesheet edits nor file
+    //      DELETIONS are live-reconciled here. A deleted file's lines linger
+    //      until the next full `analyze`, which overwrites the table completely
+    //      (the same staleness the symbol index already carries for deleted
+    //      files). This keeps code-file literals (e.g. JSX strings) current.
+    await this.updateTextLines(changedFiles);
+
     // 4. Vector update — decoupled from signature freshness (Step 4).
     const isBulk = consumedVcsBulk || changedFiles.length >= this.bulkThreshold;
     if (this.embed && !this.embedDegraded && context.callGraph) {
@@ -648,6 +659,24 @@ export class McpWatcher {
       }
     } catch (err) {
       process.stderr.write(`[mcp-watcher] embed error: ${(err as Error).message}\n`);
+    }
+  }
+
+  /**
+   * Row-level literal-text line update for the changed files. No-op when the
+   * text-line index has not been built. Never throws into the batch loop.
+   */
+  private async updateTextLines(changedFiles: ChangedFile[]): Promise<void> {
+    try {
+      const { TextLineIndex } = await import('../analyzer/text-line-index.js');
+      if (!TextLineIndex.exists(this.outputPath)) return;
+      const changed = changedFiles.map((f) => ({ filePath: f.rel, content: f.content }));
+      await TextLineIndex.updateFiles(this.outputPath, changed);
+      if (this.debug) {
+        process.stderr.write(`[mcp-watcher] text-line index: updated ${changed.length} file(s)\n`);
+      }
+    } catch (err) {
+      process.stderr.write(`[mcp-watcher] text-line error: ${(err as Error).message}\n`);
     }
   }
 

--- a/src/core/services/tool-dispatch.ts
+++ b/src/core/services/tool-dispatch.ts
@@ -193,9 +193,9 @@ export async function dispatchTool(
       args as { directory: string; base?: string; files?: string[]; domains?: string[]; failOn?: 'error' | 'warning' | 'info'; maxFiles?: number };
     return handleCheckSpecDrift(directory, base, files, domains, failOn, maxFiles);
   } else if (name === 'search_code') {
-    const { directory, query, limit = 10, language, minFanIn, tokenBudget } =
-      args as { directory: string; query: string; limit?: number; language?: string; minFanIn?: number; tokenBudget?: number };
-    return handleSearchCode(directory, query, limit, language, minFanIn, tokenBudget);
+    const { directory, query, limit = 10, language, minFanIn, tokenBudget, mode } =
+      args as { directory: string; query: string; limit?: number; language?: string; minFanIn?: number; tokenBudget?: number; mode?: 'text' };
+    return handleSearchCode(directory, query, limit, language, minFanIn, tokenBudget, mode);
   } else if (name === 'suggest_insertion_points') {
     const { directory, description, limit = 5, language } =
       args as { directory: string; description: string; limit?: number; language?: string };


### PR DESCRIPTION
## Problem

`search_code`'s corpus is **symbol-derived** — every searchable row comes from a call-graph node or a signature entry (`[lang] path name signature docstring skeleton`). A file that extracts **no symbols** produces zero rows and is invisible to search. Static markup, UI copy, hard-coded error strings — none of it is a function/class/signature, so none is indexed.

This is a *silent* failure: `search_code` returns confident symbol matches, the agent trusts the tool over a plain grep, and burns the loop hunting in the wrong index. Real incident that motivated this: an agent asked to find a green **"Message completed"** banner ran `orient` + many greps and never found it — the string lived as static text in `index.html`. A human's find-in-files located it in seconds.

## What this does

- **New `TextLineIndex`** (`src/core/analyzer/text-line-index.ts`): a **separate** LanceDB table (`text_lines`), **BM25-only (no embeddings)**, storing raw non-blank lines keyed by `filePath:lineNumber`. Reuses `buildBm25Corpus` / `tokenize` / `bm25Score` from `vector-index.ts` — no second BM25 implementation.
- **Call graph stays pure by construction.** Text lines are never nodes and never feed `fanIn`/`fanOut`, hubs, entrypoints, communities, PageRank, `orient`, or `get_map`. This is the explicit rejection of the "index text as pseudo-symbols" alternative (decision `fd256fde`), which would have forced a "is this a text node?" filter at every present and future call site.
- **`search_code` falls back to it.** Symbol search runs first; on **zero hits** it queries the text index and returns `file:line` matches. `mode:"text"` forces the text path. The fallback is **guarded** — a text-index failure degrades to the normal empty response, never a tool error. When symbol hits exist, behavior is unchanged and the text index is not touched.
- **Build + watch wiring.** Built at `analyze` time over all walked files (`runTextLineIndexing`); kept fresh in watch mode for changed source files. Deletions and markup edits reconcile at the next full `analyze` (which overwrites the table) — the same watch-mode staleness the symbol index already carries.

## Out of scope

- Inline `<script>` JS as call-graph symbols (orthogonal structural improvement).
- Semantic/NL search over text — this is exact-lexical only, by design.

## Tests

- `text-line-index.test.ts` — extraction (blank-skip, truncate, 1-based lines), the "Message completed in index.html" regression, inline `<script>` literal, incremental update (replace / sibling survives / delete).
- `search-code-text-fallback.test.ts` — zero-hit fallback, `mode:"text"`, no-fallback-when-symbols-hit, and the guard (zero hits + no text index → empty response, not an error).
- Full suite green (one pre-existing `memory-invariant` timeout, unrelated — confirmed it times out on the clean base without these changes).

A `code-reviewer` pass flagged two issues, both addressed: the fallback throw now degrades gracefully (was a MEDIUM), and the watch-mode deletion behavior is documented as consistent with the symbol index (HIGH, downgraded — the watcher has no `unlink` handler for either index by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)