### PR TITLE
feat: change footprint projection + pairwise hazard classifier (PARALLEL-WORK proposal 1)

### DIFF
--- a/openspec/changes/PARALLEL-WORK-COORDINATION.md
+++ b/openspec/changes/PARALLEL-WORK-COORDINATION.md
@@ -139,7 +139,7 @@ a future, clearly-fenced follow-up — never on the served path.
 
 | # | Change | What it adds | Primary domain | Depends on (makes better, does not block) |
 |---|--------|--------------|----------------|-------------------------------------------|
-| 1 | `add-change-footprint-projection` | The borrow-analysis core: a deterministic per-task **footprint** (write-set / read-set / affected-set) and a **hazard classifier** over a pair of footprints. No new tool. | analyzer | — (foundation; reuses `blast_radius` / `analyze_impact` / `get_change_coupling`) |
+| 1 | `add-change-footprint-projection` **(SHIPPED — `feat/change-footprint-projection`)** | The borrow-analysis core: a deterministic per-task **footprint** (write-set / read-set / affected-set) and a **hazard classifier** over a pair of footprints. No new tool. | analyzer | — (foundation; reuses `blast_radius` / `analyze_impact` / `get_change_coupling`) |
 | 2 | `add-parallel-work-plan` | One conclusion tool `plan_parallel_work`: takes N task descriptors, returns the hazard-typed conflict graph, the wave schedule, the critical path, and each task's footprint. | mcp-handlers | 1 |
 | 3 | `add-footprint-escape-detection` | The back-side safety net: extend `structural_diff` to flag symbols an actual diff modified **outside** its declared write-footprint, and recompute newly-opened conflicts with peer tasks. | mcp-handlers | 1 |
 | 4 | `add-cross-actor-interference-map` | The team wedge: treat open PRs / branches **and** in-flight agent task footprints as one conflict graph across the federation — "your task collides with PR #210's blast radius." | mcp-handlers | 1, 2 |

--- a/openspec/changes/PARALLEL-WORK-COORDINATION.md
+++ b/openspec/changes/PARALLEL-WORK-COORDINATION.md
@@ -1,0 +1,242 @@
+# Change set: structural coordination for parallel agents and teams
+
+> Status: DRAFT (2026-06-24). Four independent change proposals that give OpenLore one new
+> capability family: telling many agents (and many humans) **which work is safe to run at once**,
+> computed deterministically from the call graph + specs + git history. No runtime, no lock service,
+> no learned model. This file is the umbrella; each proposal directory is independently shippable.
+
+## The motivating observation
+
+The 2026 multi-agent coding stack — Conductor, Vibe Kanban, Claude Squad, Agent Teams, the whole
+worktree-per-agent pattern — has converged on a *mechanism* for running many agents at once (branch
+isolation, git worktrees, a shared task list). What none of it can answer is the *policy* question
+that decides whether parallelism actually pays off: **given these N proposed tasks, which subset is
+safe to edit concurrently, and which must be ordered?** Worktrees isolate during editing, but
+conflicts only surface at *merge* — after the tokens are already spent. When the worker is an
+expensive LLM rather than a human who context-switches cheaply, a task thrown away at merge is pure
+loss. The highest-leverage moment to detect interference is therefore *before dispatch*, and that is
+exactly the moment a textual tool cannot help, because no diff exists yet.
+
+OpenLore already holds every primitive needed to answer the policy question deterministically: the
+call graph (who depends on whom), `blast_radius` / `analyze_impact` (transitive reach of a change),
+`get_change_coupling` (what historically changes together), community detection (`get_map`, the
+min-cut partition of the graph), `structural_diff` (what a diff actually touched), and multi-repo
+federation with stable cross-repo symbol IDs. The gap is that none of these is composed into the one
+artifact a swarm orchestrator or a team lead needs: a **hazard-typed conflict graph over a set of
+proposed changes**, plus the wave schedule and critical path that fall out of it.
+
+## The frame: a borrow checker for the repository, not a lock
+
+The unifying model for this set is **a borrow checker lifted from variables to repository regions.**
+Every task declares (or OpenLore predicts) the region it will *mutate* — its write-footprint — plus
+the region it *reads*. The coordination question is then exactly the borrow rule: no two
+concurrently-running tasks may hold overlapping **mutable** borrows of the same region; read-sharing
+is fine; write-sharing is the conflict.
+
+This frame is load-bearing because it makes both the value and the honest limit precise:
+
+- **The value is static analysis** — OpenLore's identity. The regions are blast radii; the
+  dependencies are call edges; the conflict rule is set intersection. All deterministic, all local.
+- **The limit is that OpenLore cannot *enforce* the borrow.** Rust's borrow checker is sound only
+  because the compiler rejects code that violates a declared borrow. OpenLore analyzes; it cannot
+  reject an agent's write. So OpenLore is a borrow checker that *advises* — it computes the plan and
+  detects when an actual diff escaped its declared footprint, but the *enforcement* (refuse a diff
+  that writes outside scope; refuse to dispatch a conflicting task) lives in the harness, CI, or git,
+  never in OpenLore. This is the same seam OpenLore already respects everywhere: it computes
+  conclusions; the agent or the gate acts on them.
+
+## Policy versus mechanism — the line that keeps this in-substrate
+
+This set deliberately builds only the **read side**. It is worth stating the line sharply, because
+the obvious over-reach ("a state lock so each agent owns a region until it releases it") would turn
+OpenLore into a stateful runtime service with a clock, a memory of who holds what, lease expiry,
+liveness handling for dead agents, and fencing for stale writers — Kleppmann-grade distributed
+systems, and a direct contradiction of the north star (decision `c6d1ad07`: *local-first plumbing
+like tree-sitter/SCIP/LSP, stateless, grounded in static analysis*). It would also issue **unsound**
+guarantees, because a lock derived from a *predicted* write-set gives false confidence exactly when
+it matters.
+
+The test that keeps every proposal here on the right side of the line:
+
+> Does the feature require OpenLore to *remember or arbitrate across time*, or only to *compute given
+> inputs*? Compute is in-substrate. Remember / arbitrate / hold a lease is a different product.
+
+The conflict graph, the waves, the critical path, the escape check, the cross-actor map are all
+**pure functions of the inputs**. State (which tasks are done, which diffs landed, who holds a
+worktree) is held by the harness, which re-invokes OpenLore each round and gets a freshly rendered
+plan — the same `render(state)` discipline as `change_impact_certificate`'s freshness lease. OpenLore
+never grows a coordinator.
+
+## The hazard model: "conflict" is three things, not one
+
+"Two tasks touch the same file" is the textual tools' definition and it is too crude — it serializes
+work that is actually independent. Because OpenLore has the call graph, this set classifies the
+hazard the way CPU pipeline design does, which is what turns a flat conflict graph into a real
+schedule:
+
+| Hazard | Definition (over footprints) | Consequence in the plan |
+|--------|------------------------------|-------------------------|
+| **WAW** | `write(A) ∩ write(B) ≠ ∅`, at least one side in `modify` mode | True conflict → mutual exclusion (different waves) |
+| **shared-append** | `write(A) ∩ write(B) ≠ ∅` but **both** sides touch the shared symbol in `append` mode | Low risk → may parallelize, advisory (see "registration hot-spots" below) |
+| **RAW** | `write(A) ∩ read(B) ≠ ∅`, excluding ambient symbols | Ordering dependency → B after A (topological edge), not exclusion |
+| **WAR / disjoint-region-same-file** | overlap only in read sets, or same file but disjoint symbols | Low risk → may parallelize, flagged |
+| **Soft (coupling)** | files historically co-change above threshold, no static edge | Advisory warning → surface, do not hard-serialize |
+
+Splitting "must-exclude" from "must-order" from "low-risk" is the single move that lets the planner
+emit independent-set *waves* with a topological backbone, and that lets it compute a **critical
+path** — the minimum wall-clock even with infinite agents (Amdahl's Law / Brooks's Law made
+computable from structure).
+
+### Registration hot-spots: the refinement the pressure test forced
+
+A naive symbol-level WAW rule collapses *all* parallelism on a realistic codebase, because real
+repos concentrate independent work at a few **registration sites** — a dispatcher (`dispatchTool` is
+one 62-branch `if`-chain), an exported tool/registry array (`TOOL_DEFINITIONS` is a single `const`),
+a preset list, a finding-code registry. Every new-tool task *writes the same symbol* there, yet those
+edits are pure *appends* that git 3-way-merges trivially. Treating them as hard WAW serializes the
+whole swarm (the validation below shows this set's four proposals collapsing from 2 waves to 4).
+
+The fix is caller-declared, not inferred: a task seed MAY carry `writeMode: 'append' | 'modify'`
+(default `modify`, the conservative assumption). A write-write overlap where **both** sides declare
+`append` is classified **shared-append** — a low-risk advisory, not mutual exclusion. The agent knows
+it is adding a case to a switch, not rewriting it, so it declares so; OpenLore still never guesses.
+Proposal 3 closes the loop on the back-side: it confirms from the *actual* diffs whether two
+append edits really landed disjointly (resolved-by-merge) or actually overlapped.
+
+### Ambient symbols: stop-words for the dependency graph
+
+A symbol everyone depends on — `logger` (imported by 97 files), `validateDirectory` (fan-in 64),
+the call-graph primitives (imported by 121) — appears in nearly every task's read-set. Left
+unchecked it makes any task that touches it RAW-upstream of the entire swarm, and it bloats every
+read-set toward the whole graph. These **ambient symbols** (fan-in above a configurable percentile)
+are excluded from generating RAW ordering edges and are capped out of the read-set — the
+dependency-graph equivalent of IR stop-words. The call-distance bound on the read-set is therefore
+load-bearing, not cosmetic.
+
+## Research basis
+
+The proactive-conflict half of this set descends directly from the collaboration-conflict
+literature — Palantír (workspace awareness of overlapping in-progress changes), Crystal and WeCode
+(speculative merge-build-test to find interfering changes early) — but with two upgrades those
+systems never had: a **structural/semantic** signal (call-graph reachability) instead of textual
+diff overlap, and **no speculative build** (Crystal's scaling killer was merging-and-building every
+pair in the background; this set replaces it with a static footprint intersection that is orders of
+magnitude cheaper). The scheduling half is the action-graph idea from build systems (Bazel/Buck
+compute a dependency DAG and expose which actions are independent; they do not ship the executor) —
+applied to agent tasks.
+
+- L. Hattori & M. Lanza et al., *Proactive detection of collaboration conflicts* (Palantír lineage).
+- C. Bird et al. / Kasi & Sarma, *Predicting merge conflicts* (speculative-merge: Crystal, WeCode).
+- The hazard taxonomy (RAW/WAR/WAW) is the classical data-hazard model from pipelined-CPU design.
+
+One deliberate non-borrow, exactly as the navigation set did with learned landmarks: the literature
+increasingly *learns* a conflict-probability model from merge history. We do **not** serve a learned
+model. The conflict graph and every feature it is built on stay 100% deterministic. A learned
+*threshold calibration* trained on the repo's own merge outcomes is named in "Out of scope" below as
+a future, clearly-fenced follow-up — never on the served path.
+
+## The proposals
+
+| # | Change | What it adds | Primary domain | Depends on (makes better, does not block) |
+|---|--------|--------------|----------------|-------------------------------------------|
+| 1 | `add-change-footprint-projection` | The borrow-analysis core: a deterministic per-task **footprint** (write-set / read-set / affected-set) and a **hazard classifier** over a pair of footprints. No new tool. | analyzer | — (foundation; reuses `blast_radius` / `analyze_impact` / `get_change_coupling`) |
+| 2 | `add-parallel-work-plan` | One conclusion tool `plan_parallel_work`: takes N task descriptors, returns the hazard-typed conflict graph, the wave schedule, the critical path, and each task's footprint. | mcp-handlers | 1 |
+| 3 | `add-footprint-escape-detection` | The back-side safety net: extend `structural_diff` to flag symbols an actual diff modified **outside** its declared write-footprint, and recompute newly-opened conflicts with peer tasks. | mcp-handlers | 1 |
+| 4 | `add-cross-actor-interference-map` | The team wedge: treat open PRs / branches **and** in-flight agent task footprints as one conflict graph across the federation — "your task collides with PR #210's blast radius." | mcp-handlers | 1, 2 |
+
+Recommended build order is 1 → 2 → 3 → 4, but each ships on its own. Ship 1 and 2 first; they are the
+whole single-machine swarm story. 3 closes the soundness gap. 4 is the multi-human, multi-repo
+payoff and is the most differentiated against the field.
+
+## Design constraints inherited by every proposal in this set
+
+- **Stateless and advisory.** No proposal adds a lock, a lease OpenLore holds, a coordinator, a
+  queue, or any cross-invocation memory of agent/worktree state. Every output is a pure function of
+  (graph state, task descriptors, git state) at call time. Enforcement and dispatch live in the
+  harness / CI / git, never here. Outputs never *block* by default; a configured surface MAY opt into
+  gating, consistent with `add-finding-enforcement-policy`.
+- **Conclusion over graph** (`mcp-quality`). The planner returns the *schedule* (waves, ordering
+  edges, critical path) — the computed answer — not a node-and-edge dump for the agent to BFS. New
+  tools are classified in `tool-contract.ts` and fail the contract test until classified.
+- **Determinism is a hard constraint.** No learned, statistical, or predictive model on the served
+  path. Re-evaluation against a fixed (graph state, task set, git state) is byte-identical. The
+  conflict graph is set intersection over deterministic footprints.
+- **Honesty over coverage; the soundness limit is disclosed, not hidden.** Predicted footprints are
+  *advisory* — an agent can edit outside them, and two tasks with no static or co-change edge can
+  still share a latent invariant. The planner therefore claims "reduces conflict probability / shifts
+  detection left," never "guarantees safe parallelism," and every output that asserts independence
+  carries the known-unknowable disclosure that integration tests remain the ground truth
+  (`confidence-boundary`). A footprint seeded below its evidence threshold returns "no signal," not a
+  guess.
+- **OpenLore schedules; the agent generates the work.** Turning "what needs doing" into atomic,
+  well-bounded tasks is a planning step that is partly LLM-shaped and therefore out of substrate
+  scope. The agent (or a human) supplies the task descriptors — an id, seed symbols/files, optional
+  intent text; OpenLore only *scores, classifies, and schedules* them deterministically. Task
+  *generation* never enters core.
+- **Tool-surface discipline.** This set adds exactly **one** new MCP tool (`plan_parallel_work`) plus
+  one extension to an existing tool (`structural_diff`) and one extension under federation
+  (the cross-actor map MAY ride `plan_parallel_work` or land as a sibling — see proposal 4). New
+  tools default opt-in: they land in a named preset (a new `coordination` preset, or `federation`
+  for the cross-actor map), never in `MINIMAL_TOOLS` or the lean first-run default
+  (`default-to-lean-tool-surface`).
+- **Additive, no schema break.** Footprints and hazard metadata reuse existing `FunctionNode` /
+  `CallEdge` primitives and existing edge-metadata conventions; no graph-schema change. New tool
+  fields are optional; artifacts written before a change load without migration.
+
+## Out of scope for the whole set (explicitly considered, deliberately excluded)
+
+- **Any stateful lock, lease OpenLore holds, or coordinator/dispatcher.** This is the central
+  non-goal. OpenLore computes plans; it never owns mutual exclusion, assigns a task to an agent,
+  tells an agent to wait, or tracks who holds a worktree. Point users at git worktrees + their
+  harness's Agent-Teams primitives for mechanism.
+- **A learned conflict-probability model on the served path.** Excluded by the determinism
+  constraint. A future, clearly-fenced follow-up MAY *calibrate the conflict threshold* offline from
+  the repo's own merge history (did predicted-independent tasks actually merge clean?) — but the
+  served conflict graph and its features stay deterministic; only a scalar threshold could ever be
+  tuned, never the answer itself.
+- **Soundness for semantic / latent-invariant conflicts.** Static analysis cannot see two tasks that
+  share no call edge and no co-change history yet both depend on one unwritten invariant. The set
+  reduces conflict probability and shifts detection left; it does not eliminate conflict. Integration
+  tests remain ground truth and the docs say so plainly.
+- **Task generation / decomposition.** OpenLore does not invent the task list from specs; it
+  schedules a list the agent supplies. (Enumerating *candidate* work from `check_spec_drift`,
+  `audit_spec_coverage`, `find_dead_code` is already possible with existing tools and is left to the
+  agent to assemble into descriptors.)
+- **Optimal scheduling.** The planner emits a correct, greedy wave schedule (maximal independent set
+  honoring ordering edges) and a critical-path estimate; it does not solve for a globally optimal
+  makespan or weight tasks by value. Greedy + topological is sufficient and deterministic.
+
+## Validation: this set, run through its own planner (2026-06-24)
+
+Before specifying code, we pressure-tested the design by hand-computing a plan for **the four
+proposals in this set, treated as tasks**, using real graph data from this repository
+(`analyze_impact` on `dispatchTool`; the on-disk shapes of `dispatchTool` and `TOOL_DEFINITIONS`;
+the fan-in figures from `CODEBASE.md`). The exercise changed the design in four concrete ways, all
+folded into the proposals below:
+
+- **Registration hot-spots collapsed all parallelism (→ added `shared-append`).** T2 (`plan_parallel_work`),
+  T3 (escape detection), and T4 (cross-actor map) all write the single `TOOL_DEFINITIONS` const; T2
+  and T4 also both write the `dispatchTool` if-chain. Naive symbol-level WAW made them mutually
+  exclusive, serializing the set to **four waves** — zero parallelism, the exact granularity failure
+  predicted in the brainstorm. The `writeMode: append` declaration + `shared-append` class downgrades
+  these to advisories, recovering **two waves**.
+- **The critical path was already correct (→ kept, validated).** T2/T3/T4 each *read* T1's footprint
+  module, so RAW correctly orders them after the foundation: `[T1] → [T2, T3, T4]`. The planner
+  independently reproduced this set's recommended build order, which is the core value working.
+- **Read-sets exploded through ambient hubs (→ added ambient-symbol exclusion).** T1's read-set runs
+  through `call-graph.ts` (imported by 121), `logger` (97), `validateDirectory` (64). Without
+  stop-word exclusion these would make any infra-touching task RAW-upstream of the entire swarm.
+- **`affected-set` was computed but never used in classification (→ demoted to informational).** The
+  hazard rules use only write/read sets; `affected-set` is retained as human-facing output, not a
+  hazard input.
+
+The exercise also surfaced a genuine design lever (proposal 4): if the cross-actor map *rides*
+`plan_parallel_work` it RAW-depends on T2 (critical path 3); as an independent sibling it does not
+(critical path 2). The planner makes that architecture choice visible — which is the tool doing its
+job. **Usage guidance that follows:** scope the wire-up/registration step of a task as its *own* small
+task so the unavoidable hot-spot serialization is isolated to something cheap, leaving the substantive
+work parallel.
+
+At implementation time, call `record_decision` before writing code for any proposal that introduces a
+new tool, data structure, scoring rule, or on-disk format (per project `CLAUDE.md`). These spec files
+themselves introduce no code and record no decision yet.

--- a/openspec/changes/add-change-footprint-projection/DOGFOOD-change-footprint-projection.md
+++ b/openspec/changes/add-change-footprint-projection/DOGFOOD-change-footprint-projection.md
@@ -1,0 +1,60 @@
+# Dogfood — change footprint projection (2026-06-24)
+
+Ran the shipped `computeFootprint` / `classifyHazard` against **this repository's real persisted call
+graph** (`.openlore/analysis/llm-context.json`: **5932 nodes, 14825 edges**) to confirm the primitive
+behaves on real data and reproduces the hand-computed validation exercise from
+`PARALLEL-WORK-COORDINATION.md`.
+
+## Setup
+
+The four PARALLEL-WORK proposals, treated as tasks, seeded with their real hot-spots:
+
+| Task | Seed | writeMode |
+|------|------|-----------|
+| `T2-planner` (`plan_parallel_work`) | `dispatchTool` | `append` |
+| `T3-escape` (escape detection) | `handleStructuralDiff` | `modify` |
+| `T4-crossactor` (cross-actor map) | `dispatchTool` | `append` |
+
+## Results
+
+```
+Ambient fan-in threshold (p99): 7   — symbols with fan-in > 7 excluded from read-sets
+
+[T2-planner]     write=1 read=288 affected=6 ambientExcl=13 unresolved=[]
+[T3-escape]      write=1 read=30  affected=7 ambientExcl=6  unresolved=[]
+[T4-crossactor]  write=1 read=288 affected=6 ambientExcl=13 unresolved=[]
+
+  T2-planner × T3-escape     → RAW (A after B)  witness=handleStructuralDiff
+  T2-planner × T4-crossactor → shared-append    witness=dispatchTool
+  T3-escape  × T4-crossactor → RAW (B after A)  witness=handleStructuralDiff
+
+Determinism on real graph: PASS (byte-identical)
+Unresolved seed → write=0, note=["thisSymbolDoesNotExist_xyz"]
+```
+
+## What this confirms
+
+1. **The `shared-append` refinement works on the real hot-spot.** `T2-planner × T4-crossactor` both
+   append the 62-branch `dispatchTool` dispatcher and classify **`shared-append`**, NOT `WAW` — the
+   exact false-conflict collapse the validation exercise predicted, now demonstrably avoided. Without
+   `writeMode: append` these two tasks would have been forced into different waves.
+
+2. **Ambient exclusion is load-bearing and bounded.** The p99 fan-in threshold on the real graph is
+   **7**; 13 ubiquitous hubs were excluded from `T2`'s read-set (288 → kept, hubs dropped), preventing
+   the read-set from bloating toward the whole graph through `logger` / `validateDirectory` / the
+   call-graph primitives.
+
+3. **RAW ordering is directed and correct.** `T2-planner` reads `handleStructuralDiff` (in its forward
+   closure) which `T3-escape` writes, yielding `RAW (A after B)` — T2 must run after T3. The reverse
+   pair reports the symmetric direction.
+
+4. **Determinism + honesty hold on real data.** Re-evaluation is byte-identical; an unknown seed yields
+   an empty footprint with an explicit `unresolvedSeeds` note, never a fabricated region.
+
+## Honest caveat
+
+A fifth task seeded on the brand-new `change-footprint.ts` file resolved as **unresolved** (empty
+footprint) because that file was created in this session and is not yet in the pre-existing index. This
+is the intended fail-soft behavior (no fabricated region for an unindexed seed), not a defect — a fresh
+`openlore analyze` would index it. The proposal's predicted `[T1] → [T2,T3,T4]` RAW backbone therefore
+only materializes after a re-index, which is expected.

--- a/openspec/changes/add-change-footprint-projection/proposal.md
+++ b/openspec/changes/add-change-footprint-projection/proposal.md
@@ -7,7 +7,9 @@
 > no graph-schema change, no LLM, no runtime.
 >
 > Implementation: `src/core/services/mcp-handlers/change-footprint.ts` (+ co-located
-> `change-footprint.test.ts`, 24 cases). The decision is captured in the `## Decision` section below
+> `change-footprint.test.ts`, 31 cases — 24 spec-scenario tests plus 7 adversarial regression tests
+> covering WAW-over-RAW precedence, the `extraSeedIds` semantic-search seam, partial seed resolution,
+> the distance/depth overrides, and combined file+symbol seeds). The decision is captured in the `## Decision` section below
 > and recorded through the commit-time decisions gate (the `record_decision` MCP tool is not in this
 > session's lean tool surface). Dogfood verification: `DOGFOOD-change-footprint-projection.md`.
 

--- a/openspec/changes/add-change-footprint-projection/proposal.md
+++ b/openspec/changes/add-change-footprint-projection/proposal.md
@@ -1,0 +1,137 @@
+# Change footprint projection: a deterministic per-task write/read/affected region and a pairwise hazard classifier
+
+> Status: SHIPPED (2026-06-24) on branch `feat/change-footprint-projection`. Part of the
+> `PARALLEL-WORK-COORDINATION.md` set (proposal 1, the foundation). Generalizes `blast_radius` from
+> "one symbol" to "a declared task," splits the result into write / read / affected regions, and adds
+> a pure pairwise hazard classifier (WAW / shared-append / RAW / WAR / soft-coupling). No new MCP tool,
+> no graph-schema change, no LLM, no runtime.
+>
+> Implementation: `src/core/services/mcp-handlers/change-footprint.ts` (+ co-located
+> `change-footprint.test.ts`, 24 cases). The decision is captured in the `## Decision` section below
+> and recorded through the commit-time decisions gate (the `record_decision` MCP tool is not in this
+> session's lean tool surface). Dogfood verification: `DOGFOOD-change-footprint-projection.md`.
+
+## Why
+
+OpenLore can already compute the transitive reach of a *single symbol* (`blast_radius`,
+`analyze_impact`) and what *historically co-changes* with a file (`get_change_coupling`). What it
+cannot yet express is the unit the rest of this set needs: the **footprint of a proposed task** — the
+region of the codebase a unit of work is expected to mutate, the region it depends on, and the region
+it would impact. Without a first-class footprint there is nothing to intersect, so there is no way to
+ask "can these two tasks run at once?"
+
+This proposal is the borrow-analysis core of the set. It defines, deterministically and with no new
+tool surface:
+
+1. a **footprint** for a task descriptor, in three parts (write / read / affected), and
+2. a pure **hazard classifier** that, given two footprints, returns the data-hazard between them
+   (WAW / RAW / WAR / disjoint) plus any soft co-change coupling.
+
+Everything downstream — the planner (proposal 2), escape detection (proposal 3), the cross-actor map
+(proposal 4) — is a consumer of these two functions. Building them once, in the analyzer, keeps the
+conflict semantics in a single deterministic place and keeps the tool count at zero for this proposal.
+
+## What changes
+
+1. **A task descriptor (input contract, no persistence).** A task is described by the *caller* (an
+   agent or a human), never invented by OpenLore: `{ id, seedSymbols?, seedFiles?, intent?,
+   writeMode? }`. At least one seed (symbol or file) is required; `intent` is optional free text used
+   only to widen seeds via the existing semantic search when seeds are sparse, never to guess edits.
+   `writeMode: 'append' | 'modify'` (default `modify`) is an optional, caller-declared annotation that
+   a seed is a pure *addition* to a registration site (a new switch case, a new array/registry entry)
+   rather than a change to existing code; it is what lets the classifier avoid the false-conflict
+   collapse the validation exercise exposed (see the `shared-append` hazard below). The descriptor is
+   an input to a pure function; nothing about it is stored across calls.
+
+2. **The footprint, in three regions** — each computed by reusing existing reachability, not new
+   graph machinery:
+   - **write-set** — the symbols the task is expected to *modify*. Seeded by `seedSymbols`/`seedFiles`
+     and conservatively expanded to the enclosing symbol/type/file of each seed. This is a *declared*
+     region (the borrow declaration), not a prediction of every edit; the honesty contract is that
+     OpenLore reports the declared write-set, lightly normalized, and nothing more.
+   - **read-set** — the transitive *callees / dependencies* of the write-set (forward reachability):
+     what the task's code reads to function. Bounded by the existing call-distance scoping **and** with
+     *ambient symbols* excluded — symbols whose fan-in exceeds a configurable percentile (`logger`,
+     `validateDirectory`, the call-graph primitives) are the dependency-graph equivalent of IR
+     stop-words: everyone reads them, so they carry no ordering signal and would otherwise bloat every
+     read-set toward the whole graph. The validation exercise showed this bound and exclusion are
+     load-bearing, not cosmetic.
+   - **affected-set** — the transitive *callers* of the write-set (backward reachability = today's
+     `blast_radius`): who is impacted if the write-set changes. This is retained as **informational
+     human-facing output only**; it is *not* an input to hazard classification (the classifier uses
+     write/read sets exclusively), so computing it never widens the conflict graph.
+   - **coupling-neighbors** — files that co-change with the write-set above the existing
+     `COUPLING_MIN_SUPPORT` / `COUPLING_MIN_CONFIDENCE` thresholds, carried as a *soft* annotation
+     (advisory), kept separate from the static regions so consumers can weight it differently.
+
+3. **The pairwise hazard classifier (pure function).** Given two footprints A and B, return the
+   strongest hazard between them:
+   - **WAW** if `write(A) ∩ write(B) ≠ ∅` and at least one side touches the shared symbol in `modify`
+     mode — both genuinely change a shared symbol → mutual-exclusion class.
+   - **shared-append** if `write(A) ∩ write(B) ≠ ∅` but **both** sides touch every shared symbol in
+     `append` mode — concurrent additions to a registration site (dispatcher, registry array, preset
+     list) that merge trivially → low-risk advisory, *not* mutual exclusion. This is the refinement the
+     validation exercise forced: without it, every new-tool task collides on `dispatchTool` /
+     `TOOL_DEFINITIONS` and the whole swarm serializes.
+   - **RAW** if `write(A) ∩ read(B) ≠ ∅` (or symmetrically `write(B) ∩ read(A)`), after ambient
+     symbols are excluded — one task writes a non-ambient symbol the other reads → an *ordering*
+     relation (the reader runs after the writer or re-orients), not exclusion. The direction is
+     recorded.
+   - **WAR / disjoint-region-same-file** if regions overlap only in read sets, or touch the same file
+     in disjoint symbols → low-risk, surfaced but not serializing.
+   - **soft-coupling** if the write-sets share no static relation but the files co-change above
+     threshold → advisory warning only.
+   - **none** otherwise. The result includes the witnessing symbol(s) so a consumer can explain the
+     verdict.
+
+4. **Determinism & honesty.** A footprint and a hazard verdict are deterministic functions of the
+   graph state, the coupling store, and the descriptor; byte-identical across re-evaluations of a
+   fixed state. A descriptor whose seeds resolve to nothing (unknown symbol, untracked file) yields an
+   **empty footprint with an explicit "unresolved seed" note**, never a fabricated region. The
+   write-set is always reported as *declared/advisory*, carrying the known-unknowable disclosure that
+   an agent may edit outside it (this is what proposal 3 later checks).
+
+## Decision
+
+**Footprint = three reachability regions over the existing call graph + a soft co-change annotation;
+hazards = set intersection classified by the RAW/WAR/WAW data-hazard taxonomy, extended with a
+caller-declared `shared-append` class and ambient-symbol exclusion.** We deliberately do not
+introduce a new edge kind, a new persisted structure, or any predictive model. The write-set is
+*declared by the caller and normalized*, not inferred, because inferring "what an agent will edit"
+is exactly the kind of guess the north star forbids; the read/affected regions are deterministic
+reachability we already compute. The `shared-append` downgrade and the ambient-symbol exclusion are
+both forced by the validation exercise (run against this repo's real `dispatchTool` / `TOOL_DEFINITIONS`
+hot-spots and its hub fan-in): without them the classifier is technically correct but useless, because
+it serializes every task that registers a tool. `shared-append` stays *caller-declared* (`writeMode`),
+never inferred, so the honesty contract holds. The classifier is a pure function so every downstream
+consumer shares one conflict definition.
+
+## Scope contract — do not break these things
+
+This change must NOT:
+- Add an MCP tool, a new node/edge kind, or a persisted store. Footprints and hazards are computed
+  on demand from existing primitives and returned to in-process callers (the proposal-2 tool).
+- Infer the write-set beyond declared seeds + conservative enclosing-scope normalization. No
+  "predict the edits" heuristic.
+- Fabricate a region for an unresolved seed. Unresolved → empty footprint + explicit note.
+- Let the read/affected regions fan out unbounded. Reuse the existing call-distance scoping.
+- Treat soft co-change coupling as a hard hazard. It is advisory and kept separate from the static
+  hazard classes.
+- Persist or remember any descriptor across calls. The function is pure.
+
+## Out of scope (deferred)
+
+A learned write-set predictor; weighting hazards by symbol importance/PageRank (the planner may layer
+ordering on top later); cross-language footprint differences beyond what call-distance scoping already
+handles; and exposing footprints as their own MCP tool (the planner in proposal 2 is the agent-facing
+surface — a bare footprint is a primitive, not a conclusion).
+
+## Implementation status
+
+Tracked in `tasks.md`. Verified by unit tests over a fixture graph: a write-set seeded by a symbol
+expands to its enclosing scope; the affected-set equals `blast_radius` of the write-set; the read-set
+is the forward call closure within the distance bound; two tasks sharing a written symbol classify
+WAW; a task that writes a symbol another reads classifies RAW with the correct direction; same-file
+disjoint symbols classify WAR/low-risk; co-changing-but-statically-unrelated files classify
+soft-coupling; an unresolved seed yields an empty footprint with a note; and re-evaluation is
+byte-identical.

--- a/openspec/changes/add-change-footprint-projection/specs/analyzer/spec.md
+++ b/openspec/changes/add-change-footprint-projection/specs/analyzer/spec.md
@@ -1,0 +1,145 @@
+# analyzer spec delta
+
+## ADDED Requirements
+
+### Requirement: ChangeFootprintProjection
+
+The system SHALL compute, for a caller-supplied task descriptor, a deterministic **footprint**
+consisting of three regions over the existing call graph plus a soft co-change annotation, reusing the
+existing reachability and change-coupling primitives, with no new graph-schema element, no persisted
+store, and no new MCP tool. A task descriptor is `{ id, seedSymbols?, seedFiles?, intent?, writeMode? }`
+supplied by the caller (an agent or human) and is never invented by the system; at least one seed is
+required. `writeMode` is `append` or `modify` (default `modify`), a caller-declared annotation that a
+seed is a pure addition to a registration site rather than a change to existing code; the system SHALL
+NOT infer it. The footprint regions SHALL be:
+
+- a **write-set**: the seeds resolved to symbols and normalized to their enclosing symbol/type/file —
+  a *declared* region, not a prediction of every edit — each carrying its declared `writeMode`;
+- a **read-set**: the forward call closure (callees/dependencies) of the write-set, bounded by the
+  existing call-distance scoping and with ambient symbols excluded;
+- an **affected-set**: the backward reachability (callers) of the write-set, equivalent to the
+  existing blast radius of the write-set, provided as informational output only and NOT used as an
+  input to hazard classification; and
+- **coupling-neighbors**: files that co-change with the write-set above the existing co-change support
+  and confidence thresholds, carried as a separate advisory annotation, never merged into the static
+  regions.
+
+A footprint SHALL be a deterministic function of the graph state, the change-coupling store, and the
+descriptor, byte-identical across re-evaluations of a fixed state. The write-set SHALL be reported as
+advisory/declared and SHALL carry a known-unknowable disclosure that an agent may edit outside it.
+
+#### Scenario: A seed expands to a three-region footprint
+
+- **GIVEN** a task descriptor whose single seed is a function symbol
+- **WHEN** its footprint is computed
+- **THEN** the write-set contains that symbol normalized to its enclosing scope, the affected-set
+  equals the blast radius (backward reachability) of the write-set, and the read-set equals the
+  forward call closure of the write-set bounded by the call-distance scope
+
+#### Scenario: The write-set is declared, not inferred
+
+- **GIVEN** a task descriptor with explicit seeds
+- **WHEN** its footprint is computed
+- **THEN** the write-set contains only the declared seeds normalized to enclosing scope — no
+  heuristic prediction of additional edit targets — and is flagged advisory with the disclosure that
+  actual edits may fall outside it
+
+#### Scenario: An unresolved seed yields an empty footprint with a note
+
+- **GIVEN** a task descriptor whose seed names a symbol or file not present in the graph
+- **WHEN** its footprint is computed
+- **THEN** the footprint is empty and carries an explicit unresolved-seed note, and no region is
+  fabricated
+
+#### Scenario: Co-change coupling is a separate advisory annotation
+
+- **GIVEN** a write-set whose file co-changes above the support and confidence thresholds with another
+  file that has no static call relation to it
+- **WHEN** the footprint is computed
+- **THEN** that other file appears in coupling-neighbors as an advisory annotation and does not enter
+  the static write/read/affected regions
+
+### Requirement: PairwiseHazardClassification
+
+The system SHALL provide a pure function that, given two footprints, returns the strongest data-hazard
+between them using the classical hazard taxonomy, together with the witnessing symbol(s) and, for
+ordering hazards, the direction. The classification SHALL be:
+
+- **WAW** when the two write-sets intersect and at least one side touches a shared symbol in `modify`
+  mode (a true conflict requiring mutual exclusion);
+- **shared-append** when the two write-sets intersect but both sides touch every shared symbol in
+  `append` mode (concurrent additions to a registration site that merge trivially — a low-risk
+  advisory, NOT mutual exclusion);
+- **RAW** when one footprint's write-set intersects the other's read-set, after ambient symbols are
+  excluded (an ordering dependency: the reader runs after the writer or re-orients), with the
+  direction recorded;
+- **WAR / low-risk** when footprints overlap only in read sets or touch the same file in disjoint
+  symbols (surfaced, non-serializing);
+- **soft-coupling** when the write-sets share no static relation but the files co-change above
+  threshold (advisory only); and
+- **none** otherwise.
+
+Precedence SHALL be WAW > RAW > shared-append > WAR > soft-coupling > none. The classifier SHALL be
+deterministic and SHALL include the witnessing symbols so a consumer can explain the verdict.
+
+#### Scenario: Shared written symbol classifies WAW
+
+- **GIVEN** two footprints whose write-sets both contain the same symbol, at least one in `modify` mode
+- **WHEN** the hazard between them is classified
+- **THEN** the result is WAW and names the shared symbol as the witness
+
+#### Scenario: Concurrent appends to a registration symbol classify shared-append, not WAW
+
+- **GIVEN** two footprints whose only write-set overlap is a registration symbol (for example a
+  dispatcher or a tool-registry array) that both declare in `append` mode
+- **WHEN** the hazard between them is classified
+- **THEN** the result is shared-append (a low-risk advisory), so the two tasks are not forced into
+  different waves, and naming the shared registration symbol as the witness
+- **AND** if either side declares that same symbol in `modify` mode, the result is WAW instead
+
+#### Scenario: One task writes what another reads classifies RAW with direction
+
+- **GIVEN** footprint A whose write-set contains a symbol that appears in footprint B's read-set, with
+  no write-set intersection
+- **WHEN** the hazard between them is classified
+- **THEN** the result is RAW with direction "B after A" and names the witnessing symbol
+
+#### Scenario: Same file, disjoint symbols classifies low-risk
+
+- **GIVEN** two footprints that modify different symbols within the same file and share no read/write
+  symbol overlap
+- **WHEN** the hazard between them is classified
+- **THEN** the result is WAR/low-risk rather than WAW, so the two tasks are not forced into different
+  waves by file overlap alone
+
+#### Scenario: Co-change without a static relation classifies soft-coupling
+
+- **GIVEN** two footprints whose write-sets have no static call relation but whose files co-change
+  above the support and confidence thresholds
+- **WHEN** the hazard between them is classified
+- **THEN** the result is soft-coupling (advisory), not a hard hazard class
+
+### Requirement: AmbientSymbolExclusion
+
+The system SHALL treat symbols whose fan-in exceeds a configurable percentile threshold as **ambient**
+(ubiquitous infrastructure such as a logger, a directory validator, or core call-graph primitives) and
+SHALL exclude ambient symbols from a footprint's read-set and from generating RAW ordering edges, so
+that pervasive infrastructure dependencies — which carry no real ordering signal — do not serialize
+otherwise-independent tasks or bloat read-sets toward the whole graph. A *write* to an ambient symbol
+(which is rare) SHALL still be eligible to create hazards. The ambient threshold SHALL be deterministic
+and documented.
+
+#### Scenario: A shared ambient dependency does not create an ordering edge
+
+- **GIVEN** two footprints whose read-sets both include a symbol whose fan-in is above the ambient
+  threshold, with no non-ambient write/read overlap between them
+- **WHEN** the hazard between them is classified
+- **THEN** no RAW edge is created from that ambient symbol, and the two tasks remain independent
+
+#### Scenario: Writing an ambient symbol still creates a hazard
+
+- **GIVEN** footprint A whose write-set contains an ambient symbol that appears in footprint B's
+  read-set
+- **WHEN** the hazard between them is classified
+- **THEN** a RAW edge (B after A) is created, because the ambient exclusion applies to read-set
+  membership, not to a deliberate write of the symbol

--- a/openspec/changes/add-change-footprint-projection/tasks.md
+++ b/openspec/changes/add-change-footprint-projection/tasks.md
@@ -56,9 +56,14 @@
       write to it still can.
 - [x] Unresolved seed → empty footprint + note.
 - [x] Determinism (byte-identical) test.
+- [x] **Adversarial regression set (7 cases, added in PR hardening):** WAW outranks RAW (a true
+      write-write conflict is never downgraded to ordering); the `extraSeedIds` semantic-search seam
+      widens the write-set (and an unresolved candidate is noted); partial resolution still computes a
+      full footprint while noting the bad seed; `readMaxDistance` / `affectedMaxDepth` bound the
+      forward / backward closures; combined `seedFiles` + `seedSymbols` merge and de-duplicate.
 
 ## 6. Verify
-- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (245 files, 4886 pass / 2 skip),
+- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (245 files, 4893 pass / 2 skip),
       `npm run build` — all green.
 - [x] No new MCP tool registered; `tool-contract.test.ts` unaffected (this proposal adds no tool).
 

--- a/openspec/changes/add-change-footprint-projection/tasks.md
+++ b/openspec/changes/add-change-footprint-projection/tasks.md
@@ -1,0 +1,70 @@
+# Tasks — Change footprint projection
+
+> Status: SHIPPED (2026-06-24) on branch `feat/change-footprint-projection`.
+> Module: `src/core/services/mcp-handlers/change-footprint.ts` (+ co-located test).
+> No new MCP tool, no graph-schema change — an internal primitive for `plan_parallel_work` (proposal 2).
+
+## 1. Task descriptor (input contract)
+- [x] Define `TaskDescriptor { id, seedSymbols?, seedFiles?, intent?, writeMode? }` (input type only;
+      no persistence). Require at least one seed; validate ids are unique within a call.
+- [x] `writeMode: 'append' | 'modify'` (default `modify`) — caller-declared per descriptor (or per
+      seed); marks pure additions to a registration site. Never inferred.
+- [x] When seeds are sparse and `intent` is present, widen seeds via existing semantic search
+      (best-effort; never fabricates a write target — only adds candidate seeds the caller declared
+      interest in). *Implemented as the injected `opts.extraSeedIds` seam: the caller (proposal 2)
+      runs the semantic search and passes candidate ids, keeping the core pure and deterministic.*
+
+## 2. Footprint computation (reuse existing reachability)
+- [x] `write-set`: resolve seeds to symbols; normalize to enclosing symbol/type/file. Declared region
+      only — no edit prediction. Carry each symbol's declared `writeMode`.
+- [x] `read-set`: forward call closure of the write-set, bounded by existing call-distance scoping
+      (`buildWeightedAdjacency`/`weightedBfs`) **and** with ambient symbols excluded.
+- [x] `affected-set`: backward reachability of the write-set (== `blast_radius`, via the same
+      `buildAdjacency`/`bfs` hop-depth traversal `analyze_impact` uses); informational output
+      only — NOT a hazard-classification input.
+- [x] `coupling-neighbors`: files co-changing with the write-set above `COUPLING_MIN_SUPPORT` /
+      `COUPLING_MIN_CONFIDENCE` (thresholds applied at analyze time by the change-coupling store),
+      carried as a separate soft annotation via an injected `couplingLookup`.
+- [x] Ambient-symbol set: derived from a fan-in percentile (`AMBIENT_FANIN_PERCENTILE = 0.99`,
+      configurable); used to filter read-sets and suppress RAW edges. Default documented.
+- [x] Unresolved seed → empty footprint + explicit `unresolvedSeeds` note (never a fabricated region).
+
+## 3. Pairwise hazard classifier (pure function)
+- [x] `classifyHazard(a: Footprint, b: Footprint)` → `{ kind: WAW|shared-append|RAW|WAR|soft-coupling|none,
+      direction?, witnesses }`.
+- [x] WAW: `write∩write` with ≥1 side in `modify` mode. shared-append: `write∩write` with BOTH sides
+      `append` on every shared symbol. RAW: `write(X)∩read(Y)` (ambient excluded from read membership,
+      but a written ambient symbol still counts via `ambientReadDeps`), direction recorded.
+      WAR/low-risk: same-file disjoint symbols or read-only overlap. soft: co-change overlap
+      with no static relation.
+- [x] Strongest-hazard precedence WAW > RAW > shared-append > WAR > soft-coupling > none; include
+      witnessing symbols (sorted, deterministic).
+
+## 4. Determinism & honesty
+- [x] Deterministic, byte-identical re-evaluation for a fixed (graph, coupling, descriptor) state
+      (asserted in unit tests and on the real repo graph in the dogfood).
+- [x] Write-set always flagged `advisory: true` with a known-unknowable `disclosure`.
+
+## 5. Tests & fixtures
+- [x] write-set expands seed to enclosing scope; affected-set == `blast_radius`(write-set);
+      read-set == bounded forward closure with ambient symbols excluded.
+- [x] WAW / shared-append / RAW (with direction) / WAR / soft-coupling / none each classified on a
+      fixture graph.
+- [x] shared-append: two `append`-mode seeds on the same registry symbol → shared-append, NOT WAW;
+      same symbol with one `modify` side → WAW.
+- [x] ambient exclusion: a high-fan-in symbol in both read-sets does not create a RAW edge; a
+      write to it still can.
+- [x] Unresolved seed → empty footprint + note.
+- [x] Determinism (byte-identical) test.
+
+## 6. Verify
+- [x] `npm run lint`, `npm run typecheck`, `npm run test:run` (245 files, 4886 pass / 2 skip),
+      `npm run build` — all green.
+- [x] No new MCP tool registered; `tool-contract.test.ts` unaffected (this proposal adds no tool).
+
+## 7. Docs
+- [x] Documented the footprint (write/read/affected/coupling), the declared-not-predicted write-set
+      contract, the hazard taxonomy, and the advisory/soundness disclosure (module doc-comments).
+      Noted this is an internal primitive consumed by `plan_parallel_work` (proposal 2).
+- [x] Dogfood writeup: `DOGFOOD-change-footprint-projection.md` (real 5932-node graph; reproduces the
+      validation exercise's `shared-append` on `dispatchTool`).

--- a/src/core/services/mcp-handlers/change-footprint.test.ts
+++ b/src/core/services/mcp-handlers/change-footprint.test.ts
@@ -149,6 +149,76 @@ describe('computeFootprint — three regions', () => {
     const b = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] });
     expect(JSON.stringify(a)).toBe(JSON.stringify(b));
   });
+
+  it('merges seedFiles and seedSymbols and de-duplicates an overlapping seed', () => {
+    const g = chainGraph();
+    // the file seed pulls in every symbol; the symbol seed names one already in it.
+    const f = computeFootprint(g, { id: 't1', seedFiles: ['a.ts'], seedSymbols: ['a.ts::main'] });
+    const ids = f.writeSet.map(w => w.id);
+    expect(ids.sort()).toEqual(['a.ts::entry', 'a.ts::main', 'a.ts::greet', 'a.ts::emit'].sort());
+    // 'a.ts::main' came from both seeds but appears exactly once (Set-deduped write-set).
+    expect(ids.filter(id => id === 'a.ts::main')).toHaveLength(1);
+  });
+
+  it('partial resolution: a real footprint is still computed and the bad seed is noted', () => {
+    const g = chainGraph();
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main', 'a.ts::ghost'] });
+    // the good seed produces a full footprint...
+    expect(f.writeSet.map(w => w.id)).toEqual(['a.ts::main']);
+    expect(f.readSet).toEqual(['a.ts::greet', 'a.ts::emit'].sort());
+    expect(f.affectedSet).toEqual(['a.ts::entry']);
+    // ...AND the unresolved seed is still disclosed (not the empty-footprint short-circuit).
+    expect(f.unresolvedSeeds).toEqual(['a.ts::ghost']);
+  });
+
+  it('widens the write-set via the caller-injected extraSeedIds seam (proposal-2 semantic search)', () => {
+    const g = chainGraph();
+    // The core never searches; the caller resolves `intent` to candidate ids and injects them here.
+    const f = computeFootprint(
+      g,
+      { id: 't1', seedSymbols: ['a.ts::main'], intent: 'greeting path' },
+      { extraSeedIds: ['a.ts::greet'] },
+    );
+    expect(f.writeSet.map(w => w.id).sort()).toEqual(['a.ts::greet', 'a.ts::main'].sort());
+    // a symbol promoted into the write-set is no longer counted as "read".
+    expect(f.readSet).not.toContain('a.ts::greet');
+    expect(f.readSet).toEqual(['a.ts::emit']);
+  });
+
+  it('an unresolved extraSeedId is disclosed under unresolvedSeeds', () => {
+    const g = chainGraph();
+    const f = computeFootprint(
+      g,
+      { id: 't1', seedSymbols: ['a.ts::main'] },
+      { extraSeedIds: ['a.ts::ghostCandidate'] },
+    );
+    expect(f.writeSet.map(w => w.id)).toEqual(['a.ts::main']);
+    expect(f.unresolvedSeeds).toEqual(['a.ts::ghostCandidate']);
+  });
+
+  it('readMaxDistance bounds the forward read closure', () => {
+    // linear chain n1 → n2 → n3 → n4, all import edges (cost 1 each).
+    const g = graph(
+      [node({ id: 'c.ts::n1' }), node({ id: 'c.ts::n2' }), node({ id: 'c.ts::n3' }), node({ id: 'c.ts::n4' })],
+      [edge('c.ts::n1', 'c.ts::n2'), edge('c.ts::n2', 'c.ts::n3'), edge('c.ts::n3', 'c.ts::n4')],
+    );
+    const tight = computeFootprint(g, { id: 't1', seedSymbols: ['c.ts::n1'] }, { readMaxDistance: 2 });
+    expect(tight.readSet).toEqual(['c.ts::n2', 'c.ts::n3']); // n4 is at distance 3, excluded
+    const wide = computeFootprint(g, { id: 't1', seedSymbols: ['c.ts::n1'] }, { readMaxDistance: 6 });
+    expect(wide.readSet).toEqual(['c.ts::n2', 'c.ts::n3', 'c.ts::n4']);
+  });
+
+  it('affectedMaxDepth bounds the backward affected closure', () => {
+    // linear chain n1 → n2 → n3 → n4; affected(n4) walks backward through callers.
+    const g = graph(
+      [node({ id: 'c.ts::n1' }), node({ id: 'c.ts::n2' }), node({ id: 'c.ts::n3' }), node({ id: 'c.ts::n4' })],
+      [edge('c.ts::n1', 'c.ts::n2'), edge('c.ts::n2', 'c.ts::n3'), edge('c.ts::n3', 'c.ts::n4')],
+    );
+    const shallow = computeFootprint(g, { id: 't1', seedSymbols: ['c.ts::n4'] }, { affectedMaxDepth: 1 });
+    expect(shallow.affectedSet).toEqual(['c.ts::n3']); // only the direct caller
+    const deep = computeFootprint(g, { id: 't1', seedSymbols: ['c.ts::n4'] }, { affectedMaxDepth: 3 });
+    expect(deep.affectedSet).toEqual(['c.ts::n1', 'c.ts::n2', 'c.ts::n3'].sort());
+  });
 });
 
 describe('computeFootprint — coupling neighbors', () => {
@@ -260,6 +330,17 @@ describe('classifyHazard', () => {
     const a = fp('A', [{ id: 'reg.ts::REG', mode: 'append' }, { id: 'p.ts::prod' }]);
     const b = fp('B', [{ id: 'reg.ts::REG', mode: 'append' }], { readSet: ['p.ts::prod'] });
     expect(classifyHazard(a, b).kind).toBe('RAW');
+  });
+
+  it('WAW outranks RAW: a true write-write conflict is never downgraded to ordering', () => {
+    // A and B both modify `shared` (WAW), AND B writes `x` that A reads (would be RAW alone).
+    // The strongest hazard must win — scheduling these as a mere ordering dependency would
+    // let a real conflict run concurrently.
+    const a = fp('A', [{ id: 's.ts::shared' }], { readSet: ['s.ts::x'] });
+    const b = fp('B', [{ id: 's.ts::shared' }, { id: 's.ts::x' }]);
+    const v = classifyHazard(a, b);
+    expect(v.kind).toBe('WAW');
+    expect(v.witnesses).toEqual(['s.ts::shared']);
   });
 
   it('WAR: same file, disjoint symbols is low-risk, not WAW', () => {

--- a/src/core/services/mcp-handlers/change-footprint.test.ts
+++ b/src/core/services/mcp-handlers/change-footprint.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeFootprint,
+  classifyHazard,
+  ambientFanInThreshold,
+  type Footprint,
+  type WriteMode,
+} from './change-footprint.js';
+import { buildAdjacency, bfs } from './graph.js';
+import type { FunctionNode, CallEdge, SerializedCallGraph } from '../../analyzer/call-graph.js';
+import type { FileChangeCoupling } from '../../provenance/change-coupling.js';
+
+// ---- fixture builders (mirrors landmark-signals.test.ts) ----
+
+function node(over: Partial<FunctionNode> & { id: string }): FunctionNode {
+  const [filePath, rest] = over.id.split('::');
+  return {
+    name: rest ?? over.id,
+    filePath: filePath ?? 'x.ts',
+    isAsync: false,
+    language: 'typescript',
+    startIndex: 0,
+    endIndex: 1,
+    fanIn: 0,
+    fanOut: 0,
+    ...over,
+  };
+}
+
+function edge(callerId: string, calleeId: string, confidence: CallEdge['confidence'] = 'import'): CallEdge {
+  return { callerId, calleeId, calleeName: calleeId.split('::')[1] ?? calleeId, confidence, kind: 'calls' };
+}
+
+function graph(nodes: FunctionNode[], edges: CallEdge[] = []): SerializedCallGraph {
+  return {
+    nodes,
+    edges,
+    classes: [],
+    inheritanceEdges: [],
+    hubFunctions: [],
+    entryPoints: [],
+    layerViolations: [],
+    stats: { totalNodes: nodes.length, totalEdges: edges.length, avgFanIn: 0, avgFanOut: 0 },
+  };
+}
+
+/** A four-symbol chain: entry → main → {greet → emit, emit}. */
+function chainGraph(): SerializedCallGraph {
+  const nodes = [
+    node({ id: 'a.ts::entry', fanIn: 0 }),
+    node({ id: 'a.ts::main', fanIn: 1 }),
+    node({ id: 'a.ts::greet', fanIn: 1 }),
+    node({ id: 'a.ts::emit', fanIn: 2 }),
+  ];
+  const edges = [
+    edge('a.ts::entry', 'a.ts::main'),
+    edge('a.ts::main', 'a.ts::greet'),
+    edge('a.ts::main', 'a.ts::emit'),
+    edge('a.ts::greet', 'a.ts::emit'),
+  ];
+  return graph(nodes, edges);
+}
+
+/** Build a minimal Footprint literal for classifier-only tests. */
+function fp(
+  taskId: string,
+  writes: Array<{ id: string; mode?: WriteMode; file?: string }>,
+  over: Partial<Footprint> = {},
+): Footprint {
+  return {
+    taskId,
+    writeSet: writes.map(w => ({
+      id: w.id,
+      name: w.id.split('::')[1] ?? w.id,
+      filePath: w.file ?? w.id.split('::')[0] ?? 'x.ts',
+      writeMode: w.mode ?? 'modify',
+    })),
+    readSet: [],
+    ambientReadDeps: [],
+    affectedSet: [],
+    couplingNeighbors: [],
+    unresolvedSeeds: [],
+    advisory: true,
+    disclosure: 'd',
+    ...over,
+  };
+}
+
+// ---- footprint computation ----
+
+describe('computeFootprint — three regions', () => {
+  it('expands a single symbol seed into write / read / affected regions', () => {
+    const g = chainGraph();
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] });
+
+    expect(f.writeSet.map(w => w.id)).toEqual(['a.ts::main']);
+    // read-set == forward call closure of the write-set
+    expect(f.readSet).toEqual(['a.ts::greet', 'a.ts::emit'].sort());
+    // affected-set == backward reachability (== blast radius) of the write-set
+    expect(f.affectedSet).toEqual(['a.ts::entry']);
+  });
+
+  it('the affected-set equals an independent backward blast-radius computation', () => {
+    const g = chainGraph();
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] });
+    const { backward } = buildAdjacency(g);
+    const blast = [...bfs(['a.ts::main'], backward, 2).keys()]
+      .filter(id => id !== 'a.ts::main')
+      .sort();
+    expect(f.affectedSet).toEqual(blast);
+  });
+
+  it('resolves a file seed to every symbol in the file (enclosing scope)', () => {
+    const g = chainGraph();
+    const f = computeFootprint(g, { id: 't1', seedFiles: ['a.ts'] });
+    expect(f.writeSet.map(w => w.id).sort()).toEqual(
+      ['a.ts::entry', 'a.ts::main', 'a.ts::greet', 'a.ts::emit'].sort(),
+    );
+  });
+
+  it('the write-set is declared (advisory), not inferred, and carries the disclosure', () => {
+    const g = chainGraph();
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] });
+    expect(f.advisory).toBe(true);
+    expect(f.disclosure).toMatch(/declared\/advisory/);
+    // declared only — no heuristic prediction of extra edit targets
+    expect(f.writeSet.map(w => w.id)).toEqual(['a.ts::main']);
+    expect(f.writeSet[0].writeMode).toBe('modify');
+  });
+
+  it('carries a caller-declared append writeMode without inferring it', () => {
+    const g = chainGraph();
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'], writeMode: 'append' });
+    expect(f.writeSet[0].writeMode).toBe('append');
+  });
+
+  it('an unresolved seed yields an empty footprint with an explicit note (no fabricated region)', () => {
+    const g = chainGraph();
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::doesNotExist'] });
+    expect(f.writeSet).toEqual([]);
+    expect(f.readSet).toEqual([]);
+    expect(f.affectedSet).toEqual([]);
+    expect(f.unresolvedSeeds).toEqual(['a.ts::doesNotExist']);
+  });
+
+  it('is byte-identical across re-evaluations of a fixed state (determinism)', () => {
+    const g = chainGraph();
+    const a = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] });
+    const b = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});
+
+describe('computeFootprint — coupling neighbors', () => {
+  it('surfaces a co-changing file as a separate advisory annotation, not in the static regions', () => {
+    const g = chainGraph();
+    const couplingLookup = (files: string[]): FileChangeCoupling[] =>
+      files.includes('a.ts')
+        ? [{ filePath: 'a.ts', churn: 10, coupledWith: [{ file: 'docs/guide.md', support: 4, confidence: 0.6 }] }]
+        : [];
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] }, { couplingLookup });
+    expect(f.couplingNeighbors).toEqual(['docs/guide.md']);
+    // never merged into static regions
+    expect(f.readSet).not.toContain('docs/guide.md');
+    expect(f.affectedSet).not.toContain('docs/guide.md');
+  });
+
+  it('excludes the write-set own files from coupling neighbors', () => {
+    const g = chainGraph();
+    const couplingLookup = (): FileChangeCoupling[] => [
+      { filePath: 'a.ts', churn: 10, coupledWith: [{ file: 'a.ts', support: 5, confidence: 0.9 }] },
+    ];
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] }, { couplingLookup });
+    expect(f.couplingNeighbors).toEqual([]);
+  });
+});
+
+// ---- ambient symbol exclusion ----
+
+describe('ambientFanInThreshold', () => {
+  it('returns the fan-in value at the configured percentile', () => {
+    const g = graph([
+      node({ id: 'x.ts::a', fanIn: 0 }),
+      node({ id: 'x.ts::b', fanIn: 1 }),
+      node({ id: 'x.ts::c', fanIn: 2 }),
+      node({ id: 'x.ts::hub', fanIn: 100 }),
+    ]);
+    // p99 of [0,1,2,100] → index ceil(0.99*3)=3 → value 100; only fanIn>100 would be ambient.
+    expect(ambientFanInThreshold(g, { ambientFanInPercentile: 0.99 })).toBe(100);
+    // p50 → index ceil(0.5*3)=2 → value 2; symbols with fanIn>2 (the hub) are ambient.
+    expect(ambientFanInThreshold(g, { ambientFanInPercentile: 0.5 })).toBe(2);
+  });
+});
+
+describe('computeFootprint — ambient exclusion', () => {
+  function ambientGraph(): SerializedCallGraph {
+    // main → helper (normal), main → logger (ambient, high fan-in)
+    const nodes = [
+      node({ id: 'a.ts::main', fanIn: 1 }),
+      node({ id: 'a.ts::helper', fanIn: 1 }),
+      node({ id: 'log.ts::logger', fanIn: 100 }),
+    ];
+    const edges = [edge('a.ts::main', 'a.ts::helper'), edge('a.ts::main', 'log.ts::logger')];
+    return graph(nodes, edges);
+  }
+
+  it('excludes an ambient symbol from the read-set and discloses it under ambientReadDeps', () => {
+    const g = ambientGraph();
+    const f = computeFootprint(g, { id: 't1', seedSymbols: ['a.ts::main'] }, { ambientFanInThreshold: 50 });
+    expect(f.readSet).toEqual(['a.ts::helper']);
+    expect(f.ambientReadDeps).toEqual(['log.ts::logger']);
+  });
+});
+
+// ---- pairwise hazard classification ----
+
+describe('classifyHazard', () => {
+  it('WAW: a shared written symbol with a modify side', () => {
+    const a = fp('A', [{ id: 's.ts::shared' }]);
+    const b = fp('B', [{ id: 's.ts::shared' }]);
+    expect(classifyHazard(a, b)).toEqual({ kind: 'WAW', witnesses: ['s.ts::shared'] });
+  });
+
+  it('shared-append: concurrent appends to a registration symbol are NOT WAW', () => {
+    const a = fp('A', [{ id: 'reg.ts::TOOL_DEFINITIONS', mode: 'append' }]);
+    const b = fp('B', [{ id: 'reg.ts::TOOL_DEFINITIONS', mode: 'append' }]);
+    expect(classifyHazard(a, b)).toEqual({
+      kind: 'shared-append',
+      witnesses: ['reg.ts::TOOL_DEFINITIONS'],
+    });
+  });
+
+  it('shared-append downgrades to WAW if either side declares modify', () => {
+    const a = fp('A', [{ id: 'reg.ts::TOOL_DEFINITIONS', mode: 'append' }]);
+    const b = fp('B', [{ id: 'reg.ts::TOOL_DEFINITIONS', mode: 'modify' }]);
+    expect(classifyHazard(a, b).kind).toBe('WAW');
+  });
+
+  it('RAW: one task writes a symbol the other reads, with direction B after A', () => {
+    const a = fp('A', [{ id: 'm.ts::producer' }]);
+    const b = fp('B', [{ id: 'm.ts::consumer' }], { readSet: ['m.ts::producer'] });
+    expect(classifyHazard(a, b)).toEqual({
+      kind: 'RAW',
+      witnesses: ['m.ts::producer'],
+      direction: 'B after A',
+    });
+  });
+
+  it('RAW: records bidirectional when each writes what the other reads', () => {
+    const a = fp('A', [{ id: 'm.ts::x' }], { readSet: ['m.ts::y'] });
+    const b = fp('B', [{ id: 'm.ts::y' }], { readSet: ['m.ts::x'] });
+    const v = classifyHazard(a, b);
+    expect(v.kind).toBe('RAW');
+    expect(v.direction).toBe('bidirectional');
+    expect(v.witnesses).toEqual(['m.ts::x', 'm.ts::y']);
+  });
+
+  it('RAW outranks shared-append when both apply', () => {
+    // both append the registry, AND B reads what A writes elsewhere
+    const a = fp('A', [{ id: 'reg.ts::REG', mode: 'append' }, { id: 'p.ts::prod' }]);
+    const b = fp('B', [{ id: 'reg.ts::REG', mode: 'append' }], { readSet: ['p.ts::prod'] });
+    expect(classifyHazard(a, b).kind).toBe('RAW');
+  });
+
+  it('WAR: same file, disjoint symbols is low-risk, not WAW', () => {
+    const a = fp('A', [{ id: 'shared.ts::alpha' }]);
+    const b = fp('B', [{ id: 'shared.ts::beta' }]);
+    expect(classifyHazard(a, b)).toEqual({ kind: 'WAR', witnesses: ['shared.ts'] });
+  });
+
+  it('WAR: a read-only overlap is low-risk', () => {
+    const a = fp('A', [{ id: 'a.ts::one' }], { readSet: ['lib.ts::util'] });
+    const b = fp('B', [{ id: 'b.ts::two' }], { readSet: ['lib.ts::util'] });
+    expect(classifyHazard(a, b)).toEqual({ kind: 'WAR', witnesses: ['lib.ts::util'] });
+  });
+
+  it('soft-coupling: co-change with no static relation is advisory only', () => {
+    const a = fp('A', [{ id: 'a.ts::one', file: 'a.ts' }], { couplingNeighbors: ['b.ts'] });
+    const b = fp('B', [{ id: 'b.ts::two', file: 'b.ts' }]);
+    expect(classifyHazard(a, b)).toEqual({ kind: 'soft-coupling', witnesses: ['b.ts'] });
+  });
+
+  it('none: fully disjoint footprints', () => {
+    const a = fp('A', [{ id: 'a.ts::one', file: 'a.ts' }], { readSet: ['a.ts::dep'] });
+    const b = fp('B', [{ id: 'b.ts::two', file: 'b.ts' }], { readSet: ['b.ts::dep'] });
+    expect(classifyHazard(a, b)).toEqual({ kind: 'none', witnesses: [] });
+  });
+
+  // ---- ambient interaction with RAW ----
+
+  it('a shared ambient read dependency does NOT create a RAW edge (tasks stay independent)', () => {
+    const a = fp('A', [{ id: 'a.ts::one', file: 'a.ts' }], { ambientReadDeps: ['log.ts::logger'] });
+    const b = fp('B', [{ id: 'b.ts::two', file: 'b.ts' }], { ambientReadDeps: ['log.ts::logger'] });
+    expect(classifyHazard(a, b).kind).toBe('none');
+  });
+
+  it('writing an ambient symbol the other reads STILL creates a RAW hazard', () => {
+    const a = fp('A', [{ id: 'log.ts::logger', file: 'log.ts' }]);
+    const b = fp('B', [{ id: 'b.ts::two', file: 'b.ts' }], { ambientReadDeps: ['log.ts::logger'] });
+    expect(classifyHazard(a, b)).toEqual({
+      kind: 'RAW',
+      witnesses: ['log.ts::logger'],
+      direction: 'B after A',
+    });
+  });
+
+  it('is deterministic and symmetric in classification kind', () => {
+    const a = fp('A', [{ id: 'm.ts::producer' }]);
+    const b = fp('B', [{ id: 'm.ts::consumer' }], { readSet: ['m.ts::producer'] });
+    expect(classifyHazard(a, b).kind).toBe(classifyHazard(b, a).kind);
+  });
+});

--- a/src/core/services/mcp-handlers/change-footprint.ts
+++ b/src/core/services/mcp-handlers/change-footprint.ts
@@ -1,0 +1,410 @@
+/**
+ * Change footprint projection + pairwise hazard classification
+ * (change: add-change-footprint-projection, the foundation of
+ * PARALLEL-WORK-COORDINATION).
+ *
+ * Generalizes `blast_radius` from "one symbol" to "a declared task": given a
+ * caller-supplied {@link TaskDescriptor}, compute a deterministic three-region
+ * {@link Footprint} (write / read / affected) plus a soft co-change annotation,
+ * and a pure {@link classifyHazard} over two footprints returning the strongest
+ * data-hazard between them (WAW / shared-append / RAW / WAR / soft-coupling /
+ * none).
+ *
+ * Design invariants (mirrors the proposal's Decision + Scope contract):
+ * - **Borrow-checker, not a lock.** Everything here is a pure function of the
+ *   graph state, the change-coupling store, and the descriptor — no persistence,
+ *   no clock, no new MCP tool, no graph-schema change. The consumer
+ *   (`plan_parallel_work`, proposal 2) holds any state.
+ * - **Declared, not inferred.** The write-set is the caller's declared seeds,
+ *   normalized to enclosing scope — never a prediction of the edits an agent
+ *   will make. It is reported as advisory with a known-unknowable disclosure.
+ * - **Reuse, don't reinvent.** The affected-set is the existing backward
+ *   reachability (`bfs` over the same adjacency `analyze_impact`/`blast_radius`
+ *   use); the read-set is the existing call-distance-scoped forward closure
+ *   (`weightedBfs`); coupling-neighbors come from the existing change-coupling
+ *   store thresholds. No new traversal semantics.
+ * - **Honesty over coverage.** An unresolved seed yields an empty footprint with
+ *   an explicit note, never a fabricated region. Ambient (ubiquitous) symbols
+ *   are excluded from the read-set and from generating RAW edges, but a
+ *   deliberate *write* of an ambient symbol still creates a hazard.
+ */
+
+import type { SerializedCallGraph, FunctionNode } from '../../analyzer/call-graph.js';
+import type { FileChangeCoupling } from '../../provenance/change-coupling.js';
+import { buildAdjacency, bfs, buildWeightedAdjacency, weightedBfs } from './graph.js';
+
+/** Whether a declared write is a pure append to a registration site or a modify of existing code. */
+export type WriteMode = 'append' | 'modify';
+
+/**
+ * A unit of proposed work, described by the *caller* (an agent or human) — never
+ * invented by the system. At least one seed (symbol or file) is required.
+ */
+export interface TaskDescriptor {
+  /** Caller-chosen id, unique within a single planning call. */
+  id: string;
+  /** Symbol names or canonical ids the task will edit. */
+  seedSymbols?: string[];
+  /** File paths the task will edit (every symbol in the file enters the write-set). */
+  seedFiles?: string[];
+  /** Optional free text — used only by the caller to widen sparse seeds via semantic search, never to guess edits. */
+  intent?: string;
+  /**
+   * Caller-declared annotation that this task's seeds are pure *additions* to a
+   * registration site (a new switch case, a new array/registry entry) rather
+   * than a change to existing code. Default `modify` (the conservative
+   * assumption). Never inferred by the system.
+   */
+  writeMode?: WriteMode;
+}
+
+/** A symbol in a footprint region. */
+export interface FootprintMember {
+  id: string;
+  name: string;
+  filePath: string;
+}
+
+/** A write-set member, carrying its declared write mode. */
+export interface WriteMember extends FootprintMember {
+  writeMode: WriteMode;
+}
+
+/**
+ * The footprint of one task: three structural regions plus a soft co-change
+ * annotation. A deterministic function of (graph, coupling, descriptor).
+ */
+export interface Footprint {
+  taskId: string;
+  /**
+   * The declared region the task is expected to modify: its seeds resolved to
+   * symbols and normalized to enclosing scope, each carrying its declared
+   * `writeMode`. Advisory — see {@link Footprint.advisory}.
+   */
+  writeSet: WriteMember[];
+  /**
+   * Forward call closure (callees/dependencies) of the write-set, bounded by the
+   * existing call-distance scoping and with ambient symbols excluded. The region
+   * the task reads to function.
+   */
+  readSet: string[];
+  /**
+   * Ambient (ubiquitous, high-fan-in) symbols that were in the forward closure
+   * but excluded from {@link Footprint.readSet}. Disclosed for transparency and
+   * retained so that a peer task's deliberate *write* of one still raises a RAW
+   * hazard (the ambient exclusion applies to read membership, not to a write).
+   */
+  ambientReadDeps: string[];
+  /**
+   * Backward reachability (callers) of the write-set — equivalent to the blast
+   * radius of the write-set. Informational human-facing output only; NOT an
+   * input to {@link classifyHazard}.
+   */
+  affectedSet: string[];
+  /**
+   * Files that co-change with the write-set's files above the existing support
+   * and confidence thresholds, with no requirement of a static call relation.
+   * A separate advisory annotation — never merged into the static regions.
+   */
+  couplingNeighbors: string[];
+  /** Seeds that resolved to nothing in the graph (unknown symbol / untracked file). */
+  unresolvedSeeds: string[];
+  /** The write-set is always a *declared* region, not a prediction. */
+  advisory: true;
+  /** Known-unknowable disclosure carried with every footprint. */
+  disclosure: string;
+}
+
+/** The data-hazard between two footprints. */
+export type HazardKind = 'WAW' | 'shared-append' | 'RAW' | 'WAR' | 'soft-coupling' | 'none';
+
+export interface HazardVerdict {
+  kind: HazardKind;
+  /**
+   * The witnessing symbol ids (or file paths, for `WAR` same-file and
+   * `soft-coupling`) that explain the verdict. Sorted for determinism.
+   */
+  witnesses: string[];
+  /** For the ordering hazard `RAW`: which task must run after which. */
+  direction?: 'A after B' | 'B after A' | 'bidirectional';
+}
+
+export interface FootprintOptions {
+  /** Hop-depth for the backward (affected) reachability. Default {@link FOOTPRINT_AFFECTED_MAX_DEPTH}. */
+  affectedMaxDepth?: number;
+  /** Call-distance bound for the forward (read) closure. Default {@link FOOTPRINT_READ_MAX_DISTANCE}. */
+  readMaxDistance?: number;
+  /** Fan-in percentile above which a symbol is treated as ambient. Default {@link AMBIENT_FANIN_PERCENTILE}. */
+  ambientFanInPercentile?: number;
+  /**
+   * Absolute fan-in threshold for ambient classification, overriding the
+   * percentile when set (a symbol is ambient iff `fanIn > this`). Primarily for
+   * deterministic tests; production uses the percentile.
+   */
+  ambientFanInThreshold?: number;
+  /**
+   * Extra seed ids the caller derived from `intent` via semantic search. Kept
+   * out of the pure core so this function stays deterministic and I/O-free; the
+   * caller (proposal 2) performs the search and passes the resulting candidate
+   * ids here. Never fabricates a write target — only widens declared seeds.
+   */
+  extraSeedIds?: string[];
+  /**
+   * Change-coupling lookup, injected so the core stays pure and testable. The
+   * real consumer passes `edgeStore.getChangeCouplingForFiles`; tests pass a
+   * fixture. When absent, `couplingNeighbors` is empty.
+   */
+  couplingLookup?: (files: string[]) => FileChangeCoupling[];
+}
+
+/** Hop-depth for the backward (affected) reachability — mirrors `analyze_impact`'s default. */
+export const FOOTPRINT_AFFECTED_MAX_DEPTH = 2;
+/**
+ * Call-distance bound for the forward (read) closure. Smaller than pathfind's
+ * `PATH_MAX_DISTANCE` (12) because a read-set is the task's near dependencies,
+ * not a whole-program reach: 6 admits a handful of strongly-resolved hops (cost
+ * 1 each) or fewer weakly-resolved ones (cost 2–4).
+ */
+export const FOOTPRINT_READ_MAX_DISTANCE = 6;
+/**
+ * Fan-in percentile above which a symbol is "ambient" (ubiquitous infrastructure
+ * — a logger, a directory validator, the call-graph primitives). The top ~1% of
+ * symbols by fan-in carry no real ordering signal and would bloat read-sets
+ * toward the whole graph, so they are excluded from read-sets and from
+ * generating RAW edges.
+ */
+export const AMBIENT_FANIN_PERCENTILE = 0.99;
+
+const DISCLOSURE =
+  'The write-set is a declared/advisory region, not a prediction of every edit; ' +
+  'an agent may edit outside it (proposal 3 checks for that). Static footprints ' +
+  'reduce conflict probability and shift detection left — integration tests remain ' +
+  'the ground truth for safe parallelism.';
+
+/**
+ * The deterministic ambient fan-in threshold for a graph: a symbol is ambient
+ * iff its fan-in strictly exceeds this value. Derived from the fan-in
+ * distribution at the configured percentile (or an explicit override). Symbols
+ * with the value at the percentile index are NOT ambient — only those above it.
+ */
+export function ambientFanInThreshold(graph: SerializedCallGraph, opts: FootprintOptions = {}): number {
+  if (opts.ambientFanInThreshold !== undefined) return opts.ambientFanInThreshold;
+  const percentile = opts.ambientFanInPercentile ?? AMBIENT_FANIN_PERCENTILE;
+  const fanIns = graph.nodes
+    .filter(n => !n.isExternal)
+    .map(n => n.fanIn ?? 0)
+    .sort((a, b) => a - b);
+  if (fanIns.length === 0) return Infinity;
+  const idx = Math.min(fanIns.length - 1, Math.ceil(percentile * (fanIns.length - 1)));
+  return fanIns[idx];
+}
+
+/** Resolve a single seed (canonical id, exact symbol name, or file path) to graph node ids. */
+function resolveSeed(
+  seed: string,
+  nodeById: Map<string, FunctionNode>,
+  nodesByName: Map<string, FunctionNode[]>,
+  fileToNodeIds: Map<string, string[]>,
+): string[] {
+  // 1. Exact canonical id.
+  if (nodeById.has(seed)) return [seed];
+  // 2. File path — every symbol declared in the file is in scope (the file is the enclosing scope).
+  const fileIds = fileToNodeIds.get(seed);
+  if (fileIds && fileIds.length > 0) return fileIds;
+  // 3. Exact symbol name (may resolve to several overloads/definitions — all are declared targets).
+  const named = nodesByName.get(seed);
+  if (named && named.length > 0) return named.map(n => n.id);
+  return [];
+}
+
+/**
+ * Compute the footprint of one task descriptor over a serialized call graph.
+ * Pure and deterministic for a fixed (graph, coupling, descriptor) — the same
+ * inputs always yield a byte-identical footprint.
+ */
+export function computeFootprint(
+  graph: SerializedCallGraph,
+  descriptor: TaskDescriptor,
+  opts: FootprintOptions = {},
+): Footprint {
+  const writeMode: WriteMode = descriptor.writeMode ?? 'modify';
+
+  const nodeById = new Map(graph.nodes.map(n => [n.id, n]));
+  const nodesByName = new Map<string, FunctionNode[]>();
+  const fileToNodeIds = new Map<string, string[]>();
+  for (const n of graph.nodes) {
+    (nodesByName.get(n.name) ?? nodesByName.set(n.name, []).get(n.name)!).push(n);
+    (fileToNodeIds.get(n.filePath) ?? fileToNodeIds.set(n.filePath, []).get(n.filePath)!).push(n.id);
+  }
+
+  const rawSeeds = [
+    ...(descriptor.seedSymbols ?? []),
+    ...(descriptor.seedFiles ?? []),
+    ...(opts.extraSeedIds ?? []),
+  ];
+
+  const writeIds = new Set<string>();
+  const unresolvedSeeds: string[] = [];
+  for (const seed of rawSeeds) {
+    const ids = resolveSeed(seed, nodeById, nodesByName, fileToNodeIds);
+    if (ids.length === 0) unresolvedSeeds.push(seed);
+    else for (const id of ids) writeIds.add(id);
+  }
+
+  // Unresolved-only descriptor → empty footprint with a note, never a fabricated region.
+  if (writeIds.size === 0) {
+    return {
+      taskId: descriptor.id,
+      writeSet: [],
+      readSet: [],
+      ambientReadDeps: [],
+      affectedSet: [],
+      couplingNeighbors: [],
+      unresolvedSeeds: [...new Set(unresolvedSeeds)].sort(),
+      advisory: true,
+      disclosure: DISCLOSURE,
+    };
+  }
+
+  const writeSet: WriteMember[] = [...writeIds]
+    .map(id => nodeById.get(id)!)
+    .map(n => ({ id: n.id, name: n.name, filePath: n.filePath, writeMode }))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+  // --- read-set: call-distance-scoped forward closure, ambient excluded ---
+  const threshold = ambientFanInThreshold(graph, opts);
+  const isAmbient = (id: string): boolean => {
+    const n = nodeById.get(id);
+    return !!n && (n.fanIn ?? 0) > threshold;
+  };
+
+  const weighted = buildWeightedAdjacency(graph);
+  const readMaxDistance = opts.readMaxDistance ?? FOOTPRINT_READ_MAX_DISTANCE;
+  const forwardReach = weightedBfs([...writeIds], weighted.forward, readMaxDistance);
+
+  const readSet: string[] = [];
+  const ambientReadDeps: string[] = [];
+  for (const id of forwardReach.keys()) {
+    if (writeIds.has(id)) continue; // a written symbol is not "read"
+    if (!nodeById.has(id)) continue; // skip synthetic/external leaves
+    if (isAmbient(id)) ambientReadDeps.push(id);
+    else readSet.push(id);
+  }
+  readSet.sort();
+  ambientReadDeps.sort();
+
+  // --- affected-set: hop-depth backward reachability (== blast radius) ---
+  const { backward } = buildAdjacency(graph);
+  const affectedMaxDepth = opts.affectedMaxDepth ?? FOOTPRINT_AFFECTED_MAX_DEPTH;
+  const backwardReach = bfs([...writeIds], backward, affectedMaxDepth);
+  const affectedSet = [...backwardReach.keys()]
+    .filter(id => !writeIds.has(id) && nodeById.has(id))
+    .sort();
+
+  // --- coupling-neighbors: advisory co-change annotation ---
+  const writeFiles = [...new Set(writeSet.map(w => w.filePath))];
+  const couplingNeighbors = computeCouplingNeighbors(writeFiles, opts.couplingLookup);
+
+  return {
+    taskId: descriptor.id,
+    writeSet,
+    readSet,
+    ambientReadDeps,
+    affectedSet,
+    couplingNeighbors,
+    unresolvedSeeds: [...new Set(unresolvedSeeds)].sort(),
+    advisory: true,
+    disclosure: DISCLOSURE,
+  };
+}
+
+/** Files co-changing with the write-set's files above threshold, excluding the write-set's own files. */
+function computeCouplingNeighbors(
+  writeFiles: string[],
+  couplingLookup?: (files: string[]) => FileChangeCoupling[],
+): string[] {
+  if (!couplingLookup || writeFiles.length === 0) return [];
+  const own = new Set(writeFiles);
+  const neighbors = new Set<string>();
+  for (const rec of couplingLookup(writeFiles)) {
+    for (const c of rec.coupledWith) {
+      if (!own.has(c.file)) neighbors.add(c.file);
+    }
+  }
+  return [...neighbors].sort();
+}
+
+/** Sorted set intersection of two id arrays. */
+function intersectSorted(a: Iterable<string>, b: Set<string>): string[] {
+  const out: string[] = [];
+  for (const x of a) if (b.has(x)) out.push(x);
+  return out.sort();
+}
+
+/**
+ * Classify the strongest data-hazard between two footprints. A pure function:
+ * the verdict is a deterministic, byte-identical function of the two footprints.
+ *
+ * Precedence (strongest first): WAW > RAW > shared-append > WAR > soft-coupling
+ * > none. RAW outranks shared-append because an ordering constraint is stronger
+ * than a low-risk "appends merge trivially" advisory.
+ */
+export function classifyHazard(a: Footprint, b: Footprint): HazardVerdict {
+  const writeModeA = new Map(a.writeSet.map(w => [w.id, w.writeMode]));
+  const writeModeB = new Map(b.writeSet.map(w => [w.id, w.writeMode]));
+  const writeIdsA = new Set(writeModeA.keys());
+  const writeIdsB = new Set(writeModeB.keys());
+
+  const sharedWrites = intersectSorted(writeIdsA, writeIdsB);
+
+  // --- WAW: shared write where at least one side modifies ---
+  const wawWitnesses = sharedWrites.filter(
+    id => writeModeA.get(id) === 'modify' || writeModeB.get(id) === 'modify',
+  );
+  if (wawWitnesses.length > 0) {
+    return { kind: 'WAW', witnesses: wawWitnesses };
+  }
+
+  // --- RAW: one writes what the other reads (ambient excluded from read membership,
+  // but a deliberate write of an ambient symbol still counts via ambientReadDeps) ---
+  const readMembA = new Set([...a.readSet, ...a.ambientReadDeps]);
+  const readMembB = new Set([...b.readSet, ...b.ambientReadDeps]);
+  const aWritesBReads = intersectSorted(writeIdsA, readMembB); // B reads A's writes → B after A
+  const bWritesAReads = intersectSorted(writeIdsB, readMembA); // A reads B's writes → A after B
+  if (aWritesBReads.length > 0 || bWritesAReads.length > 0) {
+    const direction: HazardVerdict['direction'] =
+      aWritesBReads.length > 0 && bWritesAReads.length > 0
+        ? 'bidirectional'
+        : aWritesBReads.length > 0
+          ? 'B after A'
+          : 'A after B';
+    const witnesses = [...new Set([...aWritesBReads, ...bWritesAReads])].sort();
+    return { kind: 'RAW', witnesses, direction };
+  }
+
+  // --- shared-append: write∩write where both sides append every shared symbol ---
+  if (sharedWrites.length > 0) {
+    return { kind: 'shared-append', witnesses: sharedWrites };
+  }
+
+  // --- WAR / low-risk: same file disjoint symbols, or read-only overlap (ambient excluded) ---
+  const filesA = new Set(a.writeSet.map(w => w.filePath));
+  const filesB = new Set(b.writeSet.map(w => w.filePath));
+  const sharedFiles = intersectSorted(filesA, filesB);
+  const sharedReads = intersectSorted(a.readSet, new Set(b.readSet));
+  if (sharedFiles.length > 0 || sharedReads.length > 0) {
+    const witnesses = [...new Set([...sharedFiles, ...sharedReads])].sort();
+    return { kind: 'WAR', witnesses };
+  }
+
+  // --- soft-coupling: write-set files co-change, no static relation ---
+  const softWitnesses = [
+    ...intersectSorted(a.couplingNeighbors, filesB),
+    ...intersectSorted(b.couplingNeighbors, filesA),
+  ];
+  if (softWitnesses.length > 0) {
+    return { kind: 'soft-coupling', witnesses: [...new Set(softWitnesses)].sort() };
+  }
+
+  return { kind: 'none', witnesses: [] };
+}


### PR DESCRIPTION
## What

The **borrow-analysis core** of the `PARALLEL-WORK-COORDINATION` set (proposal 1, the foundation). It generalizes `blast_radius` from *one symbol* to *a declared task*, and adds the conflict semantics every downstream proposal in that set will consume — a "borrow checker for the repository," computed deterministically from the call graph + change-coupling store.

Two pure functions in `src/core/services/mcp-handlers/change-footprint.ts`:

1. **`computeFootprint(graph, descriptor, opts)`** → a per-task footprint in three regions plus a soft annotation:
   - **write-set** — caller-declared seeds normalized to enclosing scope, each carrying its declared `writeMode` (`append`|`modify`, default `modify`). Advisory — *declared, never inferred*.
   - **read-set** — call-distance-scoped forward closure (`weightedBfs`), with **ambient** (high-fan-in) symbols excluded so pervasive infrastructure doesn't bloat the set or serialize independent work.
   - **affected-set** — backward reachability == `blast_radius` of the write-set (informational only; **not** a hazard input).
   - **coupling-neighbors** — files co-changing above the existing thresholds, a separate advisory annotation.

2. **`classifyHazard(a, b)`** → the strongest data-hazard between two footprints, precedence **WAW > RAW > shared-append > WAR > soft-coupling > none**, with witnesses and (for RAW) direction.

## Why it stays in-substrate

- No new MCP tool, no graph-schema change, no persistence, no clock, no LLM — pure functions of (graph, coupling, descriptor). Reuses `buildAdjacency`/`bfs`/`buildWeightedAdjacency`/`weightedBfs` and the change-coupling store.
- **Honesty over coverage:** unresolved seed → empty footprint + explicit note (no fabricated region); the write-set carries a known-unknowable disclosure.
- The `shared-append` class + ambient-symbol exclusion are exactly the two refinements the proposal's validation exercise forced, so registration hot-spots (`dispatchTool`, `TOOL_DEFINITIONS`) don't collapse all parallelism.

## Verification

- **31 co-located unit tests** — 24 covering every spec scenario (three regions, declared-not-inferred, unresolved-seed note, coupling-as-advisory, all six hazard classes, ambient RAW interaction, determinism) plus 7 adversarial regression tests (WAW-over-RAW precedence, the `extraSeedIds` seam, partial seed resolution, the distance/depth overrides, combined file+symbol seeds).
- Full CI suite green: **245 files, 4893 pass / 2 skip**; `lint` + `typecheck` + `build` clean.
- **Dogfooded on this repo's real 5932-node graph** — reproduces the validation exercise's `shared-append` on `dispatchTool`, directed RAW on `handleStructuralDiff`, byte-identical determinism, and fail-soft on an unindexed seed. See `DOGFOOD-change-footprint-projection.md`.

## Scope

Foundation only. The agent-facing tool (`plan_parallel_work`), escape detection, and the cross-actor map are proposals 2–4 and ship separately; this PR adds the primitive they consume. Spec delta: `openspec/changes/add-change-footprint-projection/specs/analyzer/spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
