### PR TITLE
fix(grammar): pin tree-sitter-c-sharp to ^0.21.3 to fix C# analysis on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "tree-sitter": "^0.22.4",
     "tree-sitter-bash": "^0.23.3",
     "tree-sitter-c": "^0.23.6",
-    "tree-sitter-c-sharp": "^0.23.1",
+    "tree-sitter-c-sharp": "^0.21.3",
     "tree-sitter-cpp": "^0.23.4",
     "tree-sitter-elixir": "^0.3.5",
     "tree-sitter-go": "^0.23.4",


### PR DESCRIPTION
## Problem

After a fresh `npm install -g openlore`, running `openlore analyze` on any C# (.NET) project prints this warning and produces zero call-graph edges:

```
[warn] language C# grammar unavailable — files will be indexed for search but not graphed
       (Cannot read properties of undefined (reading 'length'))
```

Functions, internal calls, hub detection, and refactoring candidates are all missing — the analysis is essentially a file list.

## Root cause

Tree-sitter uses an internal ABI version to describe the binary interface between the core parser and grammar language objects. When those ABI versions don't match, `parser.setLanguage()` can't read the language struct and throws.

The current `package.json` pins `tree-sitter` at `^0.22.4` (ABI 14), but requests `tree-sitter-c-sharp ^0.23.1`. Version 0.23.x of the C# grammar was compiled against `tree-sitter ^0.25.0` (ABI 15) — a version bump that's binary-incompatible with what openlore ships.

This is why Java works fine while C# doesn't: `tree-sitter-java@0.23.5` still targets `^0.21.1` (ABI 14), so its binary is compatible with the installed core. The C# grammar just happened to advance its ABI requirement ahead of the rest.

## Fix

Pin `tree-sitter-c-sharp` to `^0.21.3`. That version:
- targets `tree-sitter ^0.21.0` (ABI 14) — matches what openlore installs
- uses CommonJS bindings (same pattern as `tree-sitter-java`) — no ESM top-level await issues
- covers the same C# language constructs needed for the existing `CSHARP_SPEC` queries (`method_declaration`, `invocation_expression`, etc.)

All other grammars in `package.json` also target ABI 14, so this keeps the dependency set consistent without touching the core parser version.

## Verification

Tested on a real .NET 8 service (`invitations-api`). Before the fix:

```
Functions: 49 | Internal calls: 0
[warn] language C# grammar unavailable
```

After replacing `tree-sitter-c-sharp@0.23.5` with `0.21.3` in node_modules:

```
Functions: 118 | Internal calls: 272
Hub functions: GenerateCode(fanIn=5)
Entry points: 56
God functions: 9 (real C# methods, not just YAML templates)
```

No warning. Full call graph.