### PR TITLE
feat(pi): add 10 MCP tools to Pi extension and harden Windows daemon spawn

### DIFF
--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -378,7 +378,14 @@ async function ensureDaemon(cwd: string): Promise<Daemon | null> {
   const existing = await readDescriptor(cwd);
   if (existing && (await healthy(existing))) return { baseUrl: `http://${existing.host}:${existing.port}`, token: existing.token };
   try {
-    spawn('openlore', ['serve', '--directory', cwd], { detached: true, stdio: 'ignore', windowsHide: true, ...(process.platform === 'win32' ? { shell: true } : {}) }).unref();
+    if (process.platform === 'win32') {
+      // shell:true + detached:true applies windowsHide only to cmd.exe, not the
+      // node child it spawns. `start /b` runs without a new console window and
+      // inherits the PATH, so openlore.cmd resolves correctly.
+      spawn('cmd.exe', ['/c', 'start', '/b', 'openlore', 'serve', '--directory', cwd], { stdio: 'ignore', windowsHide: true }).unref();
+    } else {
+      spawn('openlore', ['serve', '--directory', cwd], { detached: true, stdio: 'ignore' }).unref();
+    }
   } catch { return null; }
   const deadline = Date.now() + HEALTH_TIMEOUT_MS;
   while (Date.now() < deadline) {

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -321,7 +321,9 @@ async function runConfigWizard(ctx: ExtensionContext, existing?: OpenLoreConfig 
       const [exitCode, errText] = await new Promise<[number, string]>((resolve) => {
         const trySpawn = (cmd: string, args: string[]) => new Promise<[number, string] | null>((res) => {
           const chunks: Buffer[] = [];
-          const proc = spawn(cmd, args, { cwd: ctx.cwd, stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true, ...(process.platform === 'win32' ? { shell: true } : {}) });
+          const proc = process.platform === 'win32'
+            ? spawn('cmd.exe', ['/c', cmd, ...args], { cwd: ctx.cwd, stdio: ['ignore', 'ignore', 'pipe'], windowsHide: true })
+            : spawn(cmd, args, { cwd: ctx.cwd, stdio: ['ignore', 'ignore', 'pipe'] });
           proc.stderr?.on('data', (d: Buffer) => chunks.push(d));
           proc.on('close', (code) => res([code ?? 1, Buffer.concat(chunks).toString().trim()]));
           proc.on('error', () => res(null));
@@ -379,12 +381,17 @@ async function ensureDaemon(cwd: string): Promise<Daemon | null> {
   if (existing && (await healthy(existing))) return { baseUrl: `http://${existing.host}:${existing.port}`, token: existing.token };
   try {
     if (process.platform === 'win32') {
-      // shell:true + detached:true applies windowsHide only to cmd.exe, not the
-      // node child it spawns. `start /b` runs without a new console window and
-      // inherits the PATH, so openlore.cmd resolves correctly.
-      spawn('cmd.exe', ['/c', 'start', '/b', 'openlore', 'serve', '--directory', cwd], { stdio: 'ignore', windowsHide: true }).unref();
+      // shell:true + detached:true applies windowsHide only to cmd.exe, not the node child.
+      // Pass the full command as a single /c string so cmd.exe quotes cwd correctly,
+      // handling both spaces and metacharacters (&|><^) in the project path.
+      // Empty title "" prevents start from consuming the quoted cwd as a window title.
+      const child = spawn('cmd.exe', ['/c', `start "" /b openlore serve --directory "${cwd}"`], { stdio: 'ignore', windowsHide: true });
+      child.on('error', () => { /* daemon not found — polling loop will time out cleanly */ });
+      child.unref();
     } else {
-      spawn('openlore', ['serve', '--directory', cwd], { detached: true, stdio: 'ignore' }).unref();
+      const child = spawn('openlore', ['serve', '--directory', cwd], { detached: true, stdio: 'ignore' });
+      child.on('error', () => { /* daemon not found — polling loop will time out cleanly */ });
+      child.unref();
     }
   } catch { return null; }
   const deadline = Date.now() + HEALTH_TIMEOUT_MS;
@@ -667,7 +674,7 @@ const TITLE_KEYS = ['name', 'title', 'label', 'function', 'symbol', 'id', 'file'
 const BASE_SKIP = new Set([
   // input echoes
   'task', 'query', 'description', 'symbol', 'functionName', 'direction',
-  'maxDepth', 'depth', 'entryFunction', 'targetFunction', 'filePath', 'limit',
+  'maxDepth', 'depth', 'entryFunction', 'targetFunction', 'filePath', 'limit', 'domain',
   // prose / meta
   'guidance', 'note', 'graphIndexNote', 'searchMode', 'count',
 ]);

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -542,6 +542,103 @@ const NAV_TOOLS: NavToolSpec[] = [
     guideline: 'Before a PR, call openlore_get_surprising_connections to spot accidental coupling.',
     parameters: Type.Object({ limit: Type.Optional(Type.Number()) }),
   },
+  {
+    name: 'get_architecture_overview',
+    label: 'openlore get_architecture_overview',
+    description: 'Get a bird\'s-eye view of the codebase — domain clusters, cross-cluster dependencies, entry points, and critical hubs.',
+    guideline: 'Before planning a large feature or onboarding to an unknown area, call openlore_get_architecture_overview for a structural overview.',
+    parameters: Type.Object({}),
+  },
+  {
+    name: 'get_refactor_report',
+    label: 'openlore get_refactor_report',
+    description: 'List functions that need refactoring, ranked by priority: hub overload, god functions, SRP violations, cyclic dependencies.',
+    guideline: 'Before starting a refactor, call openlore_get_refactor_report to find the highest-priority targets.',
+    parameters: Type.Object({}),
+  },
+  {
+    name: 'get_critical_hubs',
+    label: 'openlore get_critical_hubs',
+    description: 'Find the most-called functions — modifying them has the widest blast radius and requires the most careful refactoring.',
+    guideline: 'Before touching widely-used code, call openlore_get_critical_hubs to see which functions are the most sensitive to change.',
+    parameters: Type.Object({
+      limit: Type.Optional(Type.Number()),
+      minFanIn: Type.Optional(Type.Number({ description: 'Minimum number of callers to be considered a hub (default: 3)' })),
+    }),
+  },
+  {
+    name: 'get_god_functions',
+    label: 'openlore get_god_functions',
+    description: 'Find god functions (high fan-out orchestrators) that call too many things and likely need to be split.',
+    guideline: 'When a function feels too large or does too much, call openlore_get_god_functions to find orchestrator candidates for refactoring.',
+    parameters: Type.Object({
+      filePath: Type.Optional(Type.String({ description: 'Restrict search to this file (relative path)' })),
+      fanOutThreshold: Type.Optional(Type.Number({ description: 'Minimum fan-out to be considered a god function (default: 8)' })),
+    }),
+  },
+  {
+    name: 'search_specs',
+    label: 'openlore search_specs',
+    description: 'Search OpenSpec specifications by meaning — find which requirement covers a concept.',
+    guideline: 'Before writing code for a feature, call openlore_search_specs to find what the spec says about it.',
+    parameters: Type.Object({
+      query: Type.String({ description: 'REQUIRED. Natural language query, e.g. "email validation workflow"' }),
+      limit: Type.Optional(Type.Number()),
+      domain: Type.Optional(Type.String({ description: 'Filter by domain name (e.g. "auth", "analyzer")' })),
+      section: Type.Optional(Type.String({ description: 'Filter by section type: "requirements", "purpose", "design"' })),
+    }),
+  },
+  {
+    name: 'search_unified',
+    label: 'openlore search_unified',
+    description: 'Search code and specs simultaneously — returns functions and requirements that match, cross-boosted when they are linked.',
+    guideline: 'When you want to find where something is implemented AND what the spec says about it in one call, use openlore_search_unified.',
+    parameters: Type.Object({
+      query: Type.String({ description: 'REQUIRED. Natural language query, e.g. "validate user authentication"' }),
+      limit: Type.Optional(Type.Number()),
+      language: Type.Optional(Type.String({ description: 'Filter code results by language (e.g. "TypeScript")' })),
+      domain: Type.Optional(Type.String({ description: 'Filter spec results by domain name' })),
+      section: Type.Optional(Type.String({ description: 'Filter spec results by section type' })),
+    }),
+  },
+  {
+    name: 'get_spec',
+    label: 'openlore get_spec',
+    description: 'Read the full specification for a domain — all requirements, scenarios, and linked source files.',
+    guideline: 'When you know which spec domain covers your task, call openlore_get_spec with the domain name to read its requirements before writing code.',
+    parameters: Type.Object({
+      domain: Type.String({ description: 'REQUIRED. Domain name (e.g. "auth", "analyzer") — use search_specs to discover domain names.' }),
+    }),
+  },
+  {
+    name: 'get_function_body',
+    label: 'openlore get_function_body',
+    description: 'Read the exact source code of a function by name and file.',
+    guideline: 'After search_code or get_function_skeleton identifies a function, call openlore_get_function_body to read its full implementation instead of opening the file.',
+    parameters: Type.Object({
+      filePath: Type.String({ description: 'REQUIRED. File path relative to the project directory, e.g. "src/auth/jwt.ts"' }),
+      functionName: Type.String({ description: 'REQUIRED. Name of the function to extract, e.g. "verifyToken"' }),
+    }),
+  },
+  {
+    name: 'get_file_dependencies',
+    label: 'openlore get_file_dependencies',
+    description: 'Show what a file imports and what files import it — the coupling picture for a single file.',
+    guideline: 'Before moving, deleting, or refactoring a file, call openlore_get_file_dependencies to understand its coupling.',
+    parameters: Type.Object({
+      filePath: Type.String({ description: 'REQUIRED. File path relative to the project root, e.g. "src/core/analyzer/vector-index.ts"' }),
+      direction: Type.Optional(StringEnum(['imports', 'importedBy', 'both'] as const)),
+    }),
+  },
+  {
+    name: 'get_decisions',
+    label: 'openlore get_decisions',
+    description: 'List or search architectural decision records (ADRs) — the documented "why" behind design choices.',
+    guideline: 'When you wonder why a pattern exists or need to check if a decision is already documented, call openlore_get_decisions.',
+    parameters: Type.Object({
+      query: Type.Optional(Type.String({ description: 'Optional text filter — returns only ADRs whose title or content contains this string' })),
+    }),
+  },
 ];
 
 function toolResult(text: string, details: unknown = null): AgentToolResult<unknown> {
@@ -652,7 +749,7 @@ function resultText(result: AgentToolResult<unknown>): unknown {
 }
 
 // The descriptive argument that names a tool call, tried in order.
-const CALL_ARG_KEYS = ['task', 'query', 'symbol', 'functionName', 'description', 'filePath'];
+const CALL_ARG_KEYS = ['task', 'query', 'symbol', 'functionName', 'description', 'filePath', 'domain'];
 const MAX_CALL_ARG = 80;
 
 /**


### PR DESCRIPTION
## Summary

- Fix console window appearing on every Pi session start on Windows (`cmd.exe /c start /b` instead of `detached + shell:true`)
- Harden Windows daemon spawn: quote `cwd` as a single `/c` string to handle spaces and metacharacters (`&|><^`) in project paths; add `.on('error')` listeners to both spawn paths
- Fix `trySpawn` in config wizard to use `cmd.exe /c` directly instead of `shell:true` (consistent with `ensureDaemon`)
- Expose 9 MCP tools directly in the Pi extension: `get_architecture_overview`, `get_refactor_report`, `get_critical_hubs`, `get_god_functions`, `search_specs`, `search_unified`, `get_spec`, `get_function_body`, `get_file_dependencies`
- Add `domain` to `CALL_ARG_KEYS` and `BASE_SKIP` so `get_spec` calls render cleanly in the TUI
- Fix `orient` to surface ADR matches in `matchingSpecs` without an embedding server — `SpecVectorIndex.search()` already falls back to BM25 when `embedSvc` is null, but the guard `&& embedSvc` in `orient` blocked the entire spec search block
- Remove `get_decisions` from MCP and Pi — `orient` already surfaces ADRs via `matchingSpecs` (BM25/semantic) and live decisions via `pendingDecisions`; the tool was a keyword-only subset that confused agents more than it helped

## Root cause (console window)

```ts
// before — windowsHide silences cmd.exe but node.exe still gets a window
spawn('openlore', [...], { detached: true, shell: true, windowsHide: true })

// after — start /b is Windows-native backgrounding, no new console
// cwd passed as a single /c string so cmd.exe quoting handles spaces + metacharacters
spawn('cmd.exe', ['/c', `start "" /b openlore serve --directory "${cwd}"`], { windowsHide: true })
```

## Root cause (ADRs not surfacing in orient)

```ts
// before — skipped entire spec search when no embedding server
if (!lean && hasSpecIndex && embedSvc) {

// after — SpecVectorIndex.search() handles null embedSvc with BM25 internally
if (!lean && hasSpecIndex) {
```

## Test plan

- [ ] Start Pi on Windows — confirm no console window appears
- [ ] Verify daemon: `$s = Get-Content .openlore\serve.json | ConvertFrom-Json; Invoke-RestMethod http://$($s.host):$($s.port)/health`
- [ ] Call `openlore_get_spec auth` — confirm it renders as `openlore get_spec "auth"` in TUI
- [ ] Call `openlore orient --task "MCP conclusion contract" --json` — confirm `matchingSpecs` contains `decisions` domain entries (ADR-0002)
- [ ] Confirm `get_decisions` no longer appears in `openlore mcp --list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
