### PR TITLE
fix(viewer): clear selection on cluster collapse to kill ghost edges

### DIFF
--- a/src/viewer/InteractiveGraphViewer.jsx
+++ b/src/viewer/InteractiveGraphViewer.jsx
@@ -268,12 +268,23 @@ export default function App({ graphUrl, mappingUrl = '/api/mapping', specUrl = '
   );
 
   const toggleCluster = useCallback((cid) => {
+    const collapsing = expandedClusters.has(cid);
+    // If we're collapsing the cluster that holds the selected node, clear the
+    // selection — otherwise its edges keep rendering from the (now empty)
+    // cluster center as ghost edges. Mirrors the chat-collapse guard above.
+    if (collapsing && selectedId) {
+      const selNode = graph?.nodes.find((n) => n.id === selectedId);
+      if (selNode && selNode.cluster?.id === cid) {
+        setSelectedId(null);
+        setAffectedIds([]);
+      }
+    }
     setExpandedClusters((prev) => {
       const next = new Set(prev);
       next.has(cid) ? next.delete(cid) : next.add(cid);
       return next;
     });
-  }, []);
+  }, [expandedClusters, selectedId, graph]);
 
   const clearSelection = useCallback(() => {
     setSelectedId(null);

--- a/src/viewer/InteractiveGraphViewer.jsx
+++ b/src/viewer/InteractiveGraphViewer.jsx
@@ -7,6 +7,7 @@ import {
   parseGraph,
   enrichGraphWithRefactors,
   computeBlast,
+  selectionBelongsToCluster,
 } from './utils/graph-helpers.js';
 import { FlatGraph } from './components/FlatGraph.jsx';
 import { ClusterGraph } from './components/ClusterGraph.jsx';
@@ -272,12 +273,9 @@ export default function App({ graphUrl, mappingUrl = '/api/mapping', specUrl = '
     // If we're collapsing the cluster that holds the selected node, clear the
     // selection — otherwise its edges keep rendering from the (now empty)
     // cluster center as ghost edges. Mirrors the chat-collapse guard above.
-    if (collapsing && selectedId) {
-      const selNode = graph?.nodes.find((n) => n.id === selectedId);
-      if (selNode && selNode.cluster?.id === cid) {
-        setSelectedId(null);
-        setAffectedIds([]);
-      }
+    if (collapsing && selectionBelongsToCluster(graph, selectedId, cid)) {
+      setSelectedId(null);
+      setAffectedIds([]);
     }
     setExpandedClusters((prev) => {
       const next = new Set(prev);

--- a/src/viewer/components/ClusterGraph.jsx
+++ b/src/viewer/components/ClusterGraph.jsx
@@ -214,7 +214,7 @@ export function ClusterGraph({
 
             return edges
               .filter((e) => e.source === selectedId || e.target === selectedId)
-              .map((e, i) => {
+              .map((e) => {
                 const sp = getNodePos(e.source);
                 const tp = getNodePos(e.target);
                 if (!sp || !tp) return null;
@@ -226,7 +226,7 @@ export function ClusterGraph({
                 const isOut = e.source === selectedId;
                 return (
                   <line
-                    key={i}
+                    key={e.id ?? `${e.source}->${e.target}`}
                     x1={sp.x + nx * 14}
                     y1={sp.y + ny * 14}
                     x2={tp.x - nx * 19}

--- a/src/viewer/utils/graph-helpers.js
+++ b/src/viewer/utils/graph-helpers.js
@@ -155,6 +155,16 @@ export function computeBlast(edges, nodeId) {
   return [...affected];
 }
 
+// True when the currently-selected node lives inside the cluster being
+// collapsed. Collapsing that cluster hides the node's marker but its
+// selection edges would otherwise keep rendering from the (now empty)
+// cluster center as ghost edges — callers clear the selection when this holds.
+export function selectionBelongsToCluster(graph, selectedId, clusterId) {
+  if (!graph || !selectedId || !clusterId) return false;
+  const node = graph.nodes?.find((n) => n.id === selectedId);
+  return !!node && node.cluster?.id === clusterId;
+}
+
 export function computeLayout(nodes, edges, W = 900, H = 540) {
   if (!nodes.length) return {};
   const pos = {};

--- a/src/viewer/utils/graph-helpers.test.ts
+++ b/src/viewer/utils/graph-helpers.test.ts
@@ -1,4 +1,4 @@
-import { parseGraph } from './graph-helpers.js';
+import { parseGraph, selectionBelongsToCluster } from './graph-helpers.js';
 
 describe('parseGraph', () => {
   it('should parse structuralClusters and directoryClusters from raw data', () => {
@@ -35,5 +35,40 @@ describe('parseGraph', () => {
 
     expect(result.structuralClusters).toEqual([]);
     expect(result.directoryClusters).toEqual([]);
+  });
+});
+
+describe('selectionBelongsToCluster', () => {
+  const graph = {
+    nodes: [
+      { id: 'a', cluster: { id: 'c1' } },
+      { id: 'b', cluster: { id: 'c2' } },
+      { id: 'c', cluster: null },
+    ],
+  };
+
+  it('is true when the selected node lives in the collapsing cluster', () => {
+    // guards the ghost-edge fix: selection must be cleared on this collapse
+    expect(selectionBelongsToCluster(graph, 'a', 'c1')).toBe(true);
+  });
+
+  it('is false when the selected node is in a different cluster', () => {
+    expect(selectionBelongsToCluster(graph, 'b', 'c1')).toBe(false);
+  });
+
+  it('is false when nothing is selected', () => {
+    expect(selectionBelongsToCluster(graph, null, 'c1')).toBe(false);
+  });
+
+  it('is false when the selected id is not in the graph', () => {
+    expect(selectionBelongsToCluster(graph, 'missing', 'c1')).toBe(false);
+  });
+
+  it('is false for a node with no cluster', () => {
+    expect(selectionBelongsToCluster(graph, 'c', 'c1')).toBe(false);
+  });
+
+  it('handles a missing graph without throwing', () => {
+    expect(selectionBelongsToCluster(null, 'a', 'c1')).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

In `openlore view` (clusters graph), collapsing a cluster while one of its member nodes was selected left the node-level selection edges rendering from the collapsed cluster's **center** — bright lines fanning out from an empty bubble to nodes across the graph. Since the "clear" button collapses all clusters, this also surfaced as ghost edges lingering after clear.

## Root cause

The "Node-level edges when a node is selected" block in `ClusterGraph.jsx` renders whenever `selectedId` is set. Its position helper falls back to the cluster center:

```js
if (nodeLayouts[clId]?.[nid]) return nodeLayouts[clId][nid];
return clusterPos[clId] || null;   // ← draws edge from collapsed cluster center = ghost
```

An existing guard in `InteractiveGraphViewer.jsx` clears the selection on the **chat-driven** collapse path, but `toggleCluster` (manual bubble click) never did — same bug class, uncovered path.

## Fix

- **`toggleCluster`**: when collapsing the cluster that holds the selected node, clear `selectedId`/`affectedIds` (mirrors the chat-collapse guard).
- **`ClusterGraph` selection-edge map**: replace index key (`key={i}`) with a stable edge-id key so reconciliation can't leave stale `<line>`s.

## Verification (browser automation)

- Collapse-while-selected: selection edges **9 → 0** after fix.
- Select / deselect / clear sequence: **0% pixel diff** against a pristine baseline; DOM clean (0 selection lines, 0 node-glow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)