### PR TITLE
feat(pi): task-scoped context injection parity with `orient --inject`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,18 @@ For all other cases (reading a file, grepping, listing files) use native tools d
 > the source owns the finding's intrinsic `severity`, the policy owns its enforcement class. Findings stay
 > advisory by default — blocking is always opt-in (change: add-finding-enforcement-policy).
 
+> **MCP tool ↔ Pi extension parity.** OpenLore ships the same structural capabilities through two
+> surfaces: the MCP tools (`src/core/services/mcp-handlers/*`) and the Pi extension
+> (`src/pi/extension.ts` — native tools + the `before_agent_start` context-injection block).
+> Whenever you change one, ask whether the other needs the same change, and vice versa:
+> - New / changed MCP tool behavior, signature, or output shape → does the Pi extension expose or
+>   consume it (native `NAV_TOOLS`, or the injection block), and should it be updated to match?
+> - New / changed Pi behavior (injection, gating, rendering) → should the equivalent CLI/MCP path
+>   (e.g. `orient --inject`, the Claude Code hook) carry the same logic?
+> Keep shared logic in one dependency-light module both surfaces import rather than duplicating it
+> (the Pi host must never import the analyzer in-process — it orients via the warm daemon over RPC).
+> If parity is intentionally skipped, say why in the PR.
+
 <!-- openlore-decisions-instructions -->
 ## Architectural decisions
 

--- a/src/cli/commands/orient-inject-render.ts
+++ b/src/cli/commands/orient-inject-render.ts
@@ -1,0 +1,215 @@
+/**
+ * Pure presentation + gating for task-scoped context injection
+ * (change: add-task-scoped-context-injection).
+ *
+ * Extracted from `orient-inject.ts` so it can be reused by hosts that must NOT
+ * load the analyzer in-process — notably the Pi extension, which orients through
+ * a warm daemon over RPC (decision abee8e3e). Everything here is pure and
+ * deterministic; its only runtime dependency is `estimateTokens`. Keep it that
+ * way — importing the analyzer (`handleOrient`) or config I/O here would drag the
+ * analyzer back into the Pi host process the daemon split exists to keep lean.
+ *
+ * The block is framed as facts-not-coercion (Epistemic Lease, decision 8e95746d)
+ * and capped by a token budget so it can never dominate the context it economizes.
+ */
+
+import { estimateTokens } from '../../core/services/llm-service.js';
+import type { ContextInjectionConfig } from '../../types/index.js';
+
+/** Injection settings with every documented default applied. */
+export interface ResolvedInjectionConfig {
+  mode: 'off' | 'task-scoped';
+  tokenBudget: number;
+  relevanceMinMatches: number;
+  relevanceMinFanIn: number;
+  relevanceMinScore: number;
+}
+
+/** Documented defaults — used when `.openlore/config.json` omits `contextInjection`. */
+export const INJECTION_DEFAULTS: ResolvedInjectionConfig = {
+  mode: 'task-scoped',
+  tokenBudget: 600,
+  relevanceMinMatches: 2,
+  relevanceMinFanIn: 2,
+  relevanceMinScore: 0.3,
+};
+
+/**
+ * The single pointer line emitted whenever a full block is not warranted
+ * (weak match, no graph, error, or empty prompt). Informational, not coercive.
+ */
+export const POINTER_LINE =
+  '[OpenLore] Structural context is available — call `orient` with your task for a deterministic ' +
+  'briefing (relevant functions, callers, insertion points). Informational; ignore if not useful.';
+
+/** One-line framing prefix on the full block — facts, never an instruction. */
+const BLOCK_HEADER =
+  '[OpenLore] Task-scoped orientation (deterministic, from the local call graph). ' +
+  'Informational — act on it or ignore it.';
+
+const BLOCK_FOOTER = '(From OpenLore. Call `orient` for the full briefing, or ignore this.)';
+
+/** Apply documented defaults over a partial config block. */
+export function resolveInjectionConfig(ci: ContextInjectionConfig | undefined): ResolvedInjectionConfig {
+  return {
+    mode: ci?.mode ?? INJECTION_DEFAULTS.mode,
+    tokenBudget:
+      typeof ci?.tokenBudget === 'number' && ci.tokenBudget > 0
+        ? ci.tokenBudget
+        : INJECTION_DEFAULTS.tokenBudget,
+    relevanceMinMatches:
+      typeof ci?.relevanceMinMatches === 'number' && ci.relevanceMinMatches >= 0
+        ? ci.relevanceMinMatches
+        : INJECTION_DEFAULTS.relevanceMinMatches,
+    relevanceMinFanIn:
+      typeof ci?.relevanceMinFanIn === 'number' && ci.relevanceMinFanIn >= 0
+        ? ci.relevanceMinFanIn
+        : INJECTION_DEFAULTS.relevanceMinFanIn,
+    relevanceMinScore:
+      typeof ci?.relevanceMinScore === 'number' && ci.relevanceMinScore >= 0
+        ? ci.relevanceMinScore
+        : INJECTION_DEFAULTS.relevanceMinScore,
+  };
+}
+
+// These shapes mirror the lean `handleOrient` result, which reaches us through
+// an unchecked `as` cast (the handler — or the Pi daemon's `orient` tool —
+// returns `unknown`). Fields that should be present are typed optional so the
+// renderer's defensive guards against a partial/forward-incompatible payload are
+// type-checked, not lint noise.
+interface OrientFn {
+  name?: string;
+  filePath?: string;
+  score?: number;
+  fanIn?: number;
+  fanOut?: number;
+  isHub?: boolean;
+}
+
+interface CallNeighbour {
+  name?: string;
+  filePath?: string;
+}
+
+interface OrientCallPath {
+  function?: string;
+  callers?: CallNeighbour[];
+  callees?: CallNeighbour[];
+}
+
+export interface LeanOrientResult {
+  task?: string;
+  searchMode?: string;
+  error?: string;
+  relevantFiles?: string[];
+  relevantFunctions?: OrientFn[];
+  specDomains?: string[];
+  callPaths?: OrientCallPath[];
+  suggestedTools?: string[];
+}
+
+/**
+ * Deterministic orientation-relevance gate. Returns true when the task has a
+ * substantial, structurally-connected match in the graph — the case where a
+ * full briefing pays for itself. Otherwise the caller emits the pointer line,
+ * keeping injection out of the small/familiar/shallow arena the scorecard shows
+ * OpenLore should not tax.
+ *
+ * Signals are read off the lean orient result itself (no new analysis pass):
+ *   1. matched-function count >= relevanceMinMatches, AND
+ *   2. structural centrality — a match with fan-in >= relevanceMinFanIn, or a
+ *      hub — OR, only on the bounded semantic/hybrid score scale, a top match
+ *      score >= relevanceMinScore.
+ *
+ * BM25-fallback scores live on an unbounded, corpus-relative scale, so the score
+ * path is disabled there and the gate relies on count + structural centrality —
+ * which keeps a strong structural match from being gated out when embeddings are
+ * unavailable, without letting an arbitrary BM25 magnitude wave everything through.
+ */
+export function passesRelevanceGate(result: LeanOrientResult, cfg: ResolvedInjectionConfig): boolean {
+  if (result.error) return false;
+  const fns = result.relevantFunctions ?? [];
+  if (fns.length < cfg.relevanceMinMatches) return false;
+
+  const maxFanIn = fns.reduce((m, f) => Math.max(m, f.fanIn ?? 0), 0);
+  const anyHub = fns.some(f => f.isHub === true);
+  if (anyHub || maxFanIn >= cfg.relevanceMinFanIn) return true;
+
+  // Score is only comparable to a fixed threshold on the bounded hybrid scale.
+  if (result.searchMode === 'hybrid') {
+    const maxScore = fns.reduce((m, f) => Math.max(m, f.score ?? 0), 0);
+    return maxScore >= cfg.relevanceMinScore;
+  }
+  return false;
+}
+
+/** Take the first `n` graph-clean entries; tolerate undefined. */
+function take<T>(arr: T[] | undefined, n: number): T[] {
+  return (arr ?? []).slice(0, n);
+}
+
+/**
+ * Render the full injection block from a lean orient result, hard-capped to the
+ * token budget. The header, framing, and task line are mandatory (a small fixed
+ * floor that is always present so an injected block is unambiguously attributed
+ * and ignorable); detail lines are added in priority order (functions → files →
+ * call neighbours → specs → tools) only while they fit, so the data — regardless
+ * of match size — never pushes the block over budget.
+ *
+ * Every interpolated field is defensively filtered: although `handleOrient`
+ * declares its name/file fields as required strings, a partial/forward-incompat
+ * result must never leak a literal `undefined`, `[object Object]`, or a stray
+ * leading comma into the agent's context.
+ */
+export function renderInjectionBlock(result: LeanOrientResult, cfg: ResolvedInjectionConfig): string {
+  const task = (result.task ?? '').replace(/\s+/g, ' ').trim().slice(0, 200);
+  const mandatory = [BLOCK_HEADER, `Task: ${task}`];
+
+  const optional: string[] = [];
+  const clean = (xs: Array<string | undefined> | undefined, n: number): string[] =>
+    (xs ?? []).filter((x): x is string => typeof x === 'string' && x.length > 0).slice(0, n);
+
+  const fns = take(result.relevantFunctions, 8).filter(f => f.name && f.filePath);
+  if (fns.length > 0) {
+    optional.push('Relevant functions:');
+    for (const f of fns) optional.push(`  • ${f.name} — ${f.filePath}`);
+  }
+
+  const files = clean(result.relevantFiles, 8);
+  if (files.length > 0) optional.push(`Relevant files: ${files.join(', ')}`);
+
+  const names = (ns: CallNeighbour[] | undefined): string =>
+    [...new Set((ns ?? []).map(n => n?.name).filter((x): x is string => typeof x === 'string' && x.length > 0))]
+      .slice(0, 3)
+      .join(', ');
+  const paths = take(result.callPaths, 5).filter(p => p.function);
+  const pathLines: string[] = [];
+  for (const p of paths) {
+    const callers = names(p.callers);
+    const callees = names(p.callees);
+    const parts: string[] = [];
+    if (callers) parts.push(`← ${callers}`);
+    if (callees) parts.push(`→ ${callees}`);
+    if (parts.length > 0) pathLines.push(`  ${p.function}: ${parts.join('  ')}`);
+  }
+  if (pathLines.length > 0) {
+    optional.push('Call neighbours:');
+    optional.push(...pathLines);
+  }
+
+  const specs = clean(result.specDomains, 8);
+  if (specs.length > 0) optional.push(`Spec domains: ${specs.join(', ')}`);
+
+  const tools = clean(result.suggestedTools, 6);
+  if (tools.length > 0) optional.push(`Suggested tools: ${tools.join(', ')}`);
+
+  optional.push(BLOCK_FOOTER);
+
+  // Greedily include optional lines while the whole block stays within budget.
+  const lines = [...mandatory];
+  for (const line of optional) {
+    if (estimateTokens([...lines, line].join('\n')) > cfg.tokenBudget) break;
+    lines.push(line);
+  }
+  return lines.join('\n');
+}

--- a/src/cli/commands/orient-inject.ts
+++ b/src/cli/commands/orient-inject.ts
@@ -18,207 +18,29 @@
  * prompt — degrades to a single pointer line and exits 0.
  */
 
-import { estimateTokens } from '../../core/services/llm-service.js';
 import { handleOrient } from '../../core/services/mcp-handlers/orient.js';
 import { readOpenLoreConfig } from '../../core/services/config-manager.js';
-import type { ContextInjectionConfig } from '../../types/index.js';
+import {
+  INJECTION_DEFAULTS,
+  POINTER_LINE,
+  resolveInjectionConfig,
+  passesRelevanceGate,
+  renderInjectionBlock,
+  type LeanOrientResult,
+} from './orient-inject-render.js';
 
-/** Injection settings with every documented default applied. */
-export interface ResolvedInjectionConfig {
-  mode: 'off' | 'task-scoped';
-  tokenBudget: number;
-  relevanceMinMatches: number;
-  relevanceMinFanIn: number;
-  relevanceMinScore: number;
-}
-
-/** Documented defaults — used when `.openlore/config.json` omits `contextInjection`. */
-export const INJECTION_DEFAULTS: ResolvedInjectionConfig = {
-  mode: 'task-scoped',
-  tokenBudget: 600,
-  relevanceMinMatches: 2,
-  relevanceMinFanIn: 2,
-  relevanceMinScore: 0.3,
-};
-
-/**
- * The single pointer line emitted whenever a full block is not warranted
- * (weak match, no graph, error, or empty prompt). Informational, not coercive.
- */
-export const POINTER_LINE =
-  '[OpenLore] Structural context is available — call `orient` with your task for a deterministic ' +
-  'briefing (relevant functions, callers, insertion points). Informational; ignore if not useful.';
-
-/** One-line framing prefix on the full block — facts, never an instruction. */
-const BLOCK_HEADER =
-  '[OpenLore] Task-scoped orientation (deterministic, from the local call graph). ' +
-  'Informational — act on it or ignore it.';
-
-const BLOCK_FOOTER = '(From OpenLore. Call `orient` for the full briefing, or ignore this.)';
-
-/** Apply documented defaults over a partial config block. */
-export function resolveInjectionConfig(ci: ContextInjectionConfig | undefined): ResolvedInjectionConfig {
-  return {
-    mode: ci?.mode ?? INJECTION_DEFAULTS.mode,
-    tokenBudget:
-      typeof ci?.tokenBudget === 'number' && ci.tokenBudget > 0
-        ? ci.tokenBudget
-        : INJECTION_DEFAULTS.tokenBudget,
-    relevanceMinMatches:
-      typeof ci?.relevanceMinMatches === 'number' && ci.relevanceMinMatches >= 0
-        ? ci.relevanceMinMatches
-        : INJECTION_DEFAULTS.relevanceMinMatches,
-    relevanceMinFanIn:
-      typeof ci?.relevanceMinFanIn === 'number' && ci.relevanceMinFanIn >= 0
-        ? ci.relevanceMinFanIn
-        : INJECTION_DEFAULTS.relevanceMinFanIn,
-    relevanceMinScore:
-      typeof ci?.relevanceMinScore === 'number' && ci.relevanceMinScore >= 0
-        ? ci.relevanceMinScore
-        : INJECTION_DEFAULTS.relevanceMinScore,
-  };
-}
-
-// These shapes mirror the lean `handleOrient` result, which reaches us through
-// an unchecked `as` cast (the handler returns `unknown`). Fields that should be
-// present are typed optional so the renderer's defensive guards against a
-// partial/forward-incompatible payload are type-checked, not lint noise.
-interface OrientFn {
-  name?: string;
-  filePath?: string;
-  score?: number;
-  fanIn?: number;
-  fanOut?: number;
-  isHub?: boolean;
-}
-
-interface CallNeighbour {
-  name?: string;
-  filePath?: string;
-}
-
-interface OrientCallPath {
-  function?: string;
-  callers?: CallNeighbour[];
-  callees?: CallNeighbour[];
-}
-
-interface LeanOrientResult {
-  task?: string;
-  searchMode?: string;
-  error?: string;
-  relevantFiles?: string[];
-  relevantFunctions?: OrientFn[];
-  specDomains?: string[];
-  callPaths?: OrientCallPath[];
-  suggestedTools?: string[];
-}
-
-/**
- * Deterministic orientation-relevance gate. Returns true when the task has a
- * substantial, structurally-connected match in the graph — the case where a
- * full briefing pays for itself. Otherwise the caller emits the pointer line,
- * keeping injection out of the small/familiar/shallow arena the scorecard shows
- * OpenLore should not tax.
- *
- * Signals are read off the lean orient result itself (no new analysis pass):
- *   1. matched-function count >= relevanceMinMatches, AND
- *   2. structural centrality — a match with fan-in >= relevanceMinFanIn, or a
- *      hub — OR, only on the bounded semantic/hybrid score scale, a top match
- *      score >= relevanceMinScore.
- *
- * BM25-fallback scores live on an unbounded, corpus-relative scale, so the score
- * path is disabled there and the gate relies on count + structural centrality —
- * which keeps a strong structural match from being gated out when embeddings are
- * unavailable, without letting an arbitrary BM25 magnitude wave everything through.
- */
-export function passesRelevanceGate(result: LeanOrientResult, cfg: ResolvedInjectionConfig): boolean {
-  if (result.error) return false;
-  const fns = result.relevantFunctions ?? [];
-  if (fns.length < cfg.relevanceMinMatches) return false;
-
-  const maxFanIn = fns.reduce((m, f) => Math.max(m, f.fanIn ?? 0), 0);
-  const anyHub = fns.some(f => f.isHub === true);
-  if (anyHub || maxFanIn >= cfg.relevanceMinFanIn) return true;
-
-  // Score is only comparable to a fixed threshold on the bounded hybrid scale.
-  if (result.searchMode === 'hybrid') {
-    const maxScore = fns.reduce((m, f) => Math.max(m, f.score ?? 0), 0);
-    return maxScore >= cfg.relevanceMinScore;
-  }
-  return false;
-}
-
-/** Take the first `n` graph-clean entries; tolerate undefined. */
-function take<T>(arr: T[] | undefined, n: number): T[] {
-  return (arr ?? []).slice(0, n);
-}
-
-/**
- * Render the full injection block from a lean orient result, hard-capped to the
- * token budget. The header, framing, and task line are mandatory (a small fixed
- * floor that is always present so an injected block is unambiguously attributed
- * and ignorable); detail lines are added in priority order (functions → files →
- * call neighbours → specs → tools) only while they fit, so the data — regardless
- * of match size — never pushes the block over budget.
- *
- * Every interpolated field is defensively filtered: although `handleOrient`
- * declares its name/file fields as required strings, a partial/forward-incompat
- * result must never leak a literal `undefined`, `[object Object]`, or a stray
- * leading comma into the agent's context.
- */
-export function renderInjectionBlock(result: LeanOrientResult, cfg: ResolvedInjectionConfig): string {
-  const task = (result.task ?? '').replace(/\s+/g, ' ').trim().slice(0, 200);
-  const mandatory = [BLOCK_HEADER, `Task: ${task}`];
-
-  const optional: string[] = [];
-  const clean = (xs: Array<string | undefined> | undefined, n: number): string[] =>
-    (xs ?? []).filter((x): x is string => typeof x === 'string' && x.length > 0).slice(0, n);
-
-  const fns = take(result.relevantFunctions, 8).filter(f => f.name && f.filePath);
-  if (fns.length > 0) {
-    optional.push('Relevant functions:');
-    for (const f of fns) optional.push(`  • ${f.name} — ${f.filePath}`);
-  }
-
-  const files = clean(result.relevantFiles, 8);
-  if (files.length > 0) optional.push(`Relevant files: ${files.join(', ')}`);
-
-  const names = (ns: CallNeighbour[] | undefined): string =>
-    [...new Set((ns ?? []).map(n => n?.name).filter((x): x is string => typeof x === 'string' && x.length > 0))]
-      .slice(0, 3)
-      .join(', ');
-  const paths = take(result.callPaths, 5).filter(p => p.function);
-  const pathLines: string[] = [];
-  for (const p of paths) {
-    const callers = names(p.callers);
-    const callees = names(p.callees);
-    const parts: string[] = [];
-    if (callers) parts.push(`← ${callers}`);
-    if (callees) parts.push(`→ ${callees}`);
-    if (parts.length > 0) pathLines.push(`  ${p.function}: ${parts.join('  ')}`);
-  }
-  if (pathLines.length > 0) {
-    optional.push('Call neighbours:');
-    optional.push(...pathLines);
-  }
-
-  const specs = clean(result.specDomains, 8);
-  if (specs.length > 0) optional.push(`Spec domains: ${specs.join(', ')}`);
-
-  const tools = clean(result.suggestedTools, 6);
-  if (tools.length > 0) optional.push(`Suggested tools: ${tools.join(', ')}`);
-
-  optional.push(BLOCK_FOOTER);
-
-  // Greedily include optional lines while the whole block stays within budget.
-  const lines = [...mandatory];
-  for (const line of optional) {
-    if (estimateTokens([...lines, line].join('\n')) > cfg.tokenBudget) break;
-    lines.push(line);
-  }
-  return lines.join('\n');
-}
+// The pure presentation + gating layer lives in `orient-inject-render.ts` so a
+// host that must not load the analyzer in-process (the Pi extension) can reuse
+// it (decision abee8e3e). Re-export the public surface so existing importers and
+// tests continue to resolve everything from this module.
+export {
+  INJECTION_DEFAULTS,
+  POINTER_LINE,
+  resolveInjectionConfig,
+  passesRelevanceGate,
+  renderInjectionBlock,
+} from './orient-inject-render.js';
+export type { ResolvedInjectionConfig, LeanOrientResult } from './orient-inject-render.js';
 
 /**
  * Extract the user's prompt from a hook stdin payload. Claude Code's

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -91,6 +91,22 @@ export async function readConfig(cwd: string): Promise<OpenLoreConfig | null> {
   } catch { return null; }
 }
 
+/**
+ * Read just the `contextInjection` block, independent of `isUsableConfig`.
+ * The injection opt-out must work even before an LLM provider is configured —
+ * `readConfig` returns null until `generation.provider` is set (a headless/rpc
+ * session may never run the wizard), which would silently drop `mode: "off"`.
+ * Mirrors the CLI path, which reads config unconditionally.
+ */
+export async function readContextInjection(cwd: string): Promise<ContextInjectionConfig | undefined> {
+  try {
+    const raw = JSON.parse(await readFile(join(cwd, OPENLORE_DIR, 'config.json'), 'utf-8')) as unknown;
+    return raw && typeof raw === 'object'
+      ? (raw as { contextInjection?: ContextInjectionConfig }).contextInjection
+      : undefined;
+  } catch { return undefined; }
+}
+
 async function writeConfig(cwd: string, config: OpenLoreConfig): Promise<void> {
   await mkdir(join(cwd, OPENLORE_DIR), { recursive: true });
   await writeFile(join(cwd, OPENLORE_DIR, 'config.json'), JSON.stringify(config, null, 2) + '\n', 'utf-8');
@@ -998,16 +1014,19 @@ export default function openlore(pi: ExtensionAPI): void {
     // Pi's own baseline grounding, are unaffected); a weak/absent match degrades
     // to the single ignorable pointer line instead of dumping raw orient JSON.
     const daemon = await getDaemon(sessionCwd);
-    const cfg = resolveInjectionConfig((await readConfig(sessionCwd))?.contextInjection);
+    const cfg = resolveInjectionConfig(await readContextInjection(sessionCwd));
     if (daemon && event.prompt && cfg.mode !== 'off') {
       const oriented = await callTool(daemon, 'orient', { task: event.prompt }, sessionCwd);
       const result =
         oriented && typeof oriented === 'object' && !('error' in (oriented as object))
           ? (oriented as LeanOrientResult)
           : null;
-      blocks.push(result && passesRelevanceGate(result, cfg)
-        ? renderInjectionBlock(result, cfg)
-        : POINTER_LINE);
+      // Weak match → the single ignorable pointer line. A null result (daemon
+      // error / no graph) pushes nothing, so the no-analysis baseline nudge in
+      // the `suffix` fallback below can still surface.
+      if (result) {
+        blocks.push(passesRelevanceGate(result, cfg) ? renderInjectionBlock(result, cfg) : POINTER_LINE);
+      }
     }
 
     const suffix = blocks.length > 0

--- a/src/pi/extension.ts
+++ b/src/pi/extension.ts
@@ -39,6 +39,19 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
+// Task-scoped injection gate + render. This module is intentionally
+// dependency-light (its only runtime import is estimateTokens) so importing it
+// here does NOT drag the analyzer into the Pi host — orientation still comes
+// from the warm daemon over RPC (decision abee8e3e).
+import {
+  resolveInjectionConfig,
+  passesRelevanceGate,
+  renderInjectionBlock,
+  POINTER_LINE,
+  type LeanOrientResult,
+} from '../cli/commands/orient-inject-render.js';
+import type { ContextInjectionConfig } from '../types/index.js';
+
 // ── Config types & helpers ────────────────────────────────────────────────────
 
 interface OpenLoreConfig {
@@ -58,6 +71,8 @@ interface OpenLoreConfig {
     apiKey?: string;
     skipSslVerify?: boolean;
   };
+  /** Task-scoped context injection settings (gate + token budget + opt-out). */
+  contextInjection?: ContextInjectionConfig;
   createdAt: string;
   lastRun: string | null;
 }
@@ -976,12 +991,23 @@ export default function openlore(pi: ExtensionAPI): void {
     const specIndex = await readSpecIndex(sessionCwd);
     if (specIndex) blocks.push(specIndex);
 
+    // Task-scoped orientation: gate + token-budgeted render, the same pipeline
+    // `openlore orient --inject` uses for the Claude Code hook (change
+    // add-task-scoped-context-injection). The daemon does the orientation; the
+    // host only gates and renders. `mode: "off"` opts out (digest/spec index,
+    // Pi's own baseline grounding, are unaffected); a weak/absent match degrades
+    // to the single ignorable pointer line instead of dumping raw orient JSON.
     const daemon = await getDaemon(sessionCwd);
-    if (daemon && event.prompt) {
+    const cfg = resolveInjectionConfig((await readConfig(sessionCwd))?.contextInjection);
+    if (daemon && event.prompt && cfg.mode !== 'off') {
       const oriented = await callTool(daemon, 'orient', { task: event.prompt }, sessionCwd);
-      if (oriented && typeof oriented === 'object' && !('error' in (oriented as object))) {
-        blocks.push('# openlore orientation for this task\n\n' + truncate(JSON.stringify(oriented, null, 2), 6000));
-      }
+      const result =
+        oriented && typeof oriented === 'object' && !('error' in (oriented as object))
+          ? (oriented as LeanOrientResult)
+          : null;
+      blocks.push(result && passesRelevanceGate(result, cfg)
+        ? renderInjectionBlock(result, cfg)
+        : POINTER_LINE);
     }
 
     const suffix = blocks.length > 0


### PR DESCRIPTION
## What

Brings the Pi extension's pre-turn context injection up to parity with **PR #184** (`orient --inject` + Claude Code `UserPromptSubmit` hook). Pi already injected orientation before the first agent turn (`before_agent_start`, block C), but it **dumped raw `JSON.stringify(orient)`** with a fixed 6000-char truncate — no relevance gate, no token budget, no opt-out, no non-coercive framing.

Now Pi runs the **same gate + render pipeline** as the CLI hook: a strong structural match emits a bounded, OpenLore-attributed, ignorable block; a weak/absent match degrades to the single `POINTER_LINE`; `contextInjection.mode: "off"` opts out.

## How

- **New dependency-light module** `src/cli/commands/orient-inject-render.ts` — the pure gate + render + config layer extracted verbatim from `orient-inject.ts`. Its only runtime dependency is `estimateTokens`. This is load-bearing: the Pi host **must not** load the analyzer in-process (it orients via the warm daemon over RPC), so it cannot import `orient-inject.ts` directly (that pulls `handleOrient` → tree-sitter). Both surfaces now share one source of truth.
- **`orient-inject.ts`** imports and re-exports the moved symbols. The CLI `orient --inject` public surface and behavior are **unchanged** (existing tests resolve everything from this module as before).
- **`src/pi/extension.ts`** block C now:
  - resolves `contextInjection` from `.openlore/config.json`,
  - skips the orient block when `mode: "off"` (the digest + spec-index baseline grounding, Pi's own, are intentionally unaffected),
  - gates via `passesRelevanceGate` and renders via `renderInjectionBlock` (token-budgeted, non-coercive framing),
  - degrades to `POINTER_LINE` on a weak/absent match or daemon error (fail-open, matching the CLI `buildInjection` semantics).
- **`CLAUDE.md`** — adds an "MCP tool ↔ Pi extension parity" rule so future changes to one surface prompt a check of the other.

## Verification

- `tsc --noEmit` clean, `eslint` clean on all three source files.
- `vitest run src/cli/commands/orient-inject.test.ts src/pi` → 53 pass / 0 fail.

## Notes

- The extraction is a verbatim move; the `orient-inject` test suite covers the gate/render logic unchanged. The Pi block C wiring itself is not yet unit-tested — follow-up if desired.
- Decision recorded: `abee8e3e` (extract pure inject presentation into a dependency-light module for Pi reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)