### PR TITLE
feat(analyzer): link HTML to its external JS/CSS as dependency edges

### DIFF
--- a/openspec/changes/add-html-asset-dependency-edges/proposal.md
+++ b/openspec/changes/add-html-asset-dependency-edges/proposal.md
@@ -1,0 +1,77 @@
+# HTML asset-dependency edges: link `.html` to its external JS/CSS
+
+> Status: DRAFT (2026-06-20). Decision `b555b680` recorded before any code.
+> Distinct from the inline-script call graph (`5b38bad2`): that adds *function nodes* for inline
+> `<script>` JS; this adds *file→file dependency edges* from an HTML page to the external assets it
+> references. Distinct again from the literal-text line index (`fd256fde`).
+
+## Why
+
+An `.html` file has **no edges to the assets it loads**. `<script src="app.js">` and
+`<link rel="stylesheet" href="style.css">` are unparsed, so:
+
+- `get_file_dependencies("index.html")` shows nothing — the page looks isolated.
+- `analyze_impact("style.css")` / `analyze_impact("app.js")` never lists the HTML pages that consume
+  them, so the blast radius of editing a shared stylesheet or script is invisible.
+- The dependency graph treats every HTML page as a leaf with no out-edges, distorting the file-level
+  topology for any project that wires its front-end through HTML.
+
+The machinery to fix this already exists. `DependencyGraphBuilder.buildEdges` creates a file→file edge
+for every entry in a file's `FileAnalysis.imports` that `resolveImport` can resolve to a file already in
+the graph (`dependency-graph.ts:331`). `.css` and `.js` files are already walked and present as nodes.
+The only missing piece is that HTML files produce **no** `imports`.
+
+## What changes
+
+1. **HTML asset parsing.** Add `parseHtmlAssetImports(content)` producing `ImportInfo[]` for inline
+   asset references: `<script src=…>` and `<link rel="stylesheet" href=…>`. Dispatch it from
+   `ImportExportParser.parseFile` (`import-parser.ts:1047`) via a new `getFileType` → `'html'` arm.
+
+2. **Relative-href handling.** HTML hrefs are document-relative by nature, but a bare `app.js` does not
+   start with `.`, so it must be flagged `isRelative: true` (and normalized to `./app.js`) for the
+   existing `buildEdges` skip-rule and `resolveImport` to resolve it against the document's directory.
+   Absolute URLs (`http(s)://`, `//`), `data:`, `mailto:`, and `#…` anchors are excluded.
+
+3. **Edges fall out for free.** With HTML files yielding `imports`, `buildEdges` + `resolveImport`
+   create the `index.html → app.js` and `index.html → style.css` edges, update the adjacency lists, and
+   feed in/out-degree — no change to the edge-building loop itself. `.css`/`.js` targets already being
+   nodes means the `fileSet.has(resolvedPath)` guard passes.
+
+## What does NOT change
+
+- **No LLM.** Pure static extraction. North star (`c6d1ad07`) holds.
+- **No call-graph change.** These are file-level dependency edges, not function call edges; the inline
+  `<script>` call-graph work is separate and complementary.
+- **`buildEdges` / `resolveImport` are reused unchanged** (modulo the relative-href normalization done
+  in the parser, not the resolver).
+
+## Open design question — edge kind
+
+`DependencyEdge` is `{ source, target, importedNames, isTypeOnly, weight }`. Asset edges carry no
+`importedNames`. Options: (a) reuse the shape as-is with `importedNames: []`; (b) add an optional
+`kind?: 'asset'` so consumers can distinguish "loads asset" from "imports symbols". Recommend **(b)**,
+additive and cheap, so `get_file_dependencies` can label the relationship; default/absent kind keeps all
+existing edges unchanged.
+
+## Out of scope
+
+- **Root-absolute / web-root hrefs** (`/assets/app.js`) — resolving these assumes a configured web
+  root; best-effort against the project root is a follow-up, flagged as a limitation until then.
+- **Other asset references** — `<img src>`, `<a href>` page navigation, `<source>`, `srcset`,
+  `@import` inside CSS, framework template syntax. Start with script + stylesheet.
+- **Bundled/transpiled indirection** (a `<script src="dist/bundle.js">` that maps back to sources) —
+  the edge points at the referenced file as written.
+- **Inline `<script>`** — handled by the call-graph change (`5b38bad2`).
+
+## Risk
+
+**Low.** Additive: a new parser arm + a new `getFileType` case; the edge-building loop is untouched.
+HTML files that reference nothing resolvable produce no edges. No new dependency.
+
+## Application to OpenLore
+
+- `import-parser.ts` — `getFileType` gains `'html'`; `parseFile` dispatches to `parseHtmlAssetImports`;
+  the existing import-categorization loop routes relative hrefs into `localImports`.
+- `dependency-graph.ts` — unchanged except the optional `kind` field on `DependencyEdge` if (b) is
+  taken.
+- Surfaces immediately through `get_file_dependencies`, `analyze_impact`, and the dependency diagram.

--- a/openspec/changes/add-html-asset-dependency-edges/specs/analyzer/spec.md
+++ b/openspec/changes/add-html-asset-dependency-edges/specs/analyzer/spec.md
@@ -1,0 +1,33 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: HtmlAssetDependencyEdges
+
+The dependency graph SHALL create file→file edges from an `.html`/`.htm` file to the local assets it
+references inline: `<script src=…>` and `<link rel="stylesheet" href=…>`. References to absolute URLs
+(`http://`, `https://`, protocol-relative `//`), `data:` URIs, `mailto:`, and `#` fragment anchors SHALL
+NOT produce edges. A referenced asset SHALL produce an edge only when it resolves to a file already
+present as a node in the graph. HTML files referencing no resolvable local asset SHALL produce no edges
+and SHALL NOT error. Non-HTML dependency-graph output SHALL be unchanged.
+
+#### Scenario: A page links to its script and stylesheet
+
+- **GIVEN** an `index.html` containing `<script src="app.js">` and `<link rel="stylesheet" href="style.css">`,
+  with `app.js` and `style.css` present in the repository
+- **WHEN** the dependency graph is built
+- **THEN** it contains an edge `index.html → app.js` and an edge `index.html → style.css`, and the
+  in-degree of `style.css` includes `index.html`
+
+#### Scenario: External and non-stylesheet references are excluded
+
+- **GIVEN** an HTML page whose references are a CDN `<script src="https://cdn.example/app.js">` and a
+  `<link rel="preload" href="font.woff2">`
+- **WHEN** the dependency graph is built
+- **THEN** neither produces an edge, and the page contributes no out-edges
+
+#### Scenario: Non-HTML dependency edges are unaffected
+
+- **GIVEN** a project with no HTML files
+- **WHEN** the dependency graph is built with HTML asset extraction enabled
+- **THEN** the resulting edges are identical to the output without the feature

--- a/openspec/changes/add-html-asset-dependency-edges/tasks.md
+++ b/openspec/changes/add-html-asset-dependency-edges/tasks.md
@@ -1,0 +1,40 @@
+# Tasks — HTML asset-dependency edges
+
+> Status: DRAFT (2026-06-20). Decision `b555b680` recorded before code. File→file dependency edges
+> (`<script src>`, `<link rel=stylesheet href>`); reuses `buildEdges` + `resolveImport`.
+
+## 1. HTML asset parser
+- [x] `parseHtmlAssetImports(content): ImportInfo[]` in `import-parser.ts` — one entry per
+      `<script src=…>` and `<link rel="stylesheet" href=…>`.
+- [x] `normalizeAssetHref` excludes absolute URLs (`http(s)://`, `//`), `data:`/`mailto:`/`tel:`/
+      `javascript:`, `#` anchors, empty, and root-absolute `/…` (out of scope); strips `?`/`#`.
+- [x] Kept refs: `isRelative: true`, `isPackage: false`, bare `app.js` → `./app.js`, `importedNames: []`,
+      `assetKind` set.
+- [x] `<link>` filtered to `rel=stylesheet` (case/quote tolerant); `preload`/`icon`/`manifest` excluded.
+
+## 2. Dispatch wiring
+- [x] `getFileType`: `.html`/`.htm` → `'html'`.
+- [x] `ImportExportParser.parseFile`: `html` arm calls `parseHtmlAssetImports`; existing categorization
+      routes relative hrefs into `localImports`.
+
+## 3. Edge kind
+- [x] Added `assetKind?: 'script' | 'stylesheet'` to `DependencyEdge` (additive; absent = code import),
+      carried from `ImportInfo.assetKind` in `buildEdges`.
+
+## 4. Tests
+- [x] Unit (`parseHtmlAssetImports`, 6): script src + stylesheet link, external/data/anchor/root-absolute
+      excluded, `rel=preload/icon/manifest` excluded, bare-href normalization, query/fragment strip,
+      quote style + attribute order, line numbers.
+- [x] Integration (`DependencyGraphBuilder.build`, 2): `index.html → app.js` + `→ style.css` edges with
+      `assetKind`, raised stylesheet in-degree; CDN-only page → no edges.
+- [~] E2E via `runAnalysis` — covered transitively by the integration test on the real builder; a
+      dedicated `analyze_impact`/`get_file_dependencies` e2e can be added if desired.
+- [x] Regression: CDN-only page produces no edges; non-HTML output unaffected (additive branch).
+
+## 5. Docs
+- [ ] Note HTML asset edges in the analyzer/dependency spec and the relevant tool descriptions
+      (`get_file_dependencies`, `analyze_impact`).
+
+## 6. Follow-ups (not this change)
+- [ ] Root-absolute / web-root href resolution (configurable web root).
+- [ ] `<img>`, `<a href>`, `<source>`/`srcset`, CSS `@import`, framework template asset refs.

--- a/src/core/analyzer/dependency-graph.ts
+++ b/src/core/analyzer/dependency-graph.ts
@@ -73,6 +73,8 @@ export interface DependencyEdge {
   httpEdge?: HttpEdge;
   /** True when this edge was synthesized from a call-graph cross-file call (implicit import) */
   isCallEdge?: boolean;
+  /** Present when this edge is an HTML page → asset reference (decision b555b680) */
+  assetKind?: 'script' | 'stylesheet';
 }
 
 /**
@@ -370,6 +372,8 @@ export class DependencyGraphBuilder {
           isTypeOnly: imp.isTypeOnly,
           weight: imp.isTypeOnly ? 0.5 : 1,
         };
+        // Carry the HTML asset label (script / stylesheet) onto the edge.
+        if (imp.assetKind) edge.assetKind = imp.assetKind;
 
         this.edges.push(edge);
 

--- a/src/core/analyzer/html-asset-edges.integration.test.ts
+++ b/src/core/analyzer/html-asset-edges.integration.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Integration — HTML asset-dependency edges through the real dependency graph
+ * (decision b555b680).
+ *
+ * Writes a temp repo with an index.html referencing app.js and style.css, runs
+ * RepositoryMapper + DependencyGraphBuilder (the real pipeline), and asserts the
+ * page → asset edges exist, carry the right assetKind, and raise the assets'
+ * in-degree. A CDN-only page produces no edges.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RepositoryMapper } from './repository-mapper.js';
+import { DependencyGraphBuilder } from './dependency-graph.js';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'openlore-html-assets-'));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function buildGraph() {
+  const repoMap = await new RepositoryMapper(dir).map();
+  return new DependencyGraphBuilder({ rootDir: dir }).build(repoMap.allFiles);
+}
+
+describe('HTML asset-dependency edges (integration)', () => {
+  it('links index.html to its script and stylesheet, with assetKind and in-degree', async () => {
+    await writeFile(
+      join(dir, 'index.html'),
+      '<html><head>\n<link rel="stylesheet" href="style.css">\n</head>\n' +
+        '<body><script src="app.js"></script></body></html>\n',
+      'utf-8',
+    );
+    await writeFile(join(dir, 'app.js'), 'function boot() { return 1; }\n', 'utf-8');
+    await writeFile(join(dir, 'style.css'), 'body { margin: 0; }\n', 'utf-8');
+
+    const g = await buildGraph();
+    const edge = (suffix: string) =>
+      g.edges.find((e) => e.source.endsWith('index.html') && e.target.endsWith(suffix));
+
+    const jsEdge = edge('app.js');
+    const cssEdge = edge('style.css');
+    expect(jsEdge, 'index.html → app.js edge').toBeDefined();
+    expect(cssEdge, 'index.html → style.css edge').toBeDefined();
+    expect(jsEdge!.assetKind).toBe('script');
+    expect(cssEdge!.assetKind).toBe('stylesheet');
+
+    // The stylesheet's in-degree now reflects the consuming page.
+    const cssNode = g.nodes.find((n) => n.id.endsWith('style.css'));
+    expect(cssNode!.metrics.inDegree).toBeGreaterThanOrEqual(1);
+  });
+
+  it('produces no edges for a page that only references CDN assets', async () => {
+    await writeFile(
+      join(dir, 'cdn.html'),
+      '<html><head>\n<link rel="stylesheet" href="https://cdn.example/site.css">\n' +
+        '<script src="https://cdn.example/app.js"></script>\n</head></html>\n',
+      'utf-8',
+    );
+    await writeFile(join(dir, 'noop.ts'), 'export const z = 3;\n', 'utf-8');
+
+    const g = await buildGraph();
+    expect(g.edges.some((e) => e.source.endsWith('cdn.html'))).toBe(false);
+  });
+});

--- a/src/core/analyzer/html-asset-imports.test.ts
+++ b/src/core/analyzer/html-asset-imports.test.ts
@@ -1,0 +1,95 @@
+/**
+ * HTML asset-import parsing (decision b555b680).
+ *
+ * `parseHtmlAssetImports` turns `<script src>` and `<link rel=stylesheet href>`
+ * into ImportInfo entries the dependency graph resolves into file→file edges.
+ * External/CDN URLs, data URIs, anchors, root-absolute hrefs, and non-stylesheet
+ * links must NOT produce imports; bare hrefs must be normalized to `./…`.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseHtmlAssetImports } from './import-parser.js';
+
+describe('parseHtmlAssetImports', () => {
+  it('extracts a script src and a stylesheet link, normalized to ./', () => {
+    const html =
+      '<link rel="stylesheet" href="style.css">\n' +
+      '<script src="app.js"></script>';
+    const imps = parseHtmlAssetImports(html);
+    const sources = imps.map((i) => i.source).sort();
+    expect(sources).toEqual(['./app.js', './style.css']);
+    for (const i of imps) {
+      expect(i.isRelative).toBe(true);
+      expect(i.isPackage).toBe(false);
+      expect(i.importedNames).toEqual([]);
+    }
+    expect(imps.find((i) => i.source === './app.js')!.assetKind).toBe('script');
+    expect(imps.find((i) => i.source === './style.css')!.assetKind).toBe('stylesheet');
+  });
+
+  it('keeps explicit relative prefixes and resolves nested paths', () => {
+    const html =
+      '<script src="../shared/util.js"></script>' +
+      '<link rel="stylesheet" href="./css/main.css">';
+    const sources = parseHtmlAssetImports(html).map((i) => i.source).sort();
+    expect(sources).toEqual(['../shared/util.js', './css/main.css']);
+  });
+
+  it('excludes external, protocol-relative, data, anchor and root-absolute refs', () => {
+    const html = [
+      '<script src="https://cdn.example/app.js"></script>',
+      '<script src="//cdn.example/x.js"></script>',
+      '<link rel="stylesheet" href="/assets/site.css">',          // root-absolute → out of scope
+      '<link rel="stylesheet" href="data:text/css,body{}">',
+      '<a href="#top">top</a>',
+    ].join('\n');
+    expect(parseHtmlAssetImports(html)).toEqual([]);
+  });
+
+  it('only treats rel=stylesheet links as imports', () => {
+    const html = [
+      '<link rel="preload" href="font.woff2">',
+      '<link rel="icon" href="favicon.ico">',
+      '<link rel="manifest" href="site.webmanifest">',
+      '<link rel="stylesheet" href="real.css">',
+    ].join('\n');
+    const sources = parseHtmlAssetImports(html).map((i) => i.source);
+    expect(sources).toEqual(['./real.css']);
+  });
+
+  it('strips query strings and fragments, tolerates quote style and attribute order', () => {
+    const html =
+      "<script src='app.js?v=2'></script>" +
+      '<link href="theme.css#dark" rel=stylesheet>';
+    const sources = parseHtmlAssetImports(html).map((i) => i.source).sort();
+    expect(sources).toEqual(['./app.js', './theme.css']);
+  });
+
+  it('returns line numbers', () => {
+    const html = '<html>\n<head>\n<script src="app.js"></script>\n</head>';
+    expect(parseHtmlAssetImports(html)[0].line).toBe(3);
+  });
+
+  it('ignores commented-out tags (no phantom edges) and keeps line numbers', () => {
+    const html =
+      '<head>\n' +
+      '<!-- <script src="old.js"></script> -->\n' +   // line 2 — must be ignored
+      '<script src="app.js"></script>\n';             // line 3 — kept
+    const imps = parseHtmlAssetImports(html);
+    expect(imps.map((i) => i.source)).toEqual(['./app.js']);
+    expect(imps[0].line).toBe(3); // comment blanking preserved the line number
+  });
+
+  it('detects order-independent multi-token rel but not data-rel decoys', () => {
+    const html = [
+      '<link rel="preload stylesheet" href="a.css">', // reversed multi-token → IS a stylesheet
+      '<link data-rel="stylesheet" href="b.css">',    // decoy attribute → NOT a stylesheet
+    ].join('\n');
+    const sources = parseHtmlAssetImports(html).map((i) => i.source);
+    expect(sources).toEqual(['./a.css']);
+  });
+
+  it('handles a script tag whose attributes span multiple lines', () => {
+    const html = '<script\n  defer\n  src="app.js"\n></script>';
+    expect(parseHtmlAssetImports(html).map((i) => i.source)).toEqual(['./app.js']);
+  });
+});

--- a/src/core/analyzer/import-parser.ts
+++ b/src/core/analyzer/import-parser.ts
@@ -27,6 +27,12 @@ export interface ImportInfo {
   isTypeOnly: boolean;
   isDynamic: boolean;
   line: number;
+  /**
+   * Set when this import is an HTML asset reference (`<script src>` /
+   * `<link rel=stylesheet href>`) rather than a code import, so the dependency
+   * graph can label the edge. Absent for ordinary code imports.
+   */
+  assetKind?: 'script' | 'stylesheet';
 }
 
 /**
@@ -997,6 +1003,86 @@ async function resolveJavaImport(
 /**
  * Import/Export Parser
  */
+// ============================================================================
+// HTML ASSET IMPORTS (decision b555b680)
+// ============================================================================
+
+// `<script ... src="…">` — any inline-referenced external script is a file dep.
+const HTML_SCRIPT_SRC_RE = /<script\b[^>]*?\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
+// `<link …>` — filtered to rel=stylesheet below (rel/href order varies).
+const HTML_LINK_RE = /<link\b([^>]*)>/gi;
+
+/**
+ * Normalize an HTML asset href into a document-relative import source, or null
+ * when it should not produce a dependency edge. Absolute URLs (`http(s)://`,
+ * protocol-relative `//`), `data:`/`mailto:`/`tel:`/`javascript:` URIs, `#`
+ * anchors, root-absolute `/…` (web-root — out of scope), and empty refs are
+ * dropped. Query strings and fragments are stripped, and a bare `app.js` is
+ * prefixed `./` so it is treated as relative by isRelativeImport / resolveImport.
+ */
+function normalizeAssetHref(href: string): string | null {
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+  if (/^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(trimmed)) return null; // http(s):// or //
+  if (/^(?:data|mailto|tel|javascript):/i.test(trimmed)) return null;
+  if (trimmed.startsWith('#')) return null;
+  const clean = trimmed.split(/[?#]/)[0];
+  if (!clean) return null;
+  if (clean.startsWith('/')) return null; // root-absolute assumes a web root — out of scope
+  return clean.startsWith('.') ? clean : './' + clean;
+}
+
+function assetImport(source: string, line: number, assetKind: 'script' | 'stylesheet'): ImportInfo {
+  return {
+    source,
+    isRelative: true,
+    isPackage: false,
+    isBuiltin: false,
+    importedNames: [],
+    hasDefault: false,
+    hasNamespace: false,
+    isTypeOnly: false,
+    isDynamic: false,
+    line,
+    assetKind,
+  };
+}
+
+/**
+ * Extract local asset references from an HTML file as ImportInfo entries:
+ * `<script src=…>` (script) and `<link rel="stylesheet" href=…>` (stylesheet).
+ * External/CDN URLs and non-stylesheet links are excluded. The existing
+ * dependency-graph edge machinery resolves these against the document directory.
+ */
+export function parseHtmlAssetImports(content: string): ImportInfo[] {
+  const out: ImportInfo[] = [];
+  // Blank out HTML comments so commented-out <script>/<link> tags don't produce
+  // phantom edges. Same-length whitespace (newlines kept) preserves line numbers.
+  const scan = content.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ' '));
+  const lineAt = (idx: number): number => scan.slice(0, idx).split('\n').length;
+
+  HTML_SCRIPT_SRC_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = HTML_SCRIPT_SRC_RE.exec(scan)) !== null) {
+    const src = normalizeAssetHref(m[1]);
+    if (src) out.push(assetImport(src, lineAt(m.index), 'script'));
+  }
+
+  HTML_LINK_RE.lastIndex = 0;
+  while ((m = HTML_LINK_RE.exec(scan)) !== null) {
+    const attrs = m[1];
+    // rel attribute anchored on a left boundary (so `data-rel` does not match)
+    // and order-independent over multi-token rel (`preload stylesheet`).
+    if (!/(?:^|\s)rel\s*=\s*["']?[^"'>]*\bstylesheet\b/i.test(attrs)) continue;
+    const hrefM = /(?:^|\s)href\s*=\s*["']([^"']+)["']/i.exec(attrs);
+    if (!hrefM) continue;
+    const href = normalizeAssetHref(hrefM[1]);
+    if (href) out.push(assetImport(href, lineAt(m.index), 'stylesheet'));
+  }
+
+  return out;
+}
+
 export class ImportExportParser {
   private cache: Map<string, FileAnalysis> = new Map();
 
@@ -1010,13 +1096,14 @@ export class ImportExportParser {
   /**
    * Get file extension type
    */
-  private getFileType(filePath: string): 'js' | 'ts' | 'python' | 'java' | 'unknown' {
+  private getFileType(filePath: string): 'js' | 'ts' | 'python' | 'java' | 'html' | 'unknown' {
     const ext = extname(filePath).toLowerCase();
 
     if (['.ts', '.tsx', '.mts', '.cts'].includes(ext)) return 'ts';
     if (['.js', '.jsx', '.mjs', '.cjs'].includes(ext)) return 'js';
     if (['.py', '.pyw'].includes(ext)) return 'python';
     if (ext === '.java') return 'java';
+    if (['.html', '.htm'].includes(ext)) return 'html';
 
     return 'unknown';
   }
@@ -1054,6 +1141,9 @@ export class ImportExportParser {
         analysis.imports = parseJavaImports(content);
         analysis.exports = parseJavaExports(content);
         analysis.javaPackage = parseJavaPackage(content);
+      } else if (fileType === 'html') {
+        // HTML asset references (decision b555b680): <script src>, <link stylesheet>.
+        analysis.imports = parseHtmlAssetImports(content);
       } else {
         analysis.parseErrors.push(`Unsupported file type: ${extname(filePath)}`);
       }


### PR DESCRIPTION
## Problem

An `.html` file had **no edges to the assets it loads**. `<script src="app.js">` and `<link rel="stylesheet" href="style.css">` were unparsed, so:

- `get_file_dependencies("index.html")` showed nothing — every page looked isolated.
- `analyze_impact("style.css")` / `analyze_impact("app.js")` never listed the HTML pages consuming them — the blast radius of editing a shared stylesheet/script was invisible.
- The dependency graph treated each HTML page as a leaf, distorting file-level topology.

Distinct from #171 (inline `<script>` → call-graph *function nodes*); this adds *file→file dependency edges*.

## Approach — reuse the existing edge machinery

`DependencyGraphBuilder.buildEdges` already creates a file→file edge for every `FileAnalysis.imports` entry that `resolveImport` resolves to a graph node, and `.css`/`.js` files are already nodes. The only gap: HTML produced no `imports`.

- **`parseHtmlAssetImports(content)`** — emits `ImportInfo[]` for `<script src=…>` and `<link rel="stylesheet" href=…>`.
- **`normalizeAssetHref`** — drops external URLs (`http(s)://`, `//`), `data:`/`mailto:`/`tel:`/`javascript:`, `#` anchors, root-absolute `/…` (web-root, out of scope); strips `?`/`#`; prefixes bare `app.js` → `./app.js` so it resolves against the document directory.
- **Dispatch** — `getFileType` gains an `.html`/`.htm` arm; `parseFile` routes to the new parser. `buildEdges` + `resolveImport` then create the edges unchanged (the exact-path resolver candidate handles `.css`/`.js`).
- **`assetKind?: 'script' | 'stylesheet'`** — additive field on `DependencyEdge`, carried from the import, so `get_file_dependencies` can label "loads asset" vs "imports symbols".

## Safety / robustness (review-hardened)

- **Traversal-safe.** A `../../../x` href can only ever edge to a file already in the repo map — the `fileSet.has(resolvedPath)` gate blocks any out-of-repo target. Root-absolute `/…` is excluded before resolution.
- **Comments ignored.** HTML comments are blanked (same-length whitespace, line numbers preserved) so commented-out `<script>`/`<link>` tags don't produce phantom edges.
- **`rel` matching** is left-anchored (no `data-rel` false positive) and order-independent (`rel="preload stylesheet"` is detected).
- **No ReDoS** — bounded `[^>]` scans, no nested quantifiers.

## Out of scope (documented)

- Root-absolute / web-root href resolution (needs a configured web root).
- `<img>`, `<a href>`, `<source>`/`srcset`, CSS `@import`, framework template asset refs.
- A `>` inside an attribute value before `src`/`href` (rare) truncates the tag match — known limitation.

## Tests

`html-asset-imports.test.ts` (9): script src + stylesheet link, external/data/anchor/root-absolute excluded, `rel=preload/icon/manifest` excluded, bare-href normalization, query/fragment strip, quote style + attribute order, line numbers, **commented-out tags ignored**, **reversed multi-token `rel`**, **`data-rel` decoy**, **multiline tag**.

`html-asset-edges.integration.test.ts` (2): real `RepositoryMapper` + `DependencyGraphBuilder` → `index.html → app.js` + `→ style.css` edges with `assetKind` and raised stylesheet in-degree; CDN-only page → no edges.

Full suite green except one pre-existing `memory-invariant` timeout (unrelated — fails identically on the clean base).

A `code-reviewer` pass returned APPROVE; its MEDIUM findings (commented-out tags, `data-rel`) and the reversed-`rel` LOW are fixed here with regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)