### PR TITLE
feat(analyzer): index inline <script> JS into the call graph

### DIFF
--- a/openspec/changes/add-inline-script-call-graph/proposal.md
+++ b/openspec/changes/add-inline-script-call-graph/proposal.md
@@ -1,0 +1,82 @@
+# Inline `<script>` JS as call-graph symbols
+
+> Status: DRAFT (2026-06-20). Decision `5b38bad2` recorded before any code.
+> Orthogonal to the literal-text line index (`fd256fde`): that makes literal strings findable; this
+> gives the structural graph (callers/callees/impact/search) reach into JavaScript defined inside HTML.
+
+## Why
+
+Functions defined in an inline `<script>` block in an `.html` file are invisible to every structural
+tool. `detectLanguage` returns `unknown` for `.html` (`signature-extractor.ts:66`), so the file never
+reaches the call-graph builder — no nodes, no edges, no `search_code` / `orient` / `analyze_impact`
+coverage. For codebases that put real logic in inline scripts (server-rendered pages, demos, small
+apps, embedded widgets), an entire layer of behavior is structurally dark.
+
+The call-graph builder already does the hard part: `CallGraphBuilder.build` accepts
+`{ path, content, language }[]` and routes `JavaScript` content to `extractTSGraph`
+(`call-graph.ts:4379`). The only thing missing is getting the inline JS *to* it with correct file
+positions.
+
+## What changes
+
+1. **Extract inline scripts, feed them as JavaScript.** At the call-graph assembly point
+   (`artifact-generator.ts:1164`), `.html`/`.htm` files are pulled out of the `unknown` bucket: their
+   `<script>` bodies are extracted and handed to the existing JS extractor with `language: 'JavaScript'`
+   and `path` = the HTML file path. Inline functions become first-class nodes.
+
+2. **Offset-preserving blanking — the enabler.** Node line numbers come from `byteToLine` over
+   `file.content` (`call-graph.ts:4404`). Parsing a script body standalone makes every offset
+   script-relative, so `file:line` would point at the wrong place in the HTML. Instead the builder is
+   fed a string the **same length** as the HTML in which every character *outside* a `<script>…</script>`
+   body is replaced by a space, **newlines preserved**. Tree-sitter parses the JS islands at their true
+   positions; markup regions are valid empty JS. Every script character keeps its exact index, so
+   `startIndex` / `endIndex` / `startLine` map correctly back to the HTML file. `extractTSGraph` is
+   reused **unchanged**.
+
+3. **Dependency-free script extraction.** A regex (`/<script\b([^>]*)>([\s\S]*?)<\/script>/gi`) with a
+   `type` filter — accept `text/javascript`, `module`, or no `type`; skip `application/json`,
+   `importmap`, and external `src=` references — locates the inline bodies. `tree-sitter-html` is **not**
+   added; `<script>` boundary detection does not warrant a grammar dependency.
+
+## What does NOT change
+
+- **No LLM.** Pure static extraction. North star (`c6d1ad07`) holds.
+- **`extractTSGraph` is untouched.** The blanking trick means the JS extractor needs no awareness of
+  HTML.
+- **Existing call-graph entries are untouched.** This is purely additive — `.html` files that today
+  contribute nothing now contribute their inline-JS nodes; every other file is unaffected.
+- **No new graph node kind.** Inline-script functions are ordinary `JavaScript` function nodes whose
+  `filePath` is the `.html` file.
+
+## Application to OpenLore
+
+- **Build**: one branch in `resolveLang` / the `CALL_GRAPH_LANGS` gate
+  (`artifact-generator.ts:1114-1167`) plus an `extractHtmlScripts(content) → blankedContent` helper.
+- **Search / skeleton**: the vector index builds rows from call-graph **nodes**, so inline functions
+  become searchable automatically; `getSkeletonContent` slices the original HTML by the preserved
+  offsets and returns the real script source. No separate signature path required.
+- **Reuse**: the JS extractor, the trie resolution, the CFG overlay — all unchanged.
+
+## Out of scope
+
+- **Watch-mode live update.** `mcp-watcher`'s `SOURCE_EXTENSIONS` and `detectLanguage === 'unknown'`
+  skip exclude `.html`; widening them is a separate change with its own watch-scope risk. Until then,
+  inline-JS edits reconcile at the next full `analyze` (the same posture the text index took).
+- **`.vue` / `.svelte` single-file components.** Same `<script>` shape; easy follow-ups once `.html`
+  lands.
+- **Templating languages inside markup** (EJS/Handlebars/Jinja) — not JavaScript, not in scope.
+- **`</script>` appearing inside a JS string literal** — the regex truncates early; rare for inline
+  code, and the existing per-file `try/catch` (`call-graph.ts:4424`) contains any resulting parse
+  failure.
+
+## Risk
+
+**Low.** Additive at one gate; the JS extractor is reused as-is; the offset-preserving blank keeps all
+existing line/offset semantics; parse failures are already contained. No new dependency.
+
+## Research basis
+
+The "blank everything but the embedded language, parse in place" technique is the standard way editors
+and language servers provide language features inside embedded code (HTML `<script>`/`<style>`, Markdown
+fenced blocks) without a host-language-aware parser — a virtual document whose ranges align 1:1 with the
+container. Here it lets a pure-JS tree-sitter extractor produce HTML-accurate node positions.

--- a/openspec/changes/add-inline-script-call-graph/specs/analyzer/spec.md
+++ b/openspec/changes/add-inline-script-call-graph/specs/analyzer/spec.md
@@ -1,0 +1,33 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: InlineScriptCallGraphExtraction
+
+The system SHALL extract JavaScript defined in inline `<script>` blocks of `.html`/`.htm` files into the
+call graph as ordinary JavaScript function nodes whose `filePath` is the HTML file. Extraction SHALL use
+offset-preserving blanking: the JavaScript extractor SHALL be given a string of the same length as the
+HTML in which every character outside an inline `<script>` body is replaced by a space and newlines are
+preserved, so that node start/end offsets and line numbers map to the HTML file. Only inline scripts of
+type `text/javascript`, `module`, or with no `type` SHALL be extracted; `application/json`, `importmap`,
+and external (`src=`) scripts SHALL be excluded. A file with no qualifying inline script SHALL
+contribute no nodes and SHALL NOT error.
+
+#### Scenario: An inline-script function becomes a call-graph node
+
+- **GIVEN** an `index.html` whose inline `<script>` defines `function foo() { bar(); }` and `function bar() {}`
+- **WHEN** the call graph is built
+- **THEN** the graph contains nodes for `foo` and `bar` with `filePath` equal to `index.html`, a
+  `foo → bar` call edge, and 1-based line numbers matching the script's position in the file
+
+#### Scenario: Non-JavaScript and external scripts are excluded
+
+- **GIVEN** an HTML file containing a `<script type="application/json">` block and a `<script src="app.js">` tag
+- **WHEN** the call graph is built
+- **THEN** neither contributes nodes, and a file with no inline JavaScript contributes none
+
+#### Scenario: Non-HTML extraction is unaffected
+
+- **GIVEN** a project with no HTML files
+- **WHEN** the call graph is built with inline-script extraction enabled
+- **THEN** the resulting nodes and edges are identical to the output without the feature

--- a/openspec/changes/add-inline-script-call-graph/tasks.md
+++ b/openspec/changes/add-inline-script-call-graph/tasks.md
@@ -1,0 +1,39 @@
+# Tasks — Inline `<script>` JS as call-graph symbols
+
+> Status: DRAFT (2026-06-20). Decision `5b38bad2` recorded before code. Offset-preserving blanking;
+> reuses `extractTSGraph` unchanged. Orthogonal to the literal-text line index (`fd256fde`).
+
+## 1. Script extraction + blanking
+- [x] `extractHtmlScripts(content): string | null` in `html-script-extractor.ts` — same-length output,
+      newlines preserved, script bodies verbatim, markup blanked; returns `null` when no inline JS.
+- [x] Type filter via `isInlineJsScript`: keep `text/javascript`/`application/javascript`/`module`/
+      ecmascript/no-type; skip `application/json`, `importmap`, external `src=`.
+- [x] Returns `null` for no qualifying scripts so the caller skips cheaply.
+
+## 2. Build-time wiring
+- [x] `artifact-generator.ts`: after the `CALL_GRAPH_LANGS` gate, an `else if (/\.html?$/i)` branch runs
+      `extractHtmlScripts` and pushes `{ path, content: blanked, language: 'JavaScript' }` when it yields JS.
+- [x] Verified nodes carry `filePath` = the HTML path and correct 1-based `startLine` (integration test
+      uses markup above the script: foo@4, bar@7).
+
+## 3. Tests
+- [x] Unit (`extractHtmlScripts` / `isInlineJsScript`): length invariance, newline preservation, markup
+      blanked, single + multiple bodies retained, json/importmap/external excluded, whitespace-tolerant
+      close tag.
+- [x] Integration: `<script>` with `foo(){ bar() }` + `bar(){}` → two HTML-anchored nodes, `foo → bar`
+      edge, correct line numbers.
+- [~] `search_code` over the built index — covered transitively (vector index builds from nodes); not a
+      dedicated test in this change.
+- [x] Regression: `.html` with no inline JS returns `null` → contributes no nodes, no error.
+- [~] Purity: guaranteed by construction (the new branch only fires for `.html`); not asserted via a
+      diff test.
+
+## 4. Docs
+- [ ] Note `.html` inline-JS support in the analyzer spec / CODEBASE digest where language coverage is
+      listed.
+- [ ] Document the watch-mode limitation (inline-JS edits reconcile at next `analyze`) alongside the
+      existing markup caveat.
+
+## 5. Follow-ups (not this change)
+- [ ] Widen `mcp-watcher` to live-update `.html` inline JS.
+- [ ] `.vue` / `.svelte` `<script>` blocks via the same blanking helper.

--- a/src/core/analyzer/artifact-generator.ts
+++ b/src/core/analyzer/artifact-generator.ts
@@ -1107,6 +1107,7 @@ export class AnalysisArtifactGenerator {
     // All dynamic imports grouped here; CALL_GRAPH_LANGS hoisted out of the loop.
     const { extractSignatures, detectLanguage, resolveHeaderLanguage } = await import('./signature-extractor.js');
     const { CallGraphBuilder, serializeCallGraph } = await import('./call-graph.js');
+    const { extractHtmlScripts } = await import('./html-script-extractor.js');
     const { detectDuplicates } = await import('./duplicate-detector.js');
     const { analyzeForRefactoring } = await import('./refactor-analyzer.js');
     const { classifyYaml } = await import('./iac/index.js');
@@ -1118,6 +1119,9 @@ export class AnalysisArtifactGenerator {
       // Infrastructure-as-Code (spec-07) — projected onto the same graph primitives.
       'Terraform', 'Kubernetes', 'Helm', 'CloudFormation', 'Ansible',
     ]);
+    // Skip inline-script extraction for very large HTML files: bounds the
+    // same-length char-array allocation in extractHtmlScripts (the scan is O(N)).
+    const MAX_HTML_INLINE_SCRIPT_CHARS = 1_000_000;
     // Helm charts: every file under a directory containing Chart.yaml is Helm.
     const chartDirs = repoMap.allFiles
       .filter(f => /(^|\/)Chart\.ya?ml$/.test(f.path.replace(/\\/g, '/')))
@@ -1164,6 +1168,16 @@ export class AnalysisArtifactGenerator {
         const lang = resolveLang(file.path, content);
         if (CALL_GRAPH_LANGS.has(lang)) {
           callGraphFiles.push({ path: file.path, content, language: lang });
+        } else if (/\.html?$/i.test(file.path) && content.length <= MAX_HTML_INLINE_SCRIPT_CHARS) {
+          // Inline <script> JS (decision 5b38bad2): blank everything outside the
+          // script bodies (newlines preserved) so the JS extractor parses the
+          // islands at their true offsets and node line numbers map to the HTML
+          // file. Skip files with no inline JS. Oversized HTML is skipped (a
+          // bound on the per-file char-array allocation; the scan itself is O(N)).
+          const blanked = extractHtmlScripts(content);
+          if (blanked !== null) {
+            callGraphFiles.push({ path: file.path, content: blanked, language: 'JavaScript' });
+          }
         }
       } catch {
         // skip unreadable files

--- a/src/core/analyzer/html-inline-script.e2e.integration.test.ts
+++ b/src/core/analyzer/html-inline-script.e2e.integration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * E2E — inline <script> JS reaches the call graph through the real analyze
+ * pipeline (decision 5b38bad2).
+ *
+ * Unlike the unit tests (which call CallGraphBuilder.build directly with
+ * pre-blanked content), this drives the WHOLE pipeline on a temp repo on disk:
+ * RepositoryMapper → DependencyGraphBuilder → AnalysisArtifactGenerator, which
+ * is where the `.html` branch in artifact-generator actually fires. It proves
+ * the wiring end-to-end: an inline-script function in an .html file on disk
+ * becomes a call-graph node anchored to that file with correct line numbers.
+ *
+ * No embedding server needed — we inspect the call graph in the returned
+ * artifacts, which is built before (and independently of) the vector index.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runAnalysis } from '../../cli/commands/analyze.js';
+
+let tmpDir: string;
+let outDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'openlore-html-e2e-'));
+  outDir = join(tmpDir, '.openlore', 'analysis');
+  await mkdir(outDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('E2E: inline <script> JS in the analyze pipeline', () => {
+  it('indexes an inline-script function as an HTML-anchored call-graph node', async () => {
+    // Markup ABOVE the script so the line offsets are non-trivial.
+    const html = [
+      '<!DOCTYPE html>',        // 1
+      '<html>',                 // 2
+      '  <body>',               // 3
+      '    <h1>Demo</h1>',      // 4
+      '    <script>',           // 5
+      '      function greet() {',// 6
+      '        render();',       // 7
+      '      }',                 // 8
+      '      function render() {}', // 9
+      '    </script>',          // 10
+      '  </body>',              // 11
+      '</html>',                // 12
+    ].join('\n');
+    await writeFile(join(tmpDir, 'index.html'), html, 'utf-8');
+    // A trivial source file so the repo isn't empty.
+    await writeFile(join(tmpDir, 'noop.ts'), 'export const x = 1;\n', 'utf-8');
+
+    const { artifacts } = await runAnalysis(tmpDir, outDir, {
+      maxFiles: 100,
+      include: [],
+      exclude: [],
+    });
+
+    const cg = artifacts.llmContext?.callGraph;
+    expect(cg).toBeTruthy();
+    const nodes = cg!.nodes;
+
+    const greet = nodes.find((n) => n.name === 'greet');
+    const render = nodes.find((n) => n.name === 'render');
+    expect(greet, 'inline-script function greet should be a call-graph node').toBeDefined();
+    expect(render).toBeDefined();
+
+    // Anchored to the HTML file, with line numbers mapped through the markup.
+    expect(greet!.filePath).toMatch(/index\.html$/);
+    expect(greet!.startLine).toBe(6);
+    expect(render!.startLine).toBe(9);
+
+    // greet → render edge resolved within the inline script.
+    expect(cg!.edges.some((e) => e.callerId === greet!.id && e.calleeId === render!.id)).toBe(true);
+  });
+
+  it('an .html file with no inline JS contributes no nodes and does not error', async () => {
+    await writeFile(
+      join(tmpDir, 'static.html'),
+      '<html><body><p>no scripts here</p></body></html>\n',
+      'utf-8',
+    );
+    await writeFile(join(tmpDir, 'noop.ts'), 'export const y = 2;\n', 'utf-8');
+
+    const { artifacts } = await runAnalysis(tmpDir, outDir, { maxFiles: 100, include: [], exclude: [] });
+    const cg = artifacts.llmContext?.callGraph;
+    expect(cg).toBeTruthy();
+    expect(cg!.nodes.some((n) => n.filePath.endsWith('static.html'))).toBe(false);
+  });
+});

--- a/src/core/analyzer/html-script-extractor.test.ts
+++ b/src/core/analyzer/html-script-extractor.test.ts
@@ -1,0 +1,141 @@
+/**
+ * HTML inline-script extractor (decision 5b38bad2).
+ *
+ * The offset-preserving blank must keep the output the SAME length as the input,
+ * preserve newlines (so line numbers map to the HTML file), keep qualifying JS
+ * bodies verbatim at their exact offsets, and blank out markup and non-JS /
+ * external scripts. An integration test confirms the blanked content drives the
+ * JS call-graph extractor to HTML-accurate nodes.
+ */
+import { describe, it, expect } from 'vitest';
+import { extractHtmlScripts, isInlineJsScript } from './html-script-extractor.js';
+
+describe('isInlineJsScript', () => {
+  it('keeps no-type, text/javascript, module; rejects json/importmap/external', () => {
+    expect(isInlineJsScript('')).toBe(true);
+    expect(isInlineJsScript(' type="text/javascript"')).toBe(true);
+    expect(isInlineJsScript(' type="module"')).toBe(true);
+    expect(isInlineJsScript(' type="application/json"')).toBe(false);
+    expect(isInlineJsScript(' type="importmap"')).toBe(false);
+    expect(isInlineJsScript(' src="app.js"')).toBe(false);
+    expect(isInlineJsScript(' src="app.js" type="text/javascript"')).toBe(false);
+  });
+
+  it('does not let data-type / data-src false-match the type/src filters', () => {
+    // data-type must not be read as the script type.
+    expect(isInlineJsScript(' data-type="application/json"')).toBe(true);
+    // data-src is not an external-script signal.
+    expect(isInlineJsScript(' data-src="x"')).toBe(true);
+  });
+
+  it('tolerates a charset suffix on the type', () => {
+    expect(isInlineJsScript(' type="text/javascript; charset=utf-8"')).toBe(true);
+  });
+});
+
+describe('extractHtmlScripts', () => {
+  it('returns null when there is no inline JS', () => {
+    expect(extractHtmlScripts('<html><body><p>hi</p></body></html>')).toBeNull();
+    expect(extractHtmlScripts('<script src="app.js"></script>')).toBeNull();
+    expect(extractHtmlScripts('<script type="application/json">{"a":1}</script>')).toBeNull();
+  });
+
+  it('preserves length and newlines; keeps the body; blanks the markup', () => {
+    const html = [
+      '<html>',
+      '<body>',
+      '<script>',
+      'function foo() { return 1; }',
+      '</script>',
+      '</body>',
+      '</html>',
+    ].join('\n');
+    const out = extractHtmlScripts(html)!;
+    expect(out).not.toBeNull();
+    // Same length, identical newline positions.
+    expect(out.length).toBe(html.length);
+    expect(out.split('\n').length).toBe(html.split('\n').length);
+    // The JS body survives verbatim, at the same line.
+    expect(out).toContain('function foo() { return 1; }');
+    // Markup is blanked — the tags are gone, replaced by spaces.
+    expect(out).not.toContain('<body>');
+    expect(out).not.toContain('<html>');
+    // The body sits on the same line index as in the source.
+    const srcLine = html.split('\n').findIndex((l) => l.includes('function foo'));
+    const outLine = out.split('\n').findIndex((l) => l.includes('function foo'));
+    expect(outLine).toBe(srcLine);
+  });
+
+  it('keeps multiple script bodies and blanks a json block between them', () => {
+    const html =
+      '<script>function a(){}</script>' +
+      '<script type="application/json">{"x":1}</script>' +
+      '<script type="module">function b(){}</script>';
+    const out = extractHtmlScripts(html)!;
+    expect(out.length).toBe(html.length);
+    expect(out).toContain('function a(){}');
+    expect(out).toContain('function b(){}');
+    expect(out).not.toContain('{"x":1}');
+  });
+
+  it('handles a whitespace-tolerant close tag without corrupting offsets', () => {
+    const html = '<script>function a(){}</script >after';
+    const out = extractHtmlScripts(html)!;
+    expect(out.length).toBe(html.length);
+    expect(out).toContain('function a(){}');
+    expect(out).not.toContain('after'); // markup after the script is blanked
+  });
+
+  it('does not hang or index an unterminated <script> (no quadratic scan)', () => {
+    // Many open tags with no close tag — the old combined regex was O(N²) here.
+    const html = '<script>'.repeat(20_000) + 'function never(){}';
+    const t0 = Date.now();
+    const out = extractHtmlScripts(html);
+    // Linear scan: comfortably under a second even for 20k unterminated tags.
+    expect(Date.now() - t0).toBeLessThan(1000);
+    // No close tag anywhere → nothing is indexed.
+    expect(out).toBeNull();
+  });
+
+  it('keeps a real script even when an earlier one is unterminated', () => {
+    const html = '<script>broken' + '\n' + '<script>function ok(){}</script>';
+    const out = extractHtmlScripts(html)!;
+    expect(out.length).toBe(html.length);
+    expect(out).toContain('function ok(){}');
+  });
+});
+
+describe('inline scripts → call graph', () => {
+  it('produces HTML-anchored nodes and a call edge with correct line numbers', async () => {
+    const { CallGraphBuilder } = await import('./call-graph.js');
+    const html = [
+      '<!DOCTYPE html>',         // line 1
+      '<html><body>',            // line 2
+      '<script>',                // line 3
+      '  function foo() {',      // line 4
+      '    bar();',              // line 5
+      '  }',                     // line 6
+      '  function bar() {}',     // line 7
+      '</script>',               // line 8
+      '</body></html>',          // line 9
+    ].join('\n');
+    const blanked = extractHtmlScripts(html)!;
+
+    const builder = new CallGraphBuilder();
+    const result = await builder.build([
+      { path: 'public/index.html', content: blanked, language: 'JavaScript' },
+    ]);
+
+    const nodes = [...result.nodes.values()];
+    const foo = nodes.find((n) => n.name === 'foo');
+    const bar = nodes.find((n) => n.name === 'bar');
+    expect(foo).toBeDefined();
+    expect(bar).toBeDefined();
+    expect(foo!.filePath).toBe('public/index.html');
+    // foo is defined on line 4, bar on line 7 — offsets mapped through the HTML.
+    expect(foo!.startLine).toBe(4);
+    expect(bar!.startLine).toBe(7);
+    // foo → bar edge exists.
+    expect(result.edges.some((e) => e.callerId === foo!.id && e.calleeId === bar!.id)).toBe(true);
+  });
+});

--- a/src/core/analyzer/html-script-extractor.ts
+++ b/src/core/analyzer/html-script-extractor.ts
@@ -1,0 +1,92 @@
+/**
+ * HTML inline-script extractor.
+ *
+ * Produces an "offset-preserving blank" of an HTML file: a string of the SAME
+ * length as the input in which every character outside an inline `<script>` body
+ * is replaced by a space (newlines preserved), and the inline JavaScript bodies
+ * are kept verbatim at their exact positions.
+ *
+ * Feeding this blanked string to the existing JavaScript call-graph extractor
+ * makes tree-sitter parse only the script islands, at their true offsets, so the
+ * resulting nodes' start/end offsets and line numbers map back to the HTML file
+ * without the extractor needing any HTML awareness (decision 5b38bad2).
+ *
+ * Only inline scripts that are JavaScript are kept: `text/javascript`,
+ * `application/javascript`, `module`, ecmascript, or no `type`. `application/json`,
+ * `importmap`, templating types, and external (`src=`) scripts are blanked out.
+ *
+ * Parsing is a linear open-tag scan plus an `indexOf` for the close tag — NOT a
+ * single backtracking regex — so a file full of unterminated `<script` tags
+ * cannot drive the matcher into quadratic blow-up (the previous combined regex
+ * scanned to EOF per open tag → O(N²) on malformed input).
+ */
+
+// Matches just the OPENING `<script ...>` tag. `[^>]*` stops at the first `>`,
+// which is a known limitation when an attribute value itself contains `>`
+// (rare; documented). Case-insensitive, global.
+const OPEN_SCRIPT_RE = /<script\b([^>]*)>/gi;
+const CLOSE_TAG = '</script';
+
+/** JS `type` values (besides "no type") that we treat as executable JavaScript. */
+const JS_TYPES = new Set([
+  'text/javascript',
+  'application/javascript',
+  'module',
+  'text/ecmascript',
+  'application/ecmascript',
+]);
+
+/** True if a `<script>`'s attribute string denotes inline JavaScript we should index. */
+export function isInlineJsScript(attrs: string): boolean {
+  // External scripts have no inline body. Anchor the attribute name on the left
+  // (start-or-whitespace) so `data-src` / `data-type` don't false-match.
+  if (/(?:^|\s)src\s*=/i.test(attrs)) return false;
+  const typeMatch = /(?:^|\s)type\s*=\s*["']?\s*([^"'\s>]+)/i.exec(attrs);
+  if (!typeMatch) return true; // no type → classic inline JS
+  let type = typeMatch[1].toLowerCase();
+  const semi = type.indexOf(';'); // strip a `; charset=…` suffix
+  if (semi !== -1) type = type.slice(0, semi);
+  return JS_TYPES.has(type);
+}
+
+/**
+ * Return an offset-preserving blank of `content` exposing only inline JS bodies,
+ * or `null` when the file contains no qualifying inline script (so callers can
+ * skip it cheaply).
+ *
+ * The returned string has the same length as `content`; every position outside a
+ * kept script body is a space, except `\n` which is preserved so line numbers
+ * align with the original file.
+ */
+export function extractHtmlScripts(content: string): string | null {
+  // Base: same length, all spaces, newlines preserved.
+  const out = content.replace(/[^\n]/g, ' ').split('');
+  const lower = content.toLowerCase(); // one pass; case-insensitive close-tag search
+  let found = false;
+
+  OPEN_SCRIPT_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = OPEN_SCRIPT_RE.exec(content)) !== null) {
+    const attrs = m[1];
+    const bodyStart = m.index + m[0].length;
+
+    // Linear search for the matching close tag — no regex backtracking.
+    const closeIdx = lower.indexOf(CLOSE_TAG, bodyStart);
+    if (closeIdx === -1) {
+      // No close tag: malformed / not an inline body we can bound. The regex has
+      // already advanced lastIndex past this open tag, so the scan stays O(N).
+      continue;
+    }
+
+    if (closeIdx > bodyStart && isInlineJsScript(attrs)) {
+      for (let i = bodyStart; i < closeIdx; i++) out[i] = content[i];
+      found = true;
+    }
+
+    // Resume after the close tag so a `<script` appearing inside one body is not
+    // re-matched, and so lastIndex advances monotonically.
+    OPEN_SCRIPT_RE.lastIndex = closeIdx + CLOSE_TAG.length;
+  }
+
+  return found ? out.join('') : null;
+}


### PR DESCRIPTION
## Problem

Functions defined in an inline `<script>` block of an `.html` file are invisible to every structural tool. `detectLanguage` returns `unknown` for `.html`, so the file never reaches the call-graph builder — no nodes, no edges, no `search_code` / `orient` / `analyze_impact` coverage. For codebases with real logic in inline scripts, an entire layer of behavior is structurally dark.

Orthogonal to #170 (literal-text line index): that makes literal **strings** findable; this gives the **graph** structural reach into inline JS.

## Approach — offset-preserving blanking

`CallGraphBuilder.build` already routes `JavaScript` content to `extractTSGraph`, and node line numbers come from `byteToLine` over `file.content`. Parsing a script body standalone would make offsets script-relative and break `file:line` mapping.

Instead, `extractHtmlScripts(content)` returns a string the **same length** as the HTML where every char outside an inline `<script>` body is a space (**newlines preserved**) and the JS bodies are kept verbatim. Tree-sitter then parses the JS islands at their **true offsets**, so node start/end/line map back to the HTML file — `extractTSGraph` is reused **unchanged** (decision `5b38bad2`). This is the standard "virtual document" technique editors use for embedded languages.

## What changes

- **`html-script-extractor.ts`** — `extractHtmlScripts` (returns `null` when no inline JS) + `isInlineJsScript` type filter (keeps `text/javascript` / `application/javascript` / `module` / ecmascript / no-type; rejects `application/json`, `importmap`, external `src=`).
- **`artifact-generator.ts`** — additive `.html` branch at the call-graph assembly gate: blanked JS pushed as `language:'JavaScript'`. Non-HTML files take the unchanged path — no regression.
- Dependency-free: no `tree-sitter-html`.

## Robustness (addressed in review)

- **No ReDoS.** Parsing is a linear open-tag scan + `indexOf` for the close tag, **not** a single backtracking regex. A file full of unterminated `<script` tags stays O(N) (20k unterminated tags < 1s, tested). Oversized HTML (>1MB) is skipped to bound allocation.
- **Filter anchoring.** `data-type` / `data-src` no longer false-match the `type`/`src` checks; a `; charset=…` suffix on `type` is tolerated.
- **Known limitation (documented):** an attribute value containing a literal `>` can truncate the open tag — rare; offsets stay correct, only the island content is affected.

## Out of scope (documented)

- **Watch-mode live update** — `mcp-watcher` excludes `.html`; inline-JS edits reconcile at the next full `analyze`.
- **`.vue` / `.svelte`** `<script>` blocks — same shape, follow-up.

## Tests

`html-script-extractor.test.ts` (10): length-invariance, newline preservation, markup/json/importmap/external blanked, multiple bodies, whitespace-tolerant close tag, `data-type`/`data-src`/charset filters, the ReDoS guard, and an **integration test through the call graph** (inline `foo(){ bar() }` + `bar(){}` → two HTML-anchored nodes, `foo→bar` edge, correct line numbers foo@4/bar@7).

Full suite green except one pre-existing `memory-invariant` timeout (unrelated — fails identically on the clean base).

A `code-reviewer` pass flagged the ReDoS, the `data-type`/`data-src` false-match, and a charset edge case — all fixed here with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)