### PR TITLE
feat(watcher): full watch-mode reconciliation — dependency graph, HTML, create/delete

### DIFF
--- a/openspec/changes/add-watch-incremental-dependency-graph/proposal.md
+++ b/openspec/changes/add-watch-incremental-dependency-graph/proposal.md
@@ -1,0 +1,69 @@
+# Live dependency-graph edges in watch mode
+
+> Status: DRAFT (2026-06-20).
+> Closes a systemic watch-mode staleness: the call graph (function→function) is kept live by the
+> watcher, but the **dependency graph** (file→file imports) was never updated incrementally — it froze
+> until a full `analyze`. This affects every language's import edits, not just HTML assets.
+
+## Why
+
+`get_file_dependencies` reads the static `dependency-graph.json` artifact (`graph.ts`). The MCP watcher
+incrementally maintains signatures, the call-graph EdgeStore, the text-line index, and the vector index
+— but **never touches `dependency-graph.json`**. So in `mcp --watch`, the moment an import is added,
+removed, or re-pointed, the file→file dependency view goes stale until the next full `analyze`:
+
+- `get_file_dependencies("x")` returns the *old* imports.
+- file-level in/out-degree, and anything reading the dep-graph artifact, drift.
+
+(The `serve` daemon hides this by scheduling a debounced **full** re-analyze via `onBatchFlushed`, but
+that is O(repo); plain `mcp --watch` has no such fallback.)
+
+The call graph got cheap incremental updates (EdgeStore) because its edge ops are O(change). The
+dependency graph carries **global metrics** — pageRank, betweenness, clusters — that are O(graph), which
+is why it piggybacked on the full re-analyze. But the part `get_file_dependencies` actually serves — the
+**edges** — can be patched just as cheaply.
+
+## What changes
+
+1. **Incremental edge patch in the watcher.** On each batch, for every changed file already present as a
+   dependency-graph node, re-resolve its imports and replace that file's import edges in
+   `dependency-graph.json`, then recompute file in/out-degree. O(change).
+
+2. **Shared resolution — no drift.** The per-file edge logic is extracted from `buildEdges` into an
+   exported `computeFileImportEdges(fromAbs, analysis, fileSet, rootDir, extensions?)`, used by **both**
+   the full builder and the watcher, so incremental and full results can't diverge.
+
+3. **HTTP / call-synthesized edges preserved.** The patch drops only a changed file's *import* edges
+   (those it owns); `httpEdge` and `isCallEdge` edges — which the watcher does not rebuild — are kept.
+
+4. **Global metrics deferred, by design.** pageRank, betweenness, and clusters are O(graph); they are
+   left to the next full `analyze` (the same posture the call graph's hub/community stats already take
+   in watch mode). Only the edges + degrees that `get_file_dependencies` serves are kept live.
+
+   **Consequence — temporary metric divergence:** after a watch patch, a node's `inDegree`/`outDegree`
+   are fresh while its `pageRank`/`betweenness`/`cluster` reflect the pre-edit edge set (e.g. a node may
+   show a new `inDegree` but an unchanged `pageRank`). This is acceptable for an advisory artifact —
+   `get_file_dependencies` consumes the edges/degrees, not the global metrics — and self-heals on the
+   next full `analyze`. Tools must not assume degree-vs-pageRank consistency mid-watch.
+
+## What does NOT change
+
+- **No LLM, no new artifact.** Patches the existing `dependency-graph.json` in place.
+- **Full-build behavior is identical** — `buildEdges` now calls the extracted helper; existing
+  dependency-graph tests pass unchanged.
+- **The call-graph / signature / vector / text-line lanes are untouched.**
+
+## Scope boundaries
+
+- **HTML files are not watched** (they are not in `SOURCE_EXTENSIONS`), so HTML asset edges still
+  refresh only on full `analyze` — that is the separate HTML-watch follow-up.
+- **Global metrics** (pageRank/betweenness/clusters) are not recomputed incrementally; they refresh on
+  full `analyze`.
+- **New files** (not yet a dep-graph node) are added by the next full `analyze`, not patched in.
+- **Deletions** are not reconciled in watch mode (consistent with every other watcher lane).
+
+## Risk
+
+**Low.** The full-build path is refactored to reuse the same extracted function (behavior-preserving,
+covered by existing tests). The watcher addition is a guarded, best-effort JSON patch that no-ops when
+no dependency graph exists and never throws into the batch loop.

--- a/openspec/changes/add-watch-incremental-dependency-graph/tasks.md
+++ b/openspec/changes/add-watch-incremental-dependency-graph/tasks.md
@@ -1,0 +1,29 @@
+# Tasks — Live dependency-graph edges in watch mode
+
+> Status: DRAFT (2026-06-20). Incremental file→file import edges in `mcp --watch`; reuses the builder's
+> resolution logic. Global metrics deferred to full `analyze`.
+
+## 1. Shared edge resolution
+- [x] Extract `computeFileImportEdges(fromAbs, analysis, fileSet, rootDir, extensions?)` from
+      `DependencyGraphBuilder.buildEdges` (pure; returns edges, caller owns adjacency).
+- [x] `buildEdges` calls it — behavior-preserving (existing dependency-graph tests stay green).
+
+## 2. Watcher incremental patch
+- [x] `McpWatcher.updateDependencyGraph(changedFiles)`: read `dependency-graph.json`; for each changed
+      file that is a graph node, re-parse imports (`ImportExportParser`), compute new edges via the
+      shared helper, replace that file's import edges, recompute in/out-degree, persist.
+- [x] Preserve `httpEdge` / `isCallEdge` edges (the watcher doesn't rebuild them).
+- [x] Called from `handleBatch` (step 3.6, after the text-line update); guarded + best-effort, no throw.
+- [x] No-op when `dependency-graph.json` is absent.
+
+## 3. Tests
+- [x] Watcher integration: edit an import (`./b` → `./c`) → `dependency-graph.json` drops the old edge,
+      adds the new, and recomputes degrees.
+- [x] Existing dependency-graph + import-parser suites pass unchanged (shared-helper refactor).
+- [ ] (optional) Unit test for `computeFileImportEdges` in isolation — currently covered transitively
+      via `buildEdges` + the watcher integration test.
+
+## 4. Out of scope (documented in proposal)
+- [ ] HTML files in watch (separate HTML-watch follow-up).
+- [ ] Incremental global metrics (pageRank/betweenness/clusters) — full `analyze` only.
+- [ ] New-file node creation + deletion reconciliation in watch mode.

--- a/openspec/changes/add-watcher-create-delete-reconciliation/proposal.md
+++ b/openspec/changes/add-watcher-create-delete-reconciliation/proposal.md
@@ -1,0 +1,62 @@
+# Reconcile file create & delete in watch mode
+
+> Status: DRAFT (2026-06-20). Stacks on the watch-mode work (dependency-graph + HTML live). Closes the
+> last watch-mode hole: the watcher reconciled file MODIFICATIONS across every lane, but not CREATES or
+> DELETES.
+
+## Why
+
+The watcher listened only to chokidar `'change'`. So:
+
+- **Deleting** a file left phantom state in every lane — its call-graph nodes/edges, signatures,
+  text-line rows, vector rows, and dependency-graph node/edges all lingered until a full `analyze`.
+  `search_code` and `get_file_dependencies` returned results pointing at a file that no longer exists.
+- **Creating** a file made it invisible — no symbols, no edges, not searchable — until a full `analyze`.
+
+Modification was made hole-free across all lanes earlier this session; create/delete is the symmetric
+other half.
+
+## What changes
+
+1. **`'add'` events** route through the existing change pipeline (insert is a no-op delete + add), so a
+   new file is picked up by signatures, the call graph, the text-line index, and the vector index.
+   `updateDependencyGraph` now **adds a node** for a changed file that isn't yet in the graph, plus its
+   outgoing import edges. (`ignoreInitial: true` means only files created *after* start fire `'add'` —
+   no initial-scan storm.)
+
+2. **`'unlink'` events** route to a new `handleDeletions` that removes the file from **every** lane:
+   - **Call graph:** `deleteEdgesForFile` (caller OR callee — no dangling incoming edges) +
+     `deleteNodesForFile` + `deleteCfgForFile` + `deleteClassesForFile`.
+   - **Signatures:** drop the file's `FileSignatureMap` from `llm-context.json`.
+   - **Text-line index:** `TextLineIndex.updateFiles(out, [], [rel])`.
+   - **Vector index:** `VectorIndex.updateFiles` with no nodes for the path → deletes its rows.
+   - **Dependency graph:** remove the node and every edge touching it (source or target), recompute
+     degrees, **atomic write** (tmp + `rename`).
+
+3. **Coalescing.** Deletions share the same debounce as changes via a `pendingDeletions` set; a flush
+   processes deletions first (remove stale state) then re-indexes changes. A re-create supersedes a
+   pending delete and vice-versa, so a delete-then-recreate burst resolves to a re-index.
+
+## What does NOT change
+
+- **No LLM.** Reuses existing deterministic store/index primitives.
+- **Modification behavior is unchanged** — the change pipeline is untouched except for the dependency-
+  graph new-node addition.
+- **Single-flight / debounce invariants preserved** — deletions flow through the same timers and
+  running-latch.
+
+## Scope boundaries
+
+- **New-file incoming edges.** A new file gets a node + its *outgoing* imports; *incoming* edges
+  (existing files that import it) appear when those importers are next touched or on the next full
+  `analyze`. Resolving them eagerly would require re-parsing every potential importer.
+- **Global dependency-graph metrics** (pageRank/betweenness/clusters) remain deferred to full `analyze`.
+- **Stale file hash on delete.** The EdgeStore's per-file content hash for a deleted path is left; it is
+  harmless (a same-path recreate re-parses on content change).
+
+## Risk
+
+**Low–medium.** The coalescing change is the delicate part; it preserves the single-flight latch and
+debounce, and supersession prevents a delete/recreate race from leaving stale state. Each lane's
+deletion reuses an existing, tested primitive and is best-effort (a failure in one lane never blocks the
+others).

--- a/openspec/changes/add-watcher-create-delete-reconciliation/tasks.md
+++ b/openspec/changes/add-watcher-create-delete-reconciliation/tasks.md
@@ -1,0 +1,32 @@
+# Tasks — Reconcile file create & delete in watch mode
+
+> Status: DRAFT (2026-06-20). Stacks on the dependency-graph + HTML watch work.
+
+## 1. Events + coalescing
+- [x] chokidar `'add'` → `enqueue` (same pipeline as `'change'`); `'unlink'` → `enqueueDeletion`.
+- [x] `pendingDeletions` set; `armFlush` shared by both; `flush` drains both (deletions first).
+- [x] Supersession: an enqueue clears a pending delete for the path and vice-versa.
+- [x] Single-flight latch + debounce reschedule account for both sets.
+
+## 2. Create
+- [x] `updateDependencyGraph` adds a node (+ outgoing edges) for a changed file not yet in the graph.
+
+## 3. Delete (`handleDeletions`)
+- [x] Call graph: `deleteEdgesForFile` (both directions) + nodes + cfg + classes, one transaction.
+- [x] Signatures: drop the file's `FileSignatureMap`; persist.
+- [x] Text-line index: `updateFiles([], [rel])`.
+- [x] Vector index: `updateFiles([], {rel}, …)` → deletes rows.
+- [x] Dependency graph: `removeFromDependencyGraph` — drop node + edges touching it, recompute degrees,
+      atomic write (tmp + rename).
+
+## 4. Tests
+- [x] Integration: new (non-node) file edit → node + outgoing edge added.
+- [x] Integration: real `unlink` of a target → node + edges removed, importer node remains.
+- [x] E2E (`analyze → watch → get_file_dependencies`): deletion removes a file as importer + its node;
+      creation makes a new file's imports visible. (Plus the existing modify + HTML e2e.)
+- [x] Existing watcher unit + integration suites pass (coalescing restructure).
+
+## 5. Out of scope (documented)
+- [ ] New-file incoming edges (importers refresh on touch / full analyze).
+- [ ] Global dep-graph metrics incremental.
+- [ ] EdgeStore file-hash cleanup on delete (harmless).

--- a/openspec/changes/add-watcher-html-live-update/proposal.md
+++ b/openspec/changes/add-watcher-html-live-update/proposal.md
@@ -1,0 +1,54 @@
+# HTML live in watch mode
+
+> Status: DRAFT (2026-06-20). **Stacks on `feat/watch-incremental-dependency-graph` (#173)** — uses its
+> `updateDependencyGraph`. Closes the shared watch-mode gap for all three HTML features at once.
+
+## Why
+
+Three merged features index HTML — literal-text lines (#170), inline-`<script>` call-graph nodes
+(#171), and `<script src>`/`<link>` asset edges (#172) — but **none refreshed in `mcp --watch`**. The
+watcher reacts only to `SOURCE_EXTENSIONS` (and skips `detectLanguage === 'unknown'`), and HTML is
+neither. So after a full `analyze`, editing an `.html` left its text lines, inline-script nodes, and
+asset edges stale until the next full analyze.
+
+## What changes
+
+1. **Watch HTML.** The chokidar `change` filter and the `handleBatch` candidate gate now admit
+   `.html`/`.htm` alongside `SOURCE_EXTENSIONS`.
+
+2. **Blank HTML in `buildGraphSubset` (required, not optional).** Once HTML enters the call-graph loop,
+   the atomic swap deletes-then-inserts the file's nodes. If `buildGraphSubset` returned empty for HTML,
+   every edit would **delete** the page's inline-script nodes a full analyze produced. So
+   `buildGraphSubset` blanks the HTML (offset-preserving, reusing `extractHtmlScripts`) and parses it as
+   JavaScript — the inline-script nodes refresh in place. An HTML file with no inline JS returns empty
+   (nothing to churn).
+
+3. **Text lines + asset edges fall out for free.** With HTML in `changedFiles`, the existing
+   `updateTextLines` (#170) refreshes its lines, and `updateDependencyGraph` (#173) re-parses it via
+   `parseHtmlAssetImports` (#172) and patches the `<script src>` / `<link rel=stylesheet>` edges.
+
+One gate-widening + one blanking guard makes all three HTML features live in watch mode.
+
+## What does NOT change
+
+- **No LLM.** Reuses the deterministic extractors. North star holds.
+- **Source-file behavior is unchanged** — HTML takes a dedicated path; `SOURCE_EXTENSIONS` files flow
+  exactly as before.
+- **`buildGraphSubset` for non-HTML is unchanged** (the blanking branch only fires for `.html`/`.htm`
+  that `detectLanguage` reports as `unknown`).
+
+## Scope boundaries
+
+- **`.vue` / `.svelte`** single-file components are not watched (same as full analyze — separate
+  follow-up).
+- **`.css` edits** are not watched: CSS has no inline JS and no outgoing asset edges; its only index
+  presence is text lines, which still refresh on full analyze. (Could be added to the text-line lane
+  later if wanted.)
+- **Deletions / new files** are not reconciled in watch mode — consistent with every other watcher lane.
+- **Global dependency-graph metrics** stay deferred to full analyze (per #173).
+
+## Risk
+
+**Low–medium.** The watcher is invariant-sensitive, so the one real hazard — HTML entering the
+call-graph loop and wiping inline-script nodes — is closed by the `buildGraphSubset` blanking and locked
+by a unit test. Everything else is additive: HTML flows through the same lanes source files already use.

--- a/openspec/changes/add-watcher-html-live-update/tasks.md
+++ b/openspec/changes/add-watcher-html-live-update/tasks.md
@@ -1,0 +1,28 @@
+# Tasks — HTML live in watch mode
+
+> Status: DRAFT (2026-06-20). Stacks on #173. One gate-widening + one blanking guard makes #170/#171/#172
+> live for HTML in `mcp --watch`.
+
+## 1. Watch HTML
+- [x] `HTML_EXTENSIONS = /\.html?$/i`; chokidar `change` filter admits HTML alongside `SOURCE_EXTENSIONS`.
+- [x] `handleBatch` candidate gate: allow HTML past the `detectLanguage === 'unknown'` skip.
+
+## 2. Blanking guard (regression-critical)
+- [x] `buildGraphSubset`: for `.html`/`.htm`, blank via `extractHtmlScripts` and parse as JavaScript;
+      empty result when there is no inline JS. Exported for unit testing.
+
+## 3. Free flow-through
+- [x] Text-line index (#170): HTML now reaches `updateTextLines`; stale comment updated.
+- [x] Asset edges (#172/#173): HTML reaches `updateDependencyGraph` → `parseHtmlAssetImports` → edges.
+
+## 4. Tests
+- [x] Unit: `buildGraphSubset` on HTML with inline `<script>` → inline nodes + edge anchored to the html
+      file (regression guard against node-wipe); no-inline HTML → empty.
+- [x] Watcher integration: editing an inline `<script src>` (`old.js` → `app.js`) → dependency-graph
+      asset edge repatched with `assetKind: 'script'`.
+- [x] Existing watcher unit + integration suites pass unchanged.
+
+## 5. Out of scope (documented)
+- [ ] `.vue` / `.svelte` watch.
+- [ ] `.css` watch (text-line only; refreshes on full analyze).
+- [ ] Deletions / new files in watch mode.

--- a/src/core/analyzer/dependency-graph.ts
+++ b/src/core/analyzer/dependency-graph.ts
@@ -155,6 +155,60 @@ export interface DependencyGraphOptions {
 // ============================================================================
 
 /**
+ * Compute the outgoing dependency edges for a single file from its parsed
+ * imports. The canonical edge-resolution logic, shared by the full-build
+ * `buildEdges` and the watcher's incremental `dependency-graph.json` update so
+ * the two can never drift. Pure: resolves each import against `fileSet` and
+ * returns the edges; the caller owns adjacency/state.
+ *
+ * @param fromAbs    absolute path of the importing file (edge source)
+ * @param analysis   the file's parsed imports/exports (FileAnalysis)
+ * @param fileSet    absolute paths of all files that are nodes in the graph
+ * @param rootDir    project root, used as the import-resolution base
+ * @param extensions optional resolver extension override (undefined = defaults)
+ */
+export async function computeFileImportEdges(
+  fromAbs: string,
+  analysis: FileAnalysis,
+  fileSet: Set<string>,
+  rootDir: string,
+  extensions?: string[],
+): Promise<DependencyEdge[]> {
+  const isPythonFile = fromAbs.endsWith('.py') || fromAbs.endsWith('.pyw');
+  const isJavaFile = fromAbs.endsWith('.java');
+  const edges: DependencyEdge[] = [];
+
+  for (const imp of analysis.imports) {
+    // Skip non-relative imports for JS/TS (always npm packages). Python and Java
+    // must NOT skip: `from services.retriever import X` / absolute class FQNs may
+    // resolve to a local module.
+    if (!imp.isRelative && !isPythonFile && !isJavaFile) continue;
+    // Skip builtins / third-party that can't resolve to a project file.
+    if (!imp.isRelative && imp.isBuiltin) continue;
+
+    const resolvedPath = await resolveImport(imp.source, fromAbs, {
+      baseDir: rootDir,
+      extensions,
+      sourcePackage: isJavaFile ? analysis.javaPackage : undefined,
+    });
+    if (!resolvedPath || !fileSet.has(resolvedPath)) continue;
+
+    const edge: DependencyEdge = {
+      source: fromAbs,
+      target: resolvedPath,
+      importedNames: imp.importedNames,
+      isTypeOnly: imp.isTypeOnly,
+      weight: imp.isTypeOnly ? 0.5 : 1,
+    };
+    // Carry the HTML asset label (script / stylesheet) onto the edge.
+    if (imp.assetKind) edge.assetKind = imp.assetKind;
+    edges.push(edge);
+  }
+
+  return edges;
+}
+
+/**
  * Builds and analyzes a dependency graph from scored files
  */
 export class DependencyGraphBuilder {
@@ -340,46 +394,18 @@ export class DependencyGraphBuilder {
       const analysis = analyses.get(file.absolutePath);
       if (!analysis) continue;
 
-      const isPythonFile = file.absolutePath.endsWith('.py') || file.absolutePath.endsWith('.pyw');
-      const isJavaFile = file.absolutePath.endsWith('.java');
-
-      for (const imp of analysis.imports) {
-        // Skip non-relative imports for JS/TS (those are always npm packages).
-        // For Python files we must NOT skip: `from services.retriever import X`
-        // is flagged isRelative=false but may resolve to a local module.
-        // For Java files we also must NOT skip: imports are always absolute
-        // class FQNs and we try to resolve them against the project source root.
-        if (!imp.isRelative && !isPythonFile && !isJavaFile) continue;
-        // Skip known builtins and third-party packages that can't resolve to
-        // a file inside the project (Python stdlib, JDK, Spring, etc.).
-        if (!imp.isRelative && imp.isBuiltin) continue;
-
-        // Resolve the import to an absolute path
-        const resolvedPath = await resolveImport(imp.source, file.absolutePath, {
-          baseDir: this.options.rootDir,
-          extensions: this.options.extensions.length > 0 ? this.options.extensions : undefined,
-          sourcePackage: isJavaFile ? analysis.javaPackage : undefined,
-        });
-
-        // Skip if not resolved or not in our file set
-        if (!resolvedPath || !fileSet.has(resolvedPath)) continue;
-
-        // Create edge
-        const edge: DependencyEdge = {
-          source: file.absolutePath,
-          target: resolvedPath,
-          importedNames: imp.importedNames,
-          isTypeOnly: imp.isTypeOnly,
-          weight: imp.isTypeOnly ? 0.5 : 1,
-        };
-        // Carry the HTML asset label (script / stylesheet) onto the edge.
-        if (imp.assetKind) edge.assetKind = imp.assetKind;
-
+      const edges = await computeFileImportEdges(
+        file.absolutePath,
+        analysis,
+        fileSet,
+        this.options.rootDir,
+        this.options.extensions.length > 0 ? this.options.extensions : undefined,
+      );
+      for (const edge of edges) {
         this.edges.push(edge);
-
         // Update adjacency lists
-        this.adjacencyList.get(file.absolutePath)?.add(resolvedPath);
-        this.reverseAdjacencyList.get(resolvedPath)?.add(file.absolutePath);
+        this.adjacencyList.get(file.absolutePath)?.add(edge.target);
+        this.reverseAdjacencyList.get(edge.target)?.add(file.absolutePath);
       }
     }
   }

--- a/src/core/services/dependency-graph-watch.e2e.integration.test.ts
+++ b/src/core/services/dependency-graph-watch.e2e.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E — the dependency graph stays live through the REAL loop:
+ *   runAnalysis (real producer)  →  McpWatcher edit (real chokidar + fs)
+ *   →  get_file_dependencies (real consumer handler) reflects the change.
+ *
+ * Unlike the watcher integration tests (which seed dependency-graph.json by hand
+ * and assert the JSON directly), this drives the actual analyze pipeline to
+ * produce the graph and reads it back through the MCP tool an agent would call,
+ * closing the producer→watcher→consumer loop for both a code import and an HTML
+ * asset reference.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runAnalysis } from '../../cli/commands/analyze.js';
+import { McpWatcher } from './mcp-watcher.js';
+import { handleGetFileDependencies } from './mcp-handlers/graph.js';
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+interface DepResult { imports?: Array<{ filePath: string }>; error?: string }
+const importTargets = (r: unknown): string[] =>
+  ((r as DepResult).imports ?? []).map((i) => i.filePath);
+
+describe('E2E: dependency graph stays live in watch mode', () => {
+  const watchers: McpWatcher[] = [];
+  const dirs: string[] = [];
+
+  afterEach(async () => {
+    for (const w of watchers) await w.stop();
+    watchers.length = 0;
+    for (const d of dirs) await rm(d, { recursive: true, force: true });
+    dirs.length = 0;
+  });
+
+  it('reflects a re-pointed import through analyze → watch → get_file_dependencies', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ol-depwatch-e2e-'));
+    dirs.push(root);
+    const out = join(root, '.openlore', 'analysis');
+
+    await writeFile(join(root, 'a.ts'), "import { x } from './b';\nexport const y = x;\n", 'utf-8');
+    await writeFile(join(root, 'b.ts'), 'export const x = 1;\n', 'utf-8');
+    await writeFile(join(root, 'c.ts'), 'export const x = 2;\n', 'utf-8');
+
+    // Real producer: build the actual dependency-graph.json.
+    await runAnalysis(root, out, { maxFiles: 100, include: [], exclude: [] });
+
+    // Sanity through the real consumer: a.ts imports b.ts.
+    const before = await handleGetFileDependencies(root, 'a.ts', 'imports');
+    expect(importTargets(before).some((p) => p.endsWith('b.ts'))).toBe(true);
+
+    // Real watcher: re-point the import to ./c.
+    const watcher = new McpWatcher({ rootPath: root, outputPath: out, debounceMs: 100 });
+    watchers.push(watcher);
+    await watcher.start();
+    await writeFile(join(root, 'a.ts'), "import { x } from './c';\nexport const y = x;\n", 'utf-8');
+    await wait(600);
+
+    // Consumer now reflects the edit — no re-analyze.
+    const after = await handleGetFileDependencies(root, 'a.ts', 'imports');
+    const targets = importTargets(after);
+    expect(targets.some((p) => p.endsWith('c.ts')), 'a.ts should now import c.ts').toBe(true);
+    expect(targets.some((p) => p.endsWith('b.ts')), 'a.ts should no longer import b.ts').toBe(false);
+  }, 30_000);
+
+  it('reflects an HTML <script src> re-point live', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ol-htmlwatch-e2e-'));
+    dirs.push(root);
+    const out = join(root, '.openlore', 'analysis');
+
+    await writeFile(join(root, 'index.html'), '<html><body><script src="old.js"></script></body></html>\n', 'utf-8');
+    await writeFile(join(root, 'old.js'), 'console.log(1);\n', 'utf-8');
+    await writeFile(join(root, 'app.js'), 'console.log(2);\n', 'utf-8');
+
+    await runAnalysis(root, out, { maxFiles: 100, include: [], exclude: [] });
+    const before = await handleGetFileDependencies(root, 'index.html', 'imports');
+    expect(importTargets(before).some((p) => p.endsWith('old.js'))).toBe(true);
+
+    const watcher = new McpWatcher({ rootPath: root, outputPath: out, debounceMs: 100 });
+    watchers.push(watcher);
+    await watcher.start();
+    await writeFile(join(root, 'index.html'), '<html><body><script src="app.js"></script></body></html>\n', 'utf-8');
+    await wait(600);
+
+    const after = await handleGetFileDependencies(root, 'index.html', 'imports');
+    const targets = importTargets(after);
+    expect(targets.some((p) => p.endsWith('app.js')), 'index.html should now reference app.js').toBe(true);
+    expect(targets.some((p) => p.endsWith('old.js')), 'index.html should no longer reference old.js').toBe(false);
+  }, 30_000);
+});

--- a/src/core/services/dependency-graph-watch.e2e.integration.test.ts
+++ b/src/core/services/dependency-graph-watch.e2e.integration.test.ts
@@ -64,6 +64,49 @@ describe('E2E: dependency graph stays live in watch mode', () => {
     expect(targets.some((p) => p.endsWith('b.ts')), 'a.ts should no longer import b.ts').toBe(false);
   }, 30_000);
 
+  it('reflects a file deletion through analyze → watch → get_file_dependencies', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ol-delwatch-e2e-'));
+    dirs.push(root);
+    const out = join(root, '.openlore', 'analysis');
+    await writeFile(join(root, 'a.ts'), "import { x } from './b';\nexport const y = x;\n", 'utf-8');
+    await writeFile(join(root, 'b.ts'), 'export const x = 1;\n', 'utf-8');
+    await runAnalysis(root, out, { maxFiles: 100, include: [], exclude: [] });
+
+    // Sanity: b.ts is imported-by a.ts.
+    const before = await handleGetFileDependencies(root, 'b.ts', 'importedBy') as { importedBy?: Array<{ filePath: string }> };
+    expect((before.importedBy ?? []).some((i) => i.filePath.endsWith('a.ts'))).toBe(true);
+
+    const watcher = new McpWatcher({ rootPath: root, outputPath: out, debounceMs: 100 });
+    watchers.push(watcher);
+    await watcher.start();
+    await rm(join(root, 'a.ts')); // fires unlink
+    await wait(600);
+
+    // a.ts is gone everywhere: no longer an importer of b.ts, and its own node is gone.
+    const after = await handleGetFileDependencies(root, 'b.ts', 'importedBy') as { importedBy?: Array<{ filePath: string }> };
+    expect((after.importedBy ?? []).some((i) => i.filePath.endsWith('a.ts')), 'a.ts should no longer import b.ts').toBe(false);
+    const gone = await handleGetFileDependencies(root, 'a.ts', 'imports') as { error?: string };
+    expect(gone.error, 'a.ts node should be removed from the graph').toBeDefined();
+  }, 30_000);
+
+  it('reflects a newly created file through watch → get_file_dependencies', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'ol-addwatch-e2e-'));
+    dirs.push(root);
+    const out = join(root, '.openlore', 'analysis');
+    await writeFile(join(root, 'b.ts'), 'export const x = 1;\n', 'utf-8');
+    await runAnalysis(root, out, { maxFiles: 100, include: [], exclude: [] });
+
+    const watcher = new McpWatcher({ rootPath: root, outputPath: out, debounceMs: 100 });
+    watchers.push(watcher);
+    await watcher.start();
+    // Create a brand-new file importing the existing one.
+    await writeFile(join(root, 'a.ts'), "import { x } from './b';\nexport const y = x;\n", 'utf-8');
+    await wait(600);
+
+    const r = await handleGetFileDependencies(root, 'a.ts', 'imports');
+    expect(importTargets(r).some((p) => p.endsWith('b.ts')), 'new a.ts should import b.ts').toBe(true);
+  }, 30_000);
+
   it('reflects an HTML <script src> re-point live', async () => {
     const root = await mkdtemp(join(tmpdir(), 'ol-htmlwatch-e2e-'));
     dirs.push(root);

--- a/src/core/services/mcp-watcher-html.test.ts
+++ b/src/core/services/mcp-watcher-html.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Watcher HTML handling — buildGraphSubset blanks inline <script> JS so a watch
+ * edit refreshes a page's inline-script call-graph nodes instead of wiping them.
+ *
+ * This is the regression guard for letting HTML into the call-graph loop: if
+ * buildGraphSubset returned empty for .html, the watcher's atomic swap
+ * (deleteNodesForFile + insert) would DELETE the inline-script nodes a full
+ * analyze produced. A non-empty result means the swap re-inserts them.
+ */
+import { describe, it, expect } from 'vitest';
+import { buildGraphSubset } from './mcp-watcher.js';
+
+describe('buildGraphSubset — inline <script> JS', () => {
+  it('produces inline-script nodes + edges anchored to the HTML file', async () => {
+    const html = [
+      '<!DOCTYPE html>',         // 1
+      '<html><body>',           // 2
+      '<script>',               // 3
+      '  function greet() {',   // 4
+      '    render();',          // 5
+      '  }',                    // 6
+      '  function render() {}', // 7
+      '</script>',              // 8
+      '</body></html>',         // 9
+    ].join('\n');
+
+    const { nodes, edges } = await buildGraphSubset('index.html', html, [], '/tmp');
+    const greet = nodes.find((n) => n.name === 'greet');
+    const render = nodes.find((n) => n.name === 'render');
+    expect(greet, 'inline greet should be a node').toBeDefined();
+    expect(render).toBeDefined();
+    expect(greet!.filePath).toBe('index.html');
+    expect(greet!.startLine).toBe(4);
+    expect(edges.some((e) => e.callerId === greet!.id && e.calleeId === render!.id)).toBe(true);
+  });
+
+  it('returns empty for an HTML file with no inline JS (no spurious node churn)', async () => {
+    const { nodes, edges } = await buildGraphSubset('static.html', '<html><body><p>hi</p></body></html>', [], '/tmp');
+    expect(nodes).toEqual([]);
+    expect(edges).toEqual([]);
+  });
+});

--- a/src/core/services/mcp-watcher.integration.test.ts
+++ b/src/core/services/mcp-watcher.integration.test.ts
@@ -128,6 +128,108 @@ describe('McpWatcher — real fs watcher', () => {
     expect(after2.signatures?.filter(s => s.path === 'service.ts')).toHaveLength(1);
   }, 15_000);
 
+  it('keeps dependency-graph.json import edges live when an import changes', async () => {
+    const { rootPath, outputPath } = await setupProject();
+
+    // a.ts imports ./b initially; b.ts and c.ts are resolvable targets.
+    const aFile = join(rootPath, 'a.ts');
+    const absA = aFile, absB = join(rootPath, 'b.ts'), absC = join(rootPath, 'c.ts');
+    await writeFile(aFile, "import { x } from './b';\nexport const y = x;\n", 'utf-8');
+    await writeFile(absB, 'export const x = 1;\n', 'utf-8');
+    await writeFile(absC, 'export const x = 2;\n', 'utf-8');
+
+    // Seed dependency-graph.json with the a → b edge (as a full analyze would).
+    const graphPath = join(outputPath, 'dependency-graph.json');
+    await writeFile(graphPath, JSON.stringify({
+      nodes: [
+        { id: absA, metrics: { inDegree: 0, outDegree: 1 } },
+        { id: absB, metrics: { inDegree: 1, outDegree: 0 } },
+        { id: absC, metrics: { inDegree: 0, outDegree: 0 } },
+      ],
+      edges: [{ source: absA, target: absB, importedNames: ['x'], isTypeOnly: false, weight: 1 }],
+    }), 'utf-8');
+
+    const watcher = new McpWatcher({ rootPath, outputPath, debounceMs: DEBOUNCE_MS });
+    watchers.push(watcher);
+    await watcher.start();
+
+    // Re-point the import from ./b to ./c.
+    await writeFile(aFile, "import { x } from './c';\nexport const y = x;\n", 'utf-8');
+    await wait(WAIT_MS);
+
+    const g = JSON.parse(await readFile(graphPath, 'utf-8')) as {
+      nodes: Array<{ id: string; metrics: { inDegree: number; outDegree: number } }>;
+      edges: Array<{ source: string; target: string }>;
+    };
+    // Old edge gone, new edge present.
+    expect(g.edges.some(e => e.source === absA && e.target === absB)).toBe(false);
+    expect(g.edges.some(e => e.source === absA && e.target === absC)).toBe(true);
+    // Degrees recomputed: c now consumed, b no longer.
+    expect(g.nodes.find(n => n.id === absC)!.metrics.inDegree).toBe(1);
+    expect(g.nodes.find(n => n.id === absB)!.metrics.inDegree).toBe(0);
+    expect(g.nodes.find(n => n.id === absA)!.metrics.outDegree).toBe(1);
+  }, 15_000);
+
+  it('preserves call-synthesized edges and drops all import edges when imports are removed', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    const aFile = join(rootPath, 'a.ts');
+    const absA = aFile, absB = join(rootPath, 'b.ts');
+    await writeFile(aFile, "import { x } from './b';\nexport const y = x;\n", 'utf-8');
+    await writeFile(absB, 'export const x = 1;\n', 'utf-8');
+
+    const graphPath = join(outputPath, 'dependency-graph.json');
+    await writeFile(graphPath, JSON.stringify({
+      nodes: [
+        { id: absA, metrics: { inDegree: 0, outDegree: 1 } },
+        { id: absB, metrics: { inDegree: 1, outDegree: 0 } },
+      ],
+      edges: [
+        { source: absA, target: absB, importedNames: ['x'], isTypeOnly: false, weight: 1 },
+        // A call-synthesized edge from the same source — must survive the patch.
+        { source: absA, target: absB, importedNames: [], isTypeOnly: false, weight: 1, isCallEdge: true },
+      ],
+    }), 'utf-8');
+
+    const watcher = new McpWatcher({ rootPath, outputPath, debounceMs: DEBOUNCE_MS });
+    watchers.push(watcher);
+    await watcher.start();
+
+    // Remove the import entirely.
+    await writeFile(aFile, 'export const y = 42;\n', 'utf-8');
+    await wait(WAIT_MS);
+
+    const g = JSON.parse(await readFile(graphPath, 'utf-8')) as {
+      nodes: Array<{ id: string; metrics: { outDegree: number } }>;
+      edges: Array<{ source: string; target: string; isCallEdge?: boolean }>;
+    };
+    // The import edge is gone…
+    expect(g.edges.some(e => e.source === absA && e.target === absB && !e.isCallEdge)).toBe(false);
+    // …but the call-synthesized edge survives (watcher doesn't rebuild those).
+    expect(g.edges.some(e => e.source === absA && e.isCallEdge === true)).toBe(true);
+  }, 15_000);
+
+  it('leaves the dependency graph untouched when a non-node file changes', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    const aFile = join(rootPath, 'a.ts');
+    await writeFile(aFile, 'export const y = 1;\n', 'utf-8');
+
+    const graphPath = join(outputPath, 'dependency-graph.json');
+    // a.ts is deliberately NOT a node in the graph.
+    const original = JSON.stringify({
+      nodes: [{ id: join(rootPath, 'other.ts'), metrics: { inDegree: 0, outDegree: 0 } }],
+      edges: [],
+    });
+    await writeFile(graphPath, original, 'utf-8');
+
+    const watcher = new McpWatcher({ rootPath, outputPath, debounceMs: DEBOUNCE_MS });
+    watchers.push(watcher);
+    await watcher.start();
+    await writeFile(aFile, 'export const y = 2;\n', 'utf-8');
+    await wait(WAIT_MS);
+
+    expect(await readFile(graphPath, 'utf-8')).toBe(original); // byte-identical no-op
+  }, 15_000);
+
   it('G1: a real save primes the read cache — the next tool-call read is a HIT, not a cold re-parse', async () => {
     // The root-cause #2 fix (Spec 13.1): the watcher's write used to bump
     // llm-context.json's mtime and force the NEXT MCP tool call to re-parse the

--- a/src/core/services/mcp-watcher.integration.test.ts
+++ b/src/core/services/mcp-watcher.integration.test.ts
@@ -208,6 +208,41 @@ describe('McpWatcher — real fs watcher', () => {
     expect(g.edges.some(e => e.source === absA && e.isCallEdge === true)).toBe(true);
   }, 15_000);
 
+  it('keeps HTML asset edges live when an inline <script src> changes', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    const htmlFile = join(rootPath, 'index.html');
+    const absHtml = htmlFile, absOld = join(rootPath, 'old.js'), absApp = join(rootPath, 'app.js');
+    await writeFile(htmlFile, '<html><body><script src="old.js"></script></body></html>\n', 'utf-8');
+    await writeFile(absOld, 'console.log(1);\n', 'utf-8');
+    await writeFile(absApp, 'console.log(2);\n', 'utf-8');
+
+    const graphPath = join(outputPath, 'dependency-graph.json');
+    await writeFile(graphPath, JSON.stringify({
+      nodes: [
+        { id: absHtml, metrics: { inDegree: 0, outDegree: 1 } },
+        { id: absOld, metrics: { inDegree: 1, outDegree: 0 } },
+        { id: absApp, metrics: { inDegree: 0, outDegree: 0 } },
+      ],
+      edges: [{ source: absHtml, target: absOld, importedNames: [], isTypeOnly: false, weight: 1, assetKind: 'script' }],
+    }), 'utf-8');
+
+    const watcher = new McpWatcher({ rootPath, outputPath, debounceMs: DEBOUNCE_MS });
+    watchers.push(watcher);
+    await watcher.start();
+
+    // Re-point the script from old.js to app.js.
+    await writeFile(htmlFile, '<html><body><script src="app.js"></script></body></html>\n', 'utf-8');
+    await wait(WAIT_MS);
+
+    const g = JSON.parse(await readFile(graphPath, 'utf-8')) as {
+      edges: Array<{ source: string; target: string; assetKind?: string }>;
+    };
+    expect(g.edges.some(e => e.source === absHtml && e.target === absOld)).toBe(false);
+    const appEdge = g.edges.find(e => e.source === absHtml && e.target === absApp);
+    expect(appEdge, 'index.html → app.js asset edge').toBeDefined();
+    expect(appEdge!.assetKind).toBe('script');
+  }, 15_000);
+
   it('leaves the dependency graph untouched when a non-node file changes', async () => {
     const { rootPath, outputPath } = await setupProject();
     const aFile = join(rootPath, 'a.ts');

--- a/src/core/services/mcp-watcher.integration.test.ts
+++ b/src/core/services/mcp-watcher.integration.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { mkdtemp, writeFile, readFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, writeFile, readFile, mkdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { LLMContext } from '../analyzer/artifact-generator.js';
@@ -243,27 +243,101 @@ describe('McpWatcher — real fs watcher', () => {
     expect(appEdge!.assetKind).toBe('script');
   }, 15_000);
 
-  it('leaves the dependency graph untouched when a non-node file changes', async () => {
+  it('adds a node for a file not yet in the graph (new file / first edit after analyze)', async () => {
     const { rootPath, outputPath } = await setupProject();
     const aFile = join(rootPath, 'a.ts');
-    await writeFile(aFile, 'export const y = 1;\n', 'utf-8');
+    const absA = aFile, absOther = join(rootPath, 'other.ts');
+    await writeFile(aFile, "import { z } from './other';\nexport const y = z;\n", 'utf-8');
+    await writeFile(absOther, 'export const z = 1;\n', 'utf-8');
 
     const graphPath = join(outputPath, 'dependency-graph.json');
-    // a.ts is deliberately NOT a node in the graph.
-    const original = JSON.stringify({
-      nodes: [{ id: join(rootPath, 'other.ts'), metrics: { inDegree: 0, outDegree: 0 } }],
+    // a.ts is NOT yet a node; other.ts is.
+    await writeFile(graphPath, JSON.stringify({
+      nodes: [{ id: absOther, file: { path: 'other.ts', absolutePath: absOther }, metrics: { inDegree: 0, outDegree: 0 } }],
       edges: [],
-    });
-    await writeFile(graphPath, original, 'utf-8');
+    }), 'utf-8');
 
     const watcher = new McpWatcher({ rootPath, outputPath, debounceMs: DEBOUNCE_MS });
     watchers.push(watcher);
     await watcher.start();
-    await writeFile(aFile, 'export const y = 2;\n', 'utf-8');
+    await writeFile(aFile, "import { z } from './other';\nexport const y = z + 1;\n", 'utf-8');
     await wait(WAIT_MS);
 
-    expect(await readFile(graphPath, 'utf-8')).toBe(original); // byte-identical no-op
+    const g = JSON.parse(await readFile(graphPath, 'utf-8')) as {
+      nodes: Array<{ id: string }>;
+      edges: Array<{ source: string; target: string }>;
+    };
+    // a.ts is now a node, with its outgoing edge to other.ts.
+    expect(g.nodes.some(n => n.id === absA)).toBe(true);
+    expect(g.edges.some(e => e.source === absA && e.target === absOther)).toBe(true);
   }, 15_000);
+
+  it('removes a deleted file node and its edges from the dependency graph', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    const absA = join(rootPath, 'a.ts'), absB = join(rootPath, 'b.ts');
+    await writeFile(absA, "import { x } from './b';\nexport const y = x;\n", 'utf-8');
+    await writeFile(absB, 'export const x = 1;\n', 'utf-8');
+
+    const graphPath = join(outputPath, 'dependency-graph.json');
+    await writeFile(graphPath, JSON.stringify({
+      nodes: [
+        { id: absA, file: { path: 'a.ts', absolutePath: absA }, metrics: { inDegree: 0, outDegree: 1 } },
+        { id: absB, file: { path: 'b.ts', absolutePath: absB }, metrics: { inDegree: 1, outDegree: 0 } },
+      ],
+      edges: [{ source: absA, target: absB, importedNames: ['x'], isTypeOnly: false, weight: 1 }],
+    }), 'utf-8');
+
+    const watcher = new McpWatcher({ rootPath, outputPath, debounceMs: DEBOUNCE_MS });
+    watchers.push(watcher);
+    await watcher.start();
+
+    // Delete b.ts — fires chokidar 'unlink'.
+    await rm(absB);
+    await wait(WAIT_MS);
+
+    const g = JSON.parse(await readFile(graphPath, 'utf-8')) as {
+      nodes: Array<{ id: string }>;
+      edges: Array<{ source: string; target: string }>;
+    };
+    expect(g.nodes.some(n => n.id === absB), 'b.ts node should be gone').toBe(false);
+    expect(g.edges.some(e => e.target === absB), 'edges to b.ts should be gone').toBe(false);
+    expect(g.nodes.some(n => n.id === absA), 'a.ts node should remain').toBe(true);
+  }, 15_000);
+
+  it('supersession: delete-then-recreate ends indexed; recreate-then-delete ends removed', async () => {
+    const { rootPath, outputPath } = await setupProject();
+    const absA = join(rootPath, 'a.ts'), absB = join(rootPath, 'b.ts');
+    await writeFile(absA, "import { x } from './b';\nexport const y = x;\n", 'utf-8');
+    await writeFile(absB, 'export const x = 1;\n', 'utf-8');
+    const graphPath = join(outputPath, 'dependency-graph.json');
+    const seed = () => writeFile(graphPath, JSON.stringify({
+      nodes: [
+        { id: absA, file: { path: 'a.ts', absolutePath: absA }, metrics: { inDegree: 0, outDegree: 1 } },
+        { id: absB, file: { path: 'b.ts', absolutePath: absB }, metrics: { inDegree: 1, outDegree: 0 } },
+      ],
+      edges: [{ source: absA, target: absB, importedNames: ['x'], isTypeOnly: false, weight: 1 }],
+    }), 'utf-8');
+    const nodes = async () => (JSON.parse(await readFile(graphPath, 'utf-8')) as { nodes: Array<{ id: string }> }).nodes;
+
+    await seed();
+    const watcher = new McpWatcher({ rootPath, outputPath, debounceMs: DEBOUNCE_MS });
+    watchers.push(watcher);
+    await watcher.start();
+
+    // delete → recreate (in event order) ends with a.ts present.
+    await rm(absA);
+    await writeFile(absA, "import { x } from './b';\nexport const y = x + 1;\n", 'utf-8');
+    await wait(WAIT_MS);
+    expect((await nodes()).some(n => n.id === absA), 'delete→recreate ⇒ present').toBe(true);
+
+    // recreate (change) → delete ends with a.ts removed (deletion wins — the
+    // supersession guard prevents a re-add after the delete in one flush).
+    await seed();
+    await writeFile(absA, "import { x } from './b';\nexport const y = x + 2;\n", 'utf-8');
+    await rm(absA);
+    await wait(WAIT_MS);
+    expect((await nodes()).some(n => n.id === absA), 'recreate→delete ⇒ removed').toBe(false);
+  }, 20_000);
 
   it('G1: a real save primes the read cache — the next tool-call read is a HIT, not a cold re-parse', async () => {
     // The root-cause #2 fix (Spec 13.1): the watcher's write used to bump

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -24,7 +24,7 @@
  *     OPENLORE_WATCH_DEBUG).
  */
 
-import { readFile, writeFile, readdir } from 'node:fs/promises';
+import { readFile, writeFile, readdir, rename } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { join, relative } from 'node:path';
 import { spawn } from 'node:child_process';
@@ -38,6 +38,7 @@ import {
   OPENLORE_DIR,
   OPENLORE_ANALYSIS_SUBDIR,
   ARTIFACT_LLM_CONTEXT,
+  ARTIFACT_DEPENDENCY_GRAPH,
   WATCH_DEBOUNCE_MS,
   WATCH_MAX_BATCH_MS,
   WATCH_BULK_THRESHOLD,
@@ -471,6 +472,13 @@ export class McpWatcher {
     //      files). This keeps code-file literals (e.g. JSX strings) current.
     await this.updateTextLines(changedFiles);
 
+    // 3.6. Dependency graph — keep dependency-graph.json's file→file import edges
+    //      live (get_file_dependencies reads that static artifact). Incremental,
+    //      O(change): re-resolve the changed files' imports and splice their
+    //      edges, recompute in/out-degree. Global metrics (pageRank, clusters,
+    //      betweenness) are O(graph) and left to the next full `analyze`.
+    await this.updateDependencyGraph(changedFiles);
+
     // 4. Vector update — decoupled from signature freshness (Step 4).
     const isBulk = consumedVcsBulk || changedFiles.length >= this.bulkThreshold;
     if (this.embed && !this.embedDegraded && context.callGraph) {
@@ -677,6 +685,93 @@ export class McpWatcher {
       }
     } catch (err) {
       process.stderr.write(`[mcp-watcher] text-line error: ${(err as Error).message}\n`);
+    }
+  }
+
+  /**
+   * Incrementally patch dependency-graph.json's file→file import edges for the
+   * changed files. `get_file_dependencies` reads that static artifact, so without
+   * this an import edit goes stale until a full `analyze`. O(change): re-resolve
+   * each changed file's imports (reusing the builder's `computeFileImportEdges`,
+   * so resolution can't drift), replace that file's import edges, and recompute
+   * in/out-degree. HTTP- and call-graph-synthesized edges are preserved (the
+   * watcher does not rebuild them). Global metrics (pageRank, betweenness,
+   * clusters) are O(graph) and deliberately left to the next full `analyze`.
+   * No-op when no dependency graph exists. Never throws into the batch loop.
+   */
+  private async updateDependencyGraph(changedFiles: ChangedFile[]): Promise<void> {
+    const graphPath = join(this.outputPath, ARTIFACT_DEPENDENCY_GRAPH);
+    try {
+      let raw: string;
+      try {
+        raw = await readFile(graphPath, 'utf-8');
+      } catch {
+        return; // no dependency graph yet — nothing to keep fresh
+      }
+      // Narrow view for the fields we touch. We MUTATE the parsed object in place
+      // and re-serialize it, so untyped node fields not modeled here (file,
+      // exports, cluster, metrics.pageRank/betweenness) survive the round-trip.
+      const graph = JSON.parse(raw) as {
+        nodes: Array<{ id: string; metrics?: Record<string, number> }>;
+        edges: Array<{ source: string; target: string; httpEdge?: unknown; isCallEdge?: boolean }>;
+      };
+      if (!Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) return;
+
+      const { ImportExportParser } = await import('../analyzer/import-parser.js');
+      const { computeFileImportEdges } = await import('../analyzer/dependency-graph.js');
+      const fileSet = new Set(graph.nodes.map((n) => n.id)); // absolute paths
+      const parser = new ImportExportParser();
+      let changed = false;
+
+      for (const f of changedFiles) {
+        const abs = join(this.rootPath, f.rel);
+        if (!fileSet.has(abs)) continue; // new file — a full analyze adds the node
+        let analysis;
+        try {
+          analysis = await parser.parseFile(abs);
+        } catch {
+          continue;
+        }
+        const newEdges = await computeFileImportEdges(abs, analysis, fileSet, this.rootPath);
+        // Drop this file's previous IMPORT edges (keep HTTP / call-synthesized
+        // edges, which the watcher does not rebuild), then splice in the fresh set.
+        graph.edges = graph.edges.filter(
+          (e) => e.source !== abs || e.httpEdge !== undefined || e.isCallEdge === true,
+        );
+        graph.edges.push(...(newEdges as typeof graph.edges));
+        changed = true;
+      }
+      if (!changed) return;
+
+      // Recompute file-level in/out degree from the patched edge set (cheap).
+      const out = new Map<string, Set<string>>();
+      const inn = new Map<string, Set<string>>();
+      for (const n of graph.nodes) {
+        out.set(n.id, new Set());
+        inn.set(n.id, new Set());
+      }
+      for (const e of graph.edges) {
+        out.get(e.source)?.add(e.target);
+        inn.get(e.target)?.add(e.source);
+      }
+      for (const n of graph.nodes) {
+        if (!n.metrics) n.metrics = {};
+        n.metrics.outDegree = out.get(n.id)?.size ?? 0;
+        n.metrics.inDegree = inn.get(n.id)?.size ?? 0;
+      }
+
+      // Atomic write (tmp + rename) so a concurrent MCP read never sees a torn
+      // JSON — matching the watcher's "readers never see a torn graph" invariant.
+      const tmp = `${graphPath}.${process.pid}.tmp`;
+      await writeFile(tmp, JSON.stringify(graph));
+      await rename(tmp, graphPath);
+      if (this.debug) {
+        process.stderr.write(
+          `[mcp-watcher] dependency graph: patched import edges for ${changedFiles.length} file(s)\n`,
+        );
+      }
+    } catch (err) {
+      process.stderr.write(`[mcp-watcher] dependency-graph error: ${(err as Error).message}\n`);
     }
   }
 

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -103,6 +103,13 @@ interface ChangedFile {
 }
 
 const SOURCE_EXTENSIONS = /\.(ts|tsx|js|jsx|py|go|rs|rb|java|kt|php|cs|cpp|cc|cxx|h|hpp|c|swift)$/;
+// HTML is watched too. detectLanguage() returns 'unknown' for it, so it takes a
+// dedicated path: an edit refreshes the literal-text line index, the inline-
+// <script> call-graph nodes (blanked → JavaScript in buildGraphSubset), and the
+// dependency-graph asset edges (<script src>/<link rel=stylesheet>). Letting HTML
+// into the call-graph loop REQUIRES the buildGraphSubset blanking — otherwise the
+// atomic swap would delete a page's inline-script nodes on every edit.
+const HTML_EXTENSIONS = /\.html?$/i;
 
 // Directory NAMES that must never be watched. Build-output and dependency
 // directories can hold hundreds of thousands of files (a Rust `target/` is
@@ -242,7 +249,7 @@ export class McpWatcher {
       });
 
       this.fsWatcher.on('change', (absPath: string) => {
-        if (SOURCE_EXTENSIONS.test(absPath)) {
+        if (SOURCE_EXTENSIONS.test(absPath) || HTML_EXTENSIONS.test(absPath)) {
           this.enqueue(absPath);
         }
       });
@@ -368,7 +375,9 @@ export class McpWatcher {
     for (const abs of absPaths) {
       const rel = relative(this.rootPath, abs);
       if (isTestFile(rel)) continue;
-      if (detectLanguage(rel) === 'unknown') continue;
+      // HTML is 'unknown' to detectLanguage but takes the dedicated HTML path
+      // (text-line + inline-script call graph + dependency asset edges).
+      if (detectLanguage(rel) === 'unknown' && !HTML_EXTENSIONS.test(rel)) continue;
       let content: string;
       try {
         content = await readFile(abs, 'utf-8');
@@ -461,15 +470,12 @@ export class McpWatcher {
     }
     await this.persistContext(context);
 
-    // 3.5. Literal-text line index — keep it fresh for the changed files. Runs
-    //      regardless of the embed setting (the text index is BM25-only).
-    //      Scope (consistent with the symbol index in watch mode): the watcher
-    //      reacts only to 'change' events on SOURCE_EXTENSIONS files — there is
-    //      no 'unlink' handler — so neither markup/stylesheet edits nor file
-    //      DELETIONS are live-reconciled here. A deleted file's lines linger
-    //      until the next full `analyze`, which overwrites the table completely
-    //      (the same staleness the symbol index already carries for deleted
-    //      files). This keeps code-file literals (e.g. JSX strings) current.
+    // 3.5. Literal-text line index — keep it fresh for the changed files
+    //      (source + HTML). Runs regardless of the embed setting (BM25-only).
+    //      Note: there is no 'unlink' handler, so file DELETIONS are not
+    //      live-reconciled — a deleted file's lines linger until the next full
+    //      `analyze` overwrites the table (the same staleness every other watcher
+    //      lane carries for deletions).
     await this.updateTextLines(changedFiles);
 
     // 3.6. Dependency graph — keep dependency-graph.json's file→file import edges
@@ -814,8 +820,10 @@ export class McpWatcher {
  * Re-parse changedFile + up to CALLER_REPARSE_LIMIT callerFiles.
  * Returns fresh edges (all files in subset) and nodes (changedFile only —
  * callerFiles nodes are untouched since their function signatures didn't change).
+ *
+ * Exported for unit testing (locks the HTML-blanking node-refresh contract).
  */
-async function buildGraphSubset(
+export async function buildGraphSubset(
   changedRel: string,
   changedContent: string,
   callerFiles: string[],
@@ -826,13 +834,25 @@ async function buildGraphSubset(
   nodes: import('../analyzer/call-graph.js').FunctionNode[];
   cfgs: Array<{ functionId: string; filePath: string; cfg: import('../analyzer/cfg.js').FunctionCfg }>;
 }> {
-  const lang = detectLanguage(changedRel);
+  let lang = detectLanguage(changedRel);
+  let content = changedContent;
+  // HTML: blank everything outside inline <script> bodies (offset-preserving) so
+  // the JS extractor parses the inline scripts at their true positions. Without
+  // this, html is 'unknown' → empty result → the caller's atomic swap would
+  // DELETE the page's inline-script nodes on every edit (regression).
+  if (lang === 'unknown' && HTML_EXTENSIONS.test(changedRel)) {
+    const { extractHtmlScripts } = await import('../analyzer/html-script-extractor.js');
+    const blanked = extractHtmlScripts(changedContent);
+    if (!blanked) return { edges: [], nodes: [], cfgs: [] }; // no inline JS
+    content = blanked;
+    lang = 'JavaScript';
+  }
   if (!CALL_GRAPH_LANGS.has(lang)) return { edges: [], nodes: [], cfgs: [] };
 
   const { CallGraphBuilder } = await import('../analyzer/call-graph.js');
   // Use relative paths as node IDs (consistent with analyze output)
   const files: Array<{ path: string; content: string; language: string }> = [
-    { path: changedRel, content: changedContent, language: lang },
+    { path: changedRel, content, language: lang },
   ];
 
   for (const cf of callerFiles.slice(0, CALLER_REPARSE_LIMIT)) {

--- a/src/core/services/mcp-watcher.ts
+++ b/src/core/services/mcp-watcher.ts
@@ -185,6 +185,7 @@ export class McpWatcher {
 
   // ── Coalescing queue (Step 1) ──────────────────────────────────────────────
   private pending = new Set<string>();              // absolute paths awaiting a flush
+  private pendingDeletions = new Set<string>();     // absolute paths of unlinked files
   private debounceTimer?: ReturnType<typeof setTimeout>;
   private maxBatchTimer?: ReturnType<typeof setTimeout>;
   private running = false;                           // single-flight for the signature flush
@@ -248,10 +249,21 @@ export class McpWatcher {
         awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 50 },
       });
 
+      const watched = (p: string): boolean => SOURCE_EXTENSIONS.test(p) || HTML_EXTENSIONS.test(p);
       this.fsWatcher.on('change', (absPath: string) => {
-        if (SOURCE_EXTENSIONS.test(absPath) || HTML_EXTENSIONS.test(absPath)) {
-          this.enqueue(absPath);
-        }
+        if (watched(absPath)) this.enqueue(absPath);
+      });
+      // A new file is indexed via the same change pipeline (insert is a no-op
+      // delete + add). ignoreInitial:true means only files created AFTER start
+      // fire 'add', so the initial scan never storms this.
+      this.fsWatcher.on('add', (absPath: string) => {
+        if (watched(absPath)) this.enqueue(absPath);
+      });
+      // A deleted file must be removed from every lane (call graph, signatures,
+      // text-line index, vector index, dependency graph) — otherwise its symbols/
+      // edges/lines linger as phantom results until the next full analyze.
+      this.fsWatcher.on('unlink', (absPath: string) => {
+        if (watched(absPath)) this.enqueueDeletion(absPath);
       });
 
       this.fsWatcher.on('ready', () => resolve());
@@ -286,12 +298,19 @@ export class McpWatcher {
     if (this.maxBatchTimer) clearTimeout(this.maxBatchTimer);
     if (this.embedTimer) clearTimeout(this.embedTimer);
     this.debounceTimer = this.maxBatchTimer = this.embedTimer = undefined;
-    // Best-effort: persist anything still queued so a save right before shutdown
-    // is not lost.
-    if (this.pending.size > 0 && !this.running) {
-      const batch = Array.from(this.pending);
-      this.pending.clear();
-      try { await this.handleBatch(batch, { syncFlush: true }); } catch { /* ignore */ }
+    // Best-effort: drain anything still queued so a save/delete right before
+    // shutdown is not lost. Deletions first, then changes (same order as flush).
+    if (!this.running) {
+      if (this.pendingDeletions.size > 0) {
+        const dels = Array.from(this.pendingDeletions);
+        this.pendingDeletions.clear();
+        try { await this.handleDeletions(dels); } catch { /* ignore */ }
+      }
+      if (this.pending.size > 0) {
+        const batch = Array.from(this.pending);
+        this.pending.clear();
+        try { await this.handleBatch(batch, { syncFlush: true }); } catch { /* ignore */ }
+      }
     }
     await this.fsWatcher?.close();
     await this.gitWatcher?.close();
@@ -306,6 +325,20 @@ export class McpWatcher {
    */
   private enqueue(absPath: string): void {
     this.pending.add(absPath);
+    // A re-create supersedes a pending delete for the same path.
+    this.pendingDeletions.delete(absPath);
+    this.armFlush();
+  }
+
+  /** Queue a file deletion for the next flush (reuses the same debounce). */
+  private enqueueDeletion(absPath: string): void {
+    this.pendingDeletions.add(absPath);
+    // A delete supersedes a pending change for the same path.
+    this.pending.delete(absPath);
+    this.armFlush();
+  }
+
+  private armFlush(): void {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.debounceTimer = setTimeout(() => this.flush(), this.debounceMs);
     if (!this.maxBatchTimer) {
@@ -332,16 +365,22 @@ export class McpWatcher {
     if (this.debounceTimer) { clearTimeout(this.debounceTimer); this.debounceTimer = undefined; }
     if (this.maxBatchTimer) { clearTimeout(this.maxBatchTimer); this.maxBatchTimer = undefined; }
     if (this.running) return;            // a follow-up is scheduled in finally{}
-    if (this.pending.size === 0) return;
+    if (this.pending.size === 0 && this.pendingDeletions.size === 0) return;
 
     const batch = Array.from(this.pending);
+    const deletions = Array.from(this.pendingDeletions);
     this.pending.clear();
+    this.pendingDeletions.clear();
     this.running = true;
-    this.handleBatch(batch)
+    // Deletions first (remove stale state), then re-index the changed/added files.
+    (async () => {
+      if (deletions.length > 0) await this.handleDeletions(deletions);
+      if (batch.length > 0) await this.handleBatch(batch);
+    })()
       .catch((err) => process.stderr.write(`[mcp-watcher] error: ${(err as Error).message}\n`))
       .finally(() => {
         this.running = false;
-        if (this.pending.size > 0) {
+        if (this.pending.size > 0 || this.pendingDeletions.size > 0) {
           this.debounceTimer = setTimeout(() => this.flush(), this.debounceMs);
         }
       });
@@ -472,10 +511,8 @@ export class McpWatcher {
 
     // 3.5. Literal-text line index — keep it fresh for the changed files
     //      (source + HTML). Runs regardless of the embed setting (BM25-only).
-    //      Note: there is no 'unlink' handler, so file DELETIONS are not
-    //      live-reconciled — a deleted file's lines linger until the next full
-    //      `analyze` overwrites the table (the same staleness every other watcher
-    //      lane carries for deletions).
+    //      File deletions are handled separately by handleDeletions (the 'unlink'
+    //      lane), which drops the removed file's lines from this index.
     await this.updateTextLines(changedFiles);
 
     // 3.6. Dependency graph — keep dependency-graph.json's file→file import edges
@@ -718,7 +755,7 @@ export class McpWatcher {
       // and re-serialize it, so untyped node fields not modeled here (file,
       // exports, cluster, metrics.pageRank/betweenness) survive the round-trip.
       const graph = JSON.parse(raw) as {
-        nodes: Array<{ id: string; metrics?: Record<string, number> }>;
+        nodes: Array<{ id: string; file?: { path: string; absolutePath: string }; exports?: unknown[]; metrics?: Record<string, number> }>;
         edges: Array<{ source: string; target: string; httpEdge?: unknown; isCallEdge?: boolean }>;
       };
       if (!Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) return;
@@ -731,12 +768,19 @@ export class McpWatcher {
 
       for (const f of changedFiles) {
         const abs = join(this.rootPath, f.rel);
-        if (!fileSet.has(abs)) continue; // new file — a full analyze adds the node
         let analysis;
         try {
           analysis = await parser.parseFile(abs);
         } catch {
           continue;
+        }
+        if (!fileSet.has(abs)) {
+          // New file (watch 'add'): create a node so its OUTGOING imports are
+          // tracked. Added AFTER a successful parse so a parse failure can't leave
+          // a bogus edgeless node. Incoming edges (importers of this file) refresh
+          // when those importers are next touched, or on the next full analyze.
+          graph.nodes.push({ id: abs, file: { path: f.rel, absolutePath: abs }, exports: [], metrics: { inDegree: 0, outDegree: 0 } });
+          fileSet.add(abs);
         }
         const newEdges = await computeFileImportEdges(abs, analysis, fileSet, this.rootPath);
         // Drop this file's previous IMPORT edges (keep HTTP / call-synthesized
@@ -778,6 +822,125 @@ export class McpWatcher {
       }
     } catch (err) {
       process.stderr.write(`[mcp-watcher] dependency-graph error: ${(err as Error).message}\n`);
+    }
+  }
+
+  /**
+   * Reconcile file DELETIONS across every lane so a removed file leaves no
+   * phantom state: call-graph nodes/edges (incoming and outgoing), signatures,
+   * text-line rows, vector rows, and dependency-graph node + edges. Best-effort;
+   * a failure in one lane does not block the others.
+   */
+  private async handleDeletions(absPaths: string[]): Promise<void> {
+    // Deletion is idempotent removal, so no need to filter — each lane no-ops for
+    // a path it never indexed. (Watch-ignored paths like *.test.ts never reach
+    // here anyway: chokidar prunes them, so no unlink fires.)
+    const rels = absPaths.map((abs) => relative(this.rootPath, abs));
+    if (rels.length === 0) return;
+
+    // 1. Call-graph store — deleteEdgesForFile removes edges where the file is
+    //    caller OR callee, so incoming edges don't dangle.
+    if (EdgeStore.exists(this.outputPath)) {
+      const store = EdgeStore.open(EdgeStore.dbPath(this.outputPath));
+      try {
+        store.transaction(() => {
+          for (const rel of rels) {
+            store.deleteEdgesForFile(rel);
+            store.deleteNodesForFile(rel);
+            store.deleteCfgForFile(rel);
+            store.deleteClassesForFile(rel);
+          }
+        });
+      } catch (err) {
+        process.stderr.write(`[mcp-watcher] delete (graph) error: ${(err as Error).message}\n`);
+      } finally {
+        store.close();
+      }
+    }
+
+    // 2. Signatures in llm-context.json.
+    const context = await this.loadContext();
+    if (context?.signatures) {
+      const relSet = new Set(rels);
+      const kept = context.signatures.filter((m) => !relSet.has(m.path));
+      if (kept.length !== context.signatures.length) {
+        context.signatures = kept;
+        await this.persistContext(context);
+      }
+    }
+
+    // 3. Text-line index — drop the deleted files' lines.
+    try {
+      const { TextLineIndex } = await import('../analyzer/text-line-index.js');
+      if (TextLineIndex.exists(this.outputPath)) {
+        await TextLineIndex.updateFiles(this.outputPath, [], rels);
+      }
+    } catch (err) {
+      process.stderr.write(`[mcp-watcher] delete (text) error: ${(err as Error).message}\n`);
+    }
+
+    // 4. Vector index — delete the deleted files' rows (no nodes to add).
+    try {
+      const { VectorIndex } = await import('../analyzer/vector-index.js');
+      if (VectorIndex.exists(this.outputPath)) {
+        await VectorIndex.updateFiles(
+          this.outputPath, [], new Set(rels), context?.signatures ?? [],
+          new Set(), new Set(), undefined,
+        );
+      }
+    } catch (err) {
+      process.stderr.write(`[mcp-watcher] delete (vector) error: ${(err as Error).message}\n`);
+    }
+
+    // 5. Dependency graph — remove the deleted nodes and every edge touching them.
+    await this.removeFromDependencyGraph(absPaths);
+
+    if (this.debug) {
+      process.stderr.write(`[mcp-watcher] reconciled ${rels.length} deletion(s)\n`);
+    }
+  }
+
+  /**
+   * Remove deleted files' nodes and any edge referencing them from
+   * dependency-graph.json, recompute degrees, and persist atomically.
+   */
+  private async removeFromDependencyGraph(absPaths: string[]): Promise<void> {
+    const graphPath = join(this.outputPath, ARTIFACT_DEPENDENCY_GRAPH);
+    try {
+      let raw: string;
+      try {
+        raw = await readFile(graphPath, 'utf-8');
+      } catch {
+        return;
+      }
+      const graph = JSON.parse(raw) as {
+        nodes: Array<{ id: string; metrics?: Record<string, number> }>;
+        edges: Array<{ source: string; target: string }>;
+      };
+      if (!Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) return;
+
+      const removed = new Set(absPaths);
+      const nodesBefore = graph.nodes.length;
+      graph.nodes = graph.nodes.filter((n) => !removed.has(n.id));
+      const edgesBefore = graph.edges.length;
+      graph.edges = graph.edges.filter((e) => !removed.has(e.source) && !removed.has(e.target));
+      if (graph.nodes.length === nodesBefore && graph.edges.length === edgesBefore) return;
+
+      const out = new Map<string, Set<string>>();
+      const inn = new Map<string, Set<string>>();
+      for (const n of graph.nodes) { out.set(n.id, new Set()); inn.set(n.id, new Set()); }
+      for (const e of graph.edges) { out.get(e.source)?.add(e.target); inn.get(e.target)?.add(e.source); }
+      for (const n of graph.nodes) {
+        if (!n.metrics) n.metrics = {};
+        n.metrics.outDegree = out.get(n.id)?.size ?? 0;
+        n.metrics.inDegree = inn.get(n.id)?.size ?? 0;
+      }
+
+      const tmp = `${graphPath}.${process.pid}.tmp`;
+      await writeFile(tmp, JSON.stringify(graph));
+      await rename(tmp, graphPath);
+    } catch (err) {
+      process.stderr.write(`[mcp-watcher] delete (dep-graph) error: ${(err as Error).message}\n`);
     }
   }
 


### PR DESCRIPTION
Makes `mcp --watch` reconcile **modify, create, and delete across every lane** — closing the watch-mode staleness gaps. Commits are stacked smallest-first.

## 1. Live dependency-graph edges in watch mode
The watcher kept signatures, the call-graph EdgeStore, the text-line index, and the vector index live — but **never touched `dependency-graph.json`** (what `get_file_dependencies` reads). So **any** import edit went stale until a full `analyze`. Cheap fix: extract `computeFileImportEdges` from `buildEdges` (shared, no drift) and patch the changed file's edges + degrees in `updateDependencyGraph` (atomic tmp+rename). HTTP/call-synthesized edges preserved; global metrics (pageRank/clusters) deferred to full analyze.

## 2. HTML live in watch mode
The watcher ignored HTML (`unknown` language, not in `SOURCE_EXTENSIONS`), so the three HTML features (text-line, inline-`<script>` call-graph, `<script src>`/`<link>` asset edges) only refreshed on full analyze. Admit `.html`/`.htm`; **`buildGraphSubset` blanks HTML** (offset-preserving) so an edit refreshes inline-script nodes instead of the swap wiping them. Text-lines + asset edges then refresh for free.

## 3. Create & delete reconciliation
The watcher only handled `'change'`. Now:
- **`'add'`** → the change pipeline; `updateDependencyGraph` adds a node (+ outgoing edges) for a not-yet-known file.
- **`'unlink'`** → `handleDeletions` removes the file from **every** lane: call graph (edges both directions + nodes + cfg + classes), signatures, text-line index, vector index, dependency graph (node + touching edges, degrees recomputed, atomic write).
- Coalescing: deletions share the change debounce via `pendingDeletions`; a flush does deletions first then changes; a re-create supersedes a pending delete and vice-versa (and `stop()` drains both on shutdown).

## Scope (by design, documented)
Global dep-graph metrics, new-file *incoming* edges, `.vue`/`.svelte`, and `.css` → full analyze. Watch-ignored paths (`*.test.ts`, build dirs) never fire events.

## Tests
- `mcp-watcher.integration.test.ts`: import re-point, call-edge preservation, new-file node add, deletion node/edge removal, **supersession** (delete→recreate ⇒ present, recreate→delete ⇒ removed), HTML `<script src>` re-point.
- `mcp-watcher-html.test.ts`: `buildGraphSubset` HTML blanking (node-wipe regression guard).
- `dependency-graph-watch.e2e.integration.test.ts`: full **analyze → watch → get_file_dependencies** loop for modify, create, delete, and HTML.
- Existing dependency-graph + import-parser + watcher suites pass unchanged. Full suite otherwise green; only failures are the pre-existing `memory-invariant` property tests (60s timeouts, load-sensitive, fail identically on the clean base).

Three `code-reviewer` passes: dep-graph (fixed HIGH torn-read → tmp+rename), HTML (APPROVE), create/delete (fixed MEDIUM shutdown-drains-deletions; the test-file-leak finding was moot since test files are watch-ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)